### PR TITLE
Add long and short Agentify project pitch documents

### DIFF
--- a/PROJECT_PITCH_LONG.md
+++ b/PROJECT_PITCH_LONG.md
@@ -1,0 +1,99 @@
+# Agentify Project Introduction (Long Version)
+
+## 1) Executive Overview
+Agentify is an orchestration layer for AI-assisted software development. Instead of using AI provider CLIs in isolated, person-by-person ways, Agentify introduces a shared, repeatable workflow for repository context, documentation, validation, and execution.
+
+In practical terms, provider CLIs remain the execution engines, while Agentify provides the operating model teams need to scale usage safely.
+
+---
+
+## 2) The Problem We Need to Solve
+The first problem in most teams is not writing code. It is understanding what already exists, where the sharp edges are, and how to move without damage.
+
+Without a standardized AI workflow, teams usually face:
+- inconsistent output quality between engineers,
+- missing traceability for context and decisions,
+- hard-to-resume long-running tasks,
+- stale repository context driving weaker generations,
+- fragmented processes across providers and teams.
+
+These issues increase rework and reduce trust in AI-assisted changes.
+
+---
+
+## 3) What Agentify Does
+Agentify wraps provider CLIs (Codex, Claude, Gemini, OpenCode) with a deterministic workflow:
+
+1. **Index**: Build a repository-aware model.
+2. **Doc**: Generate inspectable project docs and metadata.
+3. **Check**: Validate freshness and safety constraints.
+4. **Run / Session**: Execute tasks with bounded context and resumable continuity.
+
+This pipeline makes results more predictable, reviewable, and transferable across contributors.
+
+---
+
+## 4) Why This Is Important for Other Teams
+### Reliability
+Stable artifacts and deterministic context selection reduce “it worked on my prompt” variance.
+
+### Governance and Auditability
+Generated artifacts and checks create a transparent trail that reviewers and partner teams can inspect.
+
+### Faster Adoption
+A shared workflow lowers onboarding overhead and makes enablement easier across teams.
+
+### Collaboration at Scale
+Session continuity and manifests support better handoffs for cross-team projects.
+
+### Provider Portability
+A provider-agnostic workflow lowers lock-in risk and protects team process investments.
+
+---
+
+## 5) Why It’s Better Than Using Provider CLIs Alone
+Direct provider usage is great for one-off productivity. Team-scale engineering needs more:
+- repeatability,
+- clear validation,
+- operational guardrails,
+- handoff continuity,
+- and consistent standards.
+
+Agentify adds these layers while still preserving flexibility in provider choice.
+
+---
+
+## 6) Benefits by Stakeholder
+### Engineers
+- Less repeated context setup.
+- More confidence in generated edits.
+- Clear routine for run/verify cycles.
+
+### Team Leads and Managers
+- More predictable quality and delivery.
+- Easier onboarding and enablement.
+- Better visibility into AI-assisted workflows.
+
+### Platform / DevEx
+- Standardized process across repositories.
+- Reusable conventions and automation patterns.
+- Lower operational friction in scaling AI usage.
+
+### QA / Governance
+- Better control over stale context and unsafe drift.
+- Deterministic artifacts that simplify audits and reviews.
+
+---
+
+## 7) Suggested Rollout to Other Teams
+1. **Pilot** in one representative repo.
+2. **Set defaults** for provider, checks, and run conventions.
+3. **Track outcomes** (cycle time, rework, failed checks, handoff speed).
+4. **Expand** with the same operating model and reusable skills.
+
+---
+
+## 8) Presentation Closing Line
+"Agentify doesn’t replace AI models or developer judgment—it makes AI-assisted engineering reliable, inspectable, and scalable for the whole organization."
+
+_Last updated: April 1, 2026._

--- a/PROJECT_PITCH_SHORT.md
+++ b/PROJECT_PITCH_SHORT.md
@@ -1,0 +1,18 @@
+# Agentify Project Introduction (Short Version)
+
+## 30-Second Pitch
+**Agentify is our team AI engineering orchestration CLI.** It sits on top of provider tools (Codex, Claude, Gemini, OpenCode) and standardizes how we prepare context, generate docs, run checks, and execute sessions. The result is AI-assisted development that is **consistent, auditable, and scalable across teams**.
+
+## Why Other Teams Should Care
+The first problem in most teams is not writing code. It is understanding what already exists, where the sharp edges are, and how to move without damage.
+
+- **Consistent delivery:** Everyone follows the same workflow (`index -> doc -> check -> run`) instead of ad-hoc prompting.
+- **Higher confidence:** Freshness and safety checks reduce risky or stale AI-generated changes.
+- **Faster onboarding:** New teammates can follow one repeatable operating model.
+- **Better collaboration:** Session artifacts make handoffs and cross-team support easier.
+- **Provider flexibility:** We keep one process even if provider preferences change.
+
+## One-Line Value Statement
+Agentify turns AI coding from an individual productivity trick into a dependable team capability.
+
+_Last updated: April 1, 2026._


### PR DESCRIPTION
### Motivation
- Provide a clear, shareable description of the Agentify product, goals, and rollout plan to align teams and stakeholders.
- Offer both quick and detailed formats to support fast onboarding and deeper technical/contextual review.

### Description
- Add `PROJECT_PITCH_LONG.md`, a detailed 99-line introduction that covers executive overview, problems addressed, pipeline (`index -> doc -> check -> run`), stakeholder benefits, and rollout suggestions.
- Add `PROJECT_PITCH_SHORT.md`, a concise 30-second pitch that summarizes the value proposition, workflow, and reasons other teams should adopt Agentify.
- Both files include a one-line value statement and a last-updated timestamp for traceability.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cd42fa9928832a9ba299ec12cffd5a)