### PR TITLE
Add gh-issue-autopilot skill, enable GitHub issue publishing in grill-me, and add Q&A docs

### DIFF
--- a/QNA.md
+++ b/QNA.md
@@ -1,0 +1,242 @@
+# Agentify Deep-Dive Q&A
+
+This file explains **what this project is**, **why it exists**, and **how indexing, semantic analysis, caching, docs, and execution loops work**.
+
+---
+
+## 1) What is Agentify in one sentence?
+
+Agentify is a repository orchestration CLI that wraps provider CLIs (Codex/Claude/Gemini/OpenCode) with deterministic local indexing, planning, docs generation, validation, and session continuity.
+
+---
+
+## 2) Why not just use Codex or Claude Code directly?
+
+You can use providers directly for fast one-off tasks.
+
+Agentify adds value when you need:
+
+- repeatable repository artifacts (`.agents/index.db`, docs, run manifests),
+- deterministic context selection (`agentify plan`),
+- safety checks/freshness validation (`agentify check`),
+- provider portability and sticky defaults,
+- local session manifests (`sess run/resume/fork`) that are auditable.
+
+In short: provider CLIs are the execution engine; Agentify is the orchestration and governance layer.
+
+---
+
+## 3) What are the core phases in the workflow?
+
+A typical full cycle is:
+
+1. **index** (`scan`) -> build repository DB snapshot
+2. **doc** -> generate docs/metadata/headers
+3. **check** -> validate freshness/safety rules
+4. **run/exec/sess** -> execute provider command with selected context
+
+`agentify up` chains scan -> doc -> check -> tests.
+
+---
+
+## 4) Why does Agentify generate docs like `docs/repo-map.md` and module docs?
+
+Because provider sandboxes often vary in what they can inspect.
+
+Agentify materializes a stable repo map and module summaries so downstream prompts can rely on deterministic text context instead of repeatedly rediscovering structure from scratch.
+
+This also makes context inspectable by humans in PR review.
+
+---
+
+## 5) Why use `.agents/index.db` at all?
+
+SQLite gives a compact and queryable canonical model for:
+
+- modules,
+- files,
+- symbols,
+- imports,
+- tests,
+- commands,
+- semantic project/symbol/edge tables.
+
+Planner, query commands, docs generation, and semantic features all read from this index.
+
+---
+
+## 6) What does the index store (high level)?
+
+It stores both structural and semantic layers:
+
+- structural: modules/files/symbols/imports/tests/commands/artifacts/index events
+- semantic TS/JS: semantic projects, semantic symbols, surfaces, symbol edges, external packages, project files
+
+This lets Agentify answer ownership/dependency/search queries and build targeted prompts.
+
+---
+
+## 7) How does indexing detect modules/files?
+
+Indexing walks repository files, applies language/module detection heuristics (workspace/package roots and stack-specific rules), classifies test/config/entrypoint files, then persists fingerprinted rows.
+
+For TS/JS it uses TypeScript APIs for richer import/symbol extraction; for other stacks it also has generic extractors.
+
+---
+
+## 8) How does the AST/LSP-style analysis work here?
+
+There are two levels:
+
+1. **Structural indexer level**
+   - Uses TypeScript parser APIs to extract symbols/import relations for TS/JS source.
+   - Provides deterministic symbol spans and module linkage in `.agents/index.db`.
+
+2. **Semantic TS/JS level**
+   - `semantic refresh` discovers TS/JS projects (`tsconfig`/`jsconfig`), runs semantic worker analysis, and stores symbols/surfaces/edges.
+   - This behaves like a lightweight, persisted code intelligence graph (similar spirit to LSP navigation artifacts, but stored in Agentify tables).
+
+---
+
+## 9) What is “semantic refresh” and why optional?
+
+Semantic refresh computes deeper TS/JS facts (project graph, symbol graph, surfaces, route/react surfaces).
+
+It is optional (`semantic.tsjs.enabled`) because it can be heavier than plain structural indexing, and not all repos need it.
+
+When enabled, planner/docs/query can incorporate these richer facts.
+
+---
+
+## 10) How does planning choose context?
+
+Planner tokenizes the task, then scores modules/files/symbols by:
+
+- name/path/token matches,
+- key-file/entrypoint hints,
+- changed files,
+- module dependency proximity,
+- semantic symbol facts (when enabled).
+
+It then selects bounded modules/files/symbols/tests and renders one execution prompt with explicit verification command hints.
+
+---
+
+## 11) How does caching work in docs generation?
+
+Two major cache layers are used during `doc`:
+
+1. **Manager plan cache**
+   - If manager input fingerprint matches, reuse prior plan.
+
+2. **Per-module artifact cache**
+   - If module fingerprint+context match, reuse prior module artifact payload.
+
+Result: reruns are faster and cheaper when content is unchanged.
+
+---
+
+## 12) What does semantic caching mean in practice?
+
+Semantic refresh tracks analyzer version, project fingerprints, and project states.
+
+If project inputs are unchanged, semantic work can be skipped/reused, and doc/planner operate on stored semantic tables.
+
+This avoids recomputing large TS/JS graphs every run.
+
+---
+
+## 13) Example: cache hit during docs
+
+Suppose `src/auth` is unchanged and planner inputs are stable:
+
+- manager plan fingerprint matches -> cached manager plan reused,
+- module fingerprint matches -> cached module markdown/metadata reused,
+- output still refreshed (run manifests/docs references) with minimal recompute.
+
+If only one module changes, only that module recomputes while others remain cache hits.
+
+---
+
+## 14) Example: index + plan + run
+
+Task: “add retry logic to checkout service”
+
+1. `agentify scan` updates module/file/symbol index.
+2. `agentify plan "add retry logic..."` selects likely modules/files/tests.
+3. `agentify run ...` builds provider command template and executes.
+4. On code changes, Agentify auto-runs scan+doc refresh and validation.
+
+This makes execution loop deterministic and repo-aware.
+
+---
+
+## 15) How does validation protect the repo?
+
+Validation checks:
+
+- index freshness (HEAD commit alignment),
+- allowed generated paths,
+- constrained header-only behavior in guarded scenarios,
+- semantic project readiness/coverage when semantic mode is enabled.
+
+This catches stale/misaligned artifacts and unsafe generated file drift.
+
+---
+
+## 16) Why session manifests?
+
+Sessions store:
+
+- manifest (`session-manifest.json`),
+- context snapshot (`context.json`),
+- bootstrap markdown (`bootstrap.md`),
+- checklist.
+
+This supports resuming/forking work with bounded context and traceability across long tasks.
+
+---
+
+## 17) What is stored in `.agents/cache`?
+
+Content-addressed blobs and manifests used by cache maintenance commands (`cache gc`, `cache status`) and cleanup workflows.
+
+It enables pruning by age and measuring footprint.
+
+---
+
+## 18) What is the role of `agentify query`?
+
+It surfaces index-backed answers without manual DB work:
+
+- `owner` -> owning module of a file,
+- `deps` -> module dependency neighbors,
+- `changed` -> module impact since commit,
+- `search` -> structural + semantic search.
+
+Useful for deterministic triage and prompt preparation.
+
+---
+
+## 19) Why add skills like `grill-me` and `gh-issue-autopilot`?
+
+Skills are reusable operation playbooks.
+
+- `grill-me` now helps pressure-test plans and map final plans to GitHub issue types before optional publishing.
+- `gh-issue-autopilot` can pick first/latest open issue through `gh`, execute implementation loops, rerun checks, and commit when green.
+
+This turns repeated workflows into consistent operator patterns.
+
+---
+
+## 20) Project direction: what are we doing here?
+
+The project is building a **deterministic AI coding operations layer** for real repositories:
+
+- predictable context prep,
+- provider-agnostic execution,
+- auditable artifacts,
+- safety/freshness guardrails,
+- repeatable autonomous workflows (skills + sessions).
+
+The goal is not replacing provider intelligence; it is making AI-assisted engineering workflows **reliable, inspectable, and team-scalable**.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Built-in skills:
 
 - `grill-me`
 - `improve-codebase-architecture`
+- `gh-issue-autopilot`
 - `worktree-verifier` (alias: `god-mode`)
 
 Notes:

--- a/src/builtin-skills/gh-issue-autopilot/SKILL.md
+++ b/src/builtin-skills/gh-issue-autopilot/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: gh-issue-autopilot
+description: Pick the first or latest open GitHub issue with gh CLI, implement it autonomously in a tight loop (code, validate, test, fix), and commit when all checks pass.
+---
+
+# GH Issue Autopilot
+
+Run end-to-end with minimal human interaction.
+
+## Workflow
+
+1. Confirm repository and auth are ready:
+   - `git rev-parse --is-inside-work-tree`
+   - `gh auth status`
+2. Select issue based on user mode:
+   - `latest`: most recently created open issue
+   - `first`: oldest open issue
+3. Fetch issue details and convert to an execution checklist.
+4. Implement the smallest viable change.
+5. Run verification loop automatically:
+   - format/lint/typecheck (if present)
+   - relevant unit/integration tests
+   - repository standard checks
+6. If checks fail, fix and rerun until pass or truly blocked.
+7. Commit with message referencing issue number.
+8. Report summary, checks, and commit hash.
+
+## Issue Selection Commands
+
+Latest open issue:
+
+```bash
+gh issue list --state open --limit 100 --json number,title,createdAt --jq 'sort_by(.createdAt) | reverse | .[0]'
+```
+
+First open issue:
+
+```bash
+gh issue list --state open --limit 100 --json number,title,createdAt --jq 'sort_by(.createdAt) | .[0]'
+```
+
+Load full issue:
+
+```bash
+gh issue view <number> --json number,title,body,labels,assignees,url
+```
+
+## Operating Rules
+
+- Prefer repo scripts and existing CI-like commands.
+- Keep scope to the selected issue.
+- Use small commits and deterministic commands.
+- If blocked by external dependency, stop and report exact blocker and attempts.
+
+## Guardrails
+
+- Do not modify unrelated issues or backlog ordering.
+- Do not skip failing checks by weakening tests or protections.
+- Do not force-push or rewrite shared history.
+- Do not close an issue unless explicitly requested.

--- a/src/builtin-skills/gh-issue-autopilot/agents/openai.yaml
+++ b/src/builtin-skills/gh-issue-autopilot/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GH Issue Autopilot"
+  short_description: "Pick an issue and implement it autonomously"
+  default_prompt: "Use $gh-issue-autopilot to select the latest open issue, implement it, run checks in a loop, and commit once green."

--- a/src/builtin-skills/grill-me/SKILL.md
+++ b/src/builtin-skills/grill-me/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grill-me
-description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when the user wants to stress-test a plan, get grilled on their design, pressure-test architecture, or mentions "grill me".
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, then produce an execution plan and open mapped GitHub issues via gh CLI (feature/fix/chore/docs/test) when requested.
 ---
 
 # Grill Me
@@ -17,6 +17,33 @@ If a question can be answered by exploring the codebase, explore the codebase in
 4. Wait for the user's answer unless the repo can answer it directly.
 5. Use each answer to identify the next dependent decision.
 6. Keep going until the plan is concrete enough to implement or intentionally accepted with known risks.
+7. When done, emit a final implementation plan grouped by issue type:
+   - `feature`
+   - `fix`
+   - `chore`
+   - `docs`
+   - `test`
+8. If the user asks to publish the plan, create GitHub issues with `gh issue create`.
+
+## GitHub Issue Publishing
+
+Use this only after the plan is complete and the user confirms publishing.
+
+For each planned item:
+- Build a concise title prefixed with issue type, e.g. `[feature] add retry policy`.
+- Include acceptance criteria and a short verification checklist.
+- Add labels matching issue type when available.
+
+Preferred command shape:
+
+```bash
+gh issue create \
+  --title "[feature] add retry policy" \
+  --body "...plan details, acceptance criteria, verification..." \
+  --label "feature"
+```
+
+If labels are missing, create issue without label and note it.
 
 ## Areas To Cover
 
@@ -36,3 +63,4 @@ If a question can be answered by exploring the codebase, explore the codebase in
 - Challenge vague or hand-wavy answers.
 - Prefer concrete scenarios and edge cases over abstractions.
 - Stop only when the remaining uncertainty is explicit and accepted.
+- Do not create GitHub issues without user confirmation.

--- a/src/builtin-skills/grill-me/agents/openai.yaml
+++ b/src/builtin-skills/grill-me/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Grill Me"
-  short_description: "Stress-test a plan with tough questions"
-  default_prompt: "Use $grill-me to interrogate this plan one decision at a time."
+  short_description: "Stress-test a plan and publish GitHub issues"
+  default_prompt: "Use $grill-me to interrogate this plan, produce a final roadmap, and map it to issue types for gh issue creation."

--- a/src/core/skills.js
+++ b/src/core/skills.js
@@ -15,13 +15,19 @@ const BUILTIN_SKILLS = [
     name: "grill-me",
     aliases: [],
     description:
-      'Interview the user relentlessly about a plan or design until reaching shared understanding. Use when the user wants to stress-test a plan, get grilled on their design, or says "grill me".',
+      'Interview the user relentlessly about a plan or design until reaching shared understanding, then map the final plan to GitHub issues via gh CLI when requested. Use when the user wants to stress-test a plan, get grilled on their design, or says "grill me".',
   },
   {
     name: "improve-codebase-architecture",
     aliases: [],
     description:
       "Explore a codebase to find architectural refactors that deepen shallow modules, improve testability, and draft a local architecture RFC. Use when the user wants refactoring opportunities, tighter boundaries, or more AI-navigable modules.",
+  },
+  {
+    name: "gh-issue-autopilot",
+    aliases: [],
+    description:
+      "Select the first or latest open GitHub issue via gh CLI, implement it autonomously, run validation/test loops, and commit once checks pass.",
   },
   {
     name: "worktree-verifier",

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -11,7 +11,7 @@ test("listBuiltinSkills exposes built-in catalog and alias", () => {
   const skills = listBuiltinSkills();
   const names = skills.map((skill) => skill.name);
 
-  assert.deepEqual(names.sort(), ["grill-me", "improve-codebase-architecture", "worktree-verifier"]);
+  assert.deepEqual(names.sort(), ["gh-issue-autopilot", "grill-me", "improve-codebase-architecture", "worktree-verifier"]);
   assert.deepEqual(resolveBuiltinSkill("god-mode").name, "worktree-verifier");
 });
 
@@ -67,6 +67,22 @@ test("installBuiltinSkill copies architecture skill references into project scop
   assert.equal(result.results[0].status, "installed");
   assert.equal(await exists(skillPath), true);
   assert.equal(await exists(referencePath), true);
+});
+
+test("installBuiltinSkill copies gh issue autopilot skill bundle into project scope", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-skill-gh-auto-"));
+  const result = await installBuiltinSkill(root, {
+    name: "gh-issue-autopilot",
+    provider: "codex",
+    scope: "project",
+  });
+
+  const skillPath = path.join(root, ".codex", "skills", "gh-issue-autopilot", "SKILL.md");
+  const uiPath = path.join(root, ".codex", "skills", "gh-issue-autopilot", "agents", "openai.yaml");
+
+  assert.equal(result.results[0].status, "installed");
+  assert.equal(await exists(skillPath), true);
+  assert.equal(await exists(uiPath), true);
 });
 
 test("installBuiltinSkill installs canonical skill name for alias across all providers", async () => {


### PR DESCRIPTION
### Motivation

- Provide an autonomous workflow to pick and implement GitHub issues end-to-end using the `gh` CLI for tighter repo automation. 
- Extend the existing `grill-me` skill to map final plans to GitHub issues so plans can be published as tracked work items. 
- Document project goals, indexing, planning, semantic analysis, caching, and execution loops for developer reference.

### Description

- Add `QNA.md` containing a deep-dive Q&A explaining Agentify concepts such as indexing, semantic refresh, planning, caching, docs, sessions, and skills. 
- Add a new builtin skill `gh-issue-autopilot` with `SKILL.md` and an agent UI file at `src/builtin-skills/gh-issue-autopilot/agents/openai.yaml` describing automated issue selection and implement loop behavior. 
- Update `grill-me` skill docs and agent UI to optionally produce a final roadmap and map planned items to GitHub issue types, and add a guardrail to avoid creating issues without confirmation. 
- Register the new `gh-issue-autopilot` skill and adjust the `grill-me` description in `src/core/skills.js`. 
- Update `README.md` to list the new `gh-issue-autopilot` skill in the examples/docs. 
- Add and update unit tests in `test/skills.test.js` to include the new skill in the builtin catalog assertion and to verify `installBuiltinSkill` copies the `gh-issue-autopilot` bundle into project scope.

### Testing

- Ran the repository test suite via the node test runner (project tests), including `test/skills.test.js`, and all tests passed. 
- The new test `installBuiltinSkill copies gh issue autopilot skill bundle into project scope` executed and succeeded as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cc181f9508832a918c899b6bb99cd5)