### PR TITLE
feat(skills): add built-in pr-creator and commit-creator skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Built-in skills:
 - `improve-codebase-architecture`
 - `gh-issue-autopilot`
 - `worktree-verifier` (alias: `god-mode`)
+- `pr-creator`
+- `commit-creator`
 
 Notes:
 

--- a/src/builtin-skills/commit-creator/SKILL.md
+++ b/src/builtin-skills/commit-creator/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: commit-creator
+description: Create high-quality commits using Conventional Commit prefixes (feat, fix, chore, refactor, docs, test, etc.) with focused staging and clear messages.
+---
+
+# Commit Creator
+
+Produce clean, review-friendly commits that follow standup/conventional style prefixes.
+
+## Workflow
+
+1. Inspect git state and summarize changed files.
+2. Propose commit grouping strategy (one or more commits) based on logical change sets.
+3. Ask/confirm commit type prefix for each commit:
+   - `feat:` new behavior
+   - `fix:` bug fix
+   - `chore:` maintenance/tooling
+   - `refactor:` code restructuring without behavior change
+   - `docs:` documentation-only changes
+   - `test:` test-only changes
+   - `perf:` performance improvements
+   - `build:` build/dependency updates
+   - `ci:` CI/CD config updates
+4. Stage only the files/hunks relevant to each commit.
+5. Write concise subject lines and informative bodies when needed.
+6. Create commit(s) and report hashes with summaries.
+
+## Quality Rules
+
+- Keep commits atomic and scoped.
+- Avoid mixing unrelated concerns in one commit.
+- Prefer imperative subject lines (e.g., `refactor: simplify provider resolution`).
+- Mention why in the body when the change is non-obvious.
+- If no changes are staged, stop and explain what is missing.
+
+## Output Format
+
+- `Plan`
+- `Commits created`
+- `Files per commit`
+- `Notes`

--- a/src/builtin-skills/commit-creator/agents/openai.yaml
+++ b/src/builtin-skills/commit-creator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Commit Creator"
+  short_description: "Create clean conventional commits"
+  default_prompt: "Use $commit-creator to group changes into atomic commits with conventional prefixes and clear messages."

--- a/src/builtin-skills/pr-creator/SKILL.md
+++ b/src/builtin-skills/pr-creator/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: pr-creator
+description: Create a draft PR for GitHub, GitLab, or Azure DevOps after validating required CLI prerequisites and authentication, then return a concise summary with the PR link.
+---
+
+# PR Creator
+
+Create pull requests with strict prerequisite checks and clear operator feedback.
+
+## Workflow
+
+1. Ask the user which domain/provider to use:
+   - GitHub
+   - GitLab
+   - Azure DevOps
+2. Detect required CLIs and auth state before attempting PR creation.
+3. If prerequisites are missing, stop and provide install/auth steps for the selected provider.
+4. If prerequisites are satisfied, gather/confirm PR metadata:
+   - base/target branch
+   - source branch
+   - title
+   - description/body
+5. Create a **draft** PR using the provider CLI.
+6. Return a concise summary in chat including the PR URL.
+
+## Provider Prerequisites
+
+### GitHub
+- Required CLI: `gh`
+- Check install: `command -v gh`
+- Check auth: `gh auth status`
+- Draft PR command pattern: `gh pr create --draft ...`
+
+### GitLab
+- Required CLI: `glab`
+- Check install: `command -v glab`
+- Check auth: `glab auth status`
+- Draft PR/MR command pattern: `glab mr create --draft ...`
+
+### Azure DevOps
+- Required CLI: `az` with Azure DevOps extension
+- Check install: `command -v az`
+- Check extension: `az extension show --name azure-devops`
+- Check auth/context: verify sign-in and org/project defaults (`az account show`, `az devops configure --list`)
+- Draft PR command pattern: `az repos pr create --draft true ...`
+
+## Guardrails
+
+- Never create a non-draft PR unless the user explicitly requests it.
+- Do not guess missing branches; ask/confirm before creation.
+- If creation command fails, report exact CLI error and next fix.
+- Share the final PR link and key metadata in the response.
+
+## Output Format
+
+- `Provider`
+- `Prerequisites`
+- `Action`
+- `PR link`
+- `Notes`

--- a/src/builtin-skills/pr-creator/agents/openai.yaml
+++ b/src/builtin-skills/pr-creator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Creator"
+  short_description: "Validate provider prerequisites and open a draft PR"
+  default_prompt: "Use $pr-creator to pick a provider, validate CLI/auth prerequisites, then create a draft PR and return the PR link."

--- a/src/core/skills.js
+++ b/src/core/skills.js
@@ -35,6 +35,18 @@ const BUILTIN_SKILLS = [
     description:
       "Run an autonomous coding workflow in the current repository or worktree with minimal human interaction, including verification and commit.",
   },
+  {
+    name: "pr-creator",
+    aliases: [],
+    description:
+      "Guide pull request creation across GitHub, GitLab, or Azure DevOps by checking CLI prerequisites/auth first, then opening a draft PR and returning the link.",
+  },
+  {
+    name: "commit-creator",
+    aliases: [],
+    description:
+      "Create focused, high-quality commits using conventional prefixes (feat/fix/chore/refactor/docs/test/etc.) with clear summaries.",
+  },
 ];
 
 const BUILTIN_SKILL_INDEX = new Map();

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -76,7 +76,7 @@ test("runCli supports skill install all for codex project scope", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-skill-all-codex-"));
   await runCli(["skill", "install", "all", "--root", root, "--provider", "codex", "--scope", "project"]);
 
-  for (const skillName of ["grill-me", "improve-codebase-architecture", "gh-issue-autopilot", "worktree-verifier"]) {
+  for (const skillName of ["grill-me", "improve-codebase-architecture", "gh-issue-autopilot", "worktree-verifier", "pr-creator", "commit-creator"]) {
     await assert.doesNotReject(() =>
       fs.access(path.join(root, ".codex", "skills", skillName, "SKILL.md"))
     );

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -17,7 +17,7 @@ test("listBuiltinSkills exposes built-in catalog and alias", () => {
   const skills = listBuiltinSkills();
   const names = skills.map((skill) => skill.name);
 
-  assert.deepEqual(names.sort(), ["gh-issue-autopilot", "grill-me", "improve-codebase-architecture", "worktree-verifier"]);
+  assert.deepEqual(names.sort(), ["commit-creator", "gh-issue-autopilot", "grill-me", "improve-codebase-architecture", "pr-creator", "worktree-verifier"]);
   assert.deepEqual(resolveBuiltinSkill("god-mode").name, "worktree-verifier");
 });
 
@@ -91,6 +91,38 @@ test("installBuiltinSkill copies gh issue autopilot skill bundle into project sc
   assert.equal(await exists(uiPath), true);
 });
 
+test("installBuiltinSkill copies pr creator skill bundle into project scope", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-skill-pr-creator-"));
+  const result = await installBuiltinSkill(root, {
+    name: "pr-creator",
+    provider: "codex",
+    scope: "project",
+  });
+
+  const skillPath = path.join(root, ".codex", "skills", "pr-creator", "SKILL.md");
+  const uiPath = path.join(root, ".codex", "skills", "pr-creator", "agents", "openai.yaml");
+
+  assert.equal(result.results[0].status, "installed");
+  assert.equal(await exists(skillPath), true);
+  assert.equal(await exists(uiPath), true);
+});
+
+test("installBuiltinSkill copies commit creator skill bundle into project scope", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-skill-commit-creator-"));
+  const result = await installBuiltinSkill(root, {
+    name: "commit-creator",
+    provider: "codex",
+    scope: "project",
+  });
+
+  const skillPath = path.join(root, ".codex", "skills", "commit-creator", "SKILL.md");
+  const uiPath = path.join(root, ".codex", "skills", "commit-creator", "agents", "openai.yaml");
+
+  assert.equal(result.results[0].status, "installed");
+  assert.equal(await exists(skillPath), true);
+  assert.equal(await exists(uiPath), true);
+});
+
 test("installBuiltinSkill installs canonical skill name for alias across all providers", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-skill-all-"));
   const result = await installBuiltinSkill(root, {
@@ -141,7 +173,7 @@ test("installAllBuiltinSkills installs every built-in skill for codex project sc
 
   assert.deepEqual(
     result.installed_skills.sort(),
-    ["gh-issue-autopilot", "grill-me", "improve-codebase-architecture", "worktree-verifier"]
+    ["commit-creator", "gh-issue-autopilot", "grill-me", "improve-codebase-architecture", "pr-creator", "worktree-verifier"]
   );
 
   for (const skillName of result.installed_skills) {


### PR DESCRIPTION
### Motivation

- Add tools to guide and automate two common developer workflows: opening draft PRs across multiple provider domains and producing atomic, conventional commits. 
- Make these capabilities available as built-in, installable skills so they integrate with existing `skill` listing/installation flows.

### Description

- Register two new built-in skills in `src/core/skills.js`: `pr-creator` and `commit-creator`.
- Add skill bundles under `src/builtin-skills/pr-creator` and `src/builtin-skills/commit-creator`, each including `SKILL.md` and `agents/openai.yaml` with workflow, prerequisites, guardrails, and output formats.
- Update documentation (`README.md`) and automated tests (`test/skills.test.js`, `test/main.test.js`) so the new skills are listed and validated by the `agentify skill install` and `install all` flows.

### Testing

- Ran `npm test -- --test-name-pattern="skill|runCli supports skill install all for codex project scope"` and the test run completed successfully with all relevant subtests passing.
- New tests verify that `installBuiltinSkill` copies both `SKILL.md` and `agents/openai.yaml` for `pr-creator` and `commit-creator`, and that `listBuiltinSkills` and `agentify skill install all` include the new entries.
- All added and existing skill-related tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ce12990490832ab9a5b31025343546)