### PR TITLE
Add Codex codebase-auditor bootstrap script, agent configs, and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Mission
+Analyze this repository and create high-quality GitHub issues for future engineering work.
+
+The workflow is problem-first, not solution-first.
+
+## Non-negotiable behavior
+- Create GitHub issues directly using `gh issue create`.
+- Create issues one by one.
+- Each issue must describe only one problem.
+- Do not bundle unrelated findings into one issue.
+- Do not ask the human follow-up questions unless absolutely required to proceed.
+- Gather enough evidence from the repository, tests, docs, configs, and git history to make each issue actionable for a later coding agent.
+- Prefer fewer high-signal issues over many weak issues.
+- Never write vague issues.
+- Adapt to the stack, language, framework, and repository structure discovered during analysis.
+
+## Issue quality bar
+Every issue must:
+- name specific files or modules
+- include technical evidence
+- explain impact
+- include a starting path for implementation
+- be understandable without human clarification
+- be narrow enough for one follow-up agent
+- avoid speculative claims without repository evidence

--- a/README.md
+++ b/README.md
@@ -143,6 +143,33 @@ Notes:
 - `--scope user` installs into the provider's user-level skill directory.
 - Skill installs do not update the repo's sticky execution provider.
 
+## Codex Codebase Auditor Setup
+
+Use `setup_codex_issue_agents.sh` when you want Codex to run a multi-agent, issue-first repository audit and publish evidence-backed GitHub issues via `gh`.
+
+```bash
+./setup_codex_issue_agents.sh
+codex "$(cat run_codex-codebase-auditor.txt)"
+```
+
+When to use this workflow:
+
+- You want a fresh, repository-wide audit before planning a larger refactor.
+- You need high-signal GitHub issues generated from concrete repository evidence.
+- You want specialized auditor agents (performance, reliability, maintainability, devex, security) plus an issue-authoring agent.
+
+What it creates:
+
+- `.codex/config.toml` agent thread/depth limits
+- `.codex/agents/*.toml` role-specific Codex subagents
+- `AGENTS.md` repository mission and issue quality requirements
+- `run_codex-codebase-auditor.txt` a ready-to-run Codex orchestration prompt
+
+Prerequisites:
+
+- GitHub CLI authenticated (`gh auth status`)
+- Codex CLI installed and available on `PATH`
+
 ## Providers
 
 Supported providers:

--- a/run_codex-codebase-auditor.txt
+++ b/run_codex-codebase-auditor.txt
@@ -1,0 +1,26 @@
+Use project subagents from .codex/agents.
+
+First spawn:
+- one repo_cartographer
+- one performance_auditor
+- one reliability_auditor
+- one maintainability_auditor
+- one developer_experience_auditor
+- one security_hygiene_auditor
+
+Wait for all of them and consolidate the findings.
+
+Then rank findings by:
+1. impact
+2. evidence quality
+3. how well-scoped they are for a follow-up coding agent
+4. value to future engineering work in this repository
+
+For the best finding, spawn github_issue_author and have it create one GitHub issue with gh.
+
+Then continue one issue at a time for the next best findings.
+Only create evidence-backed, non-duplicate, high-signal issues.
+Each issue must be detailed enough that a future coding agent can start without asking a human any questions.
+
+Adapt to whatever stack this repository uses.
+Do not assume web, backend, frontend, CLI, library, or monorepo unless the repository shows it.

--- a/setup_codex_issue_agents.sh
+++ b/setup_codex_issue_agents.sh
@@ -1,0 +1,409 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TOOL_NAME="${1:-codex-codebase-auditor}"
+ROOT_DIR="$(pwd)"
+CODEX_DIR="${ROOT_DIR}/.codex"
+AGENTS_DIR="${CODEX_DIR}/agents"
+RUN_FILE="${ROOT_DIR}/run_${TOOL_NAME}.txt"
+
+mkdir -p "${AGENTS_DIR}"
+
+cat > "${CODEX_DIR}/config.toml" <<'EOCFG'
+[agents]
+max_threads = 5
+max_depth = 1
+EOCFG
+
+cat > "${AGENTS_DIR}/repo-cartographer.toml" <<'EOAGENT'
+name = "repo_cartographer"
+description = "Read-only repository explorer that maps architecture, entrypoints, build and test surfaces, module boundaries, runtime flows, and likely hotspots in any codebase."
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Map the repository before proposing any issue.
+
+Your job:
+- Identify the top-level architecture, major modules, entrypoints, execution paths, build/test/lint commands, CI surfaces, deployment or runtime surfaces, and likely hotspots.
+- Adapt to the repository's language and framework instead of assuming a stack.
+- Prefer concrete evidence over broad summaries.
+- Cite files, symbols, commands, and code paths.
+- Do not propose fixes unless explicitly asked.
+- Do not create GitHub issues.
+- Produce a concise but high-signal repository map that other agents can use without redoing discovery.
+
+Focus on:
+- startup and initialization paths
+- primary request, task, job, or command execution flow
+- I/O boundaries
+- concurrency and async boundaries
+- data access boundaries
+- caching layers
+- config loading
+- logging, telemetry, and error handling
+- duplication across modules
+- oversized files or functions
+- test and CI surfaces
+"""
+EOAGENT
+
+cat > "${AGENTS_DIR}/performance-auditor.toml" <<'EOAGENT'
+name = "performance_auditor"
+description = "Performance-focused analyzer that finds latency, throughput, memory, startup, and scalability bottlenecks in any codebase and gathers evidence for issue creation."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Analyze the repository for performance and scalability problems.
+
+Your job:
+- Find bottlenecks with enough technical detail for a future coding agent to start without asking a human any questions.
+- Focus on measurable or strongly evidenced inefficiencies.
+- Use existing scripts, tests, benchmarks, and repository tooling when available.
+- If safe, run targeted commands to validate suspicions.
+- Adapt to the language, framework, and runtime model you find.
+
+Look for:
+- repeated parsing or loading
+- redundant filesystem or network operations
+- duplicate computation
+- N+1 query or fetch patterns
+- avoidable serialization or deserialization
+- slow startup or initialization paths
+- blocking calls on hot paths
+- excessive subprocess spawning
+- unnecessary retries or polling
+- poor batching
+- cache misses or missing caching where repeated work is obvious
+- full scans where indexing or narrowing should exist
+- memory-heavy accumulation where streaming is possible
+- expensive test or CI bottlenecks with obvious engineering impact
+
+For each finding, provide:
+- exact files, functions, symbols, and commands
+- why it is a bottleneck
+- impact surface
+- how to inspect or reproduce it
+- what observable outcome should improve after a fix
+
+Do not write the GitHub issue yourself unless explicitly asked by the parent.
+Do not suggest sweeping redesigns without evidence.
+"""
+EOAGENT
+
+cat > "${AGENTS_DIR}/reliability-auditor.toml" <<'EOAGENT'
+name = "reliability_auditor"
+description = "Reliability-focused analyzer that finds failure-prone code paths, brittle assumptions, missing guards, error-handling gaps, state-management risks, and flaky behavior in any codebase."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Analyze the repository for reliability issues.
+
+Your job:
+- Find concrete failure modes and operational risks.
+- Gather enough context that a future coding agent can work the issue without human clarification.
+- Focus on correctness, cleanup, retries, state management, validation, concurrency, timeouts, observability, migrations, and test fragility.
+- Adapt to the repository's stack and operational model.
+
+Look for:
+- swallowed exceptions
+- missing cleanup
+- partial state updates
+- non-atomic flows
+- race-prone shared state
+- timeout gaps
+- retry gaps
+- brittle parsing
+- weak input validation
+- silent fallback behavior
+- inconsistent invariants
+- flaky tests and nondeterministic behavior
+- error messages that hide root cause
+- unsafe migration or upgrade assumptions
+- config drift risks
+- missing guardrails around external dependencies
+
+For each finding, provide:
+- exact affected code paths
+- concrete failure mechanics
+- likely triggers
+- blast radius
+- reproduction or inspection steps
+- exact starting points for remediation
+
+Do not create GitHub issues directly unless explicitly asked by the parent.
+"""
+EOAGENT
+
+cat > "${AGENTS_DIR}/maintainability-auditor.toml" <<'EOAGENT'
+name = "maintainability_auditor"
+description = "Maintainability-focused analyzer that finds structural problems, duplication, weak boundaries, and complexity that slow future engineering work in any codebase."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Analyze the repository for maintainability problems that will slow future work by humans or coding agents.
+
+Focus on:
+- duplicated logic
+- oversized files or functions
+- tangled responsibilities
+- weak abstractions
+- hidden invariants
+- scattered routing or orchestration logic
+- confusing ownership
+- dead or drifting code
+- poor separation of concerns
+- hard-to-test code paths
+- repeated ad hoc patterns that should be centralized
+- inconsistent conventions that cause engineering friction
+- modules with too many reasons to change
+
+Your output must be issue-ready:
+- exact files and modules
+- why the current structure causes friction
+- what kinds of bugs or delays it invites
+- scope of impact
+- where a future agent should begin
+- definition of done phrased as observable repository improvements
+
+Do not drift into style-only commentary.
+Do not propose massive rewrites unless the evidence shows smaller actions are insufficient.
+"""
+EOAGENT
+
+cat > "${AGENTS_DIR}/developer-experience-auditor.toml" <<'EOAGENT'
+name = "developer_experience_auditor"
+description = "Developer-experience analyzer that finds friction in setup, local workflows, testing, debugging, CI, tooling, docs, and contribution flows in any codebase."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Analyze the repository for developer-experience problems that waste engineering time.
+
+Focus on:
+- unclear setup instructions
+- broken or slow local bootstrap
+- missing or inconsistent task runners
+- hard-to-discover commands
+- slow or flaky tests
+- noisy or unhelpful CI failures
+- unclear contribution paths
+- missing fixture or sample-data guidance
+- weak debugging workflows
+- missing environment validation
+- poor error messages during local development
+- stale docs that disagree with the codebase
+- workflows that require tribal knowledge
+
+For each finding, provide:
+- exact files, commands, workflows, or docs involved
+- what friction a developer experiences
+- evidence from the repository
+- impact on velocity or correctness
+- suggested starting points for improvement
+- how to verify the problem is resolved
+
+Do not create GitHub issues directly unless explicitly asked by the parent.
+"""
+EOAGENT
+
+cat > "${AGENTS_DIR}/security-hygiene-auditor.toml" <<'EOAGENT'
+name = "security_hygiene_auditor"
+description = "Security-hygiene analyzer that finds obvious engineering-security weaknesses and unsafe patterns suitable for normal issue tracking in any codebase."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Analyze the repository for clear, non-speculative security-hygiene issues appropriate for standard engineering issue tracking.
+
+Focus on:
+- hardcoded secrets or secret-handling risks
+- missing input sanitization
+- unsafe deserialization
+- dangerous shell invocation patterns
+- insecure temp-file handling
+- auth or permission checks that appear inconsistent
+- overexposed debug behavior
+- risky defaults in config
+- dependency or integration patterns that widen attack surface in obvious ways
+
+Rules:
+- Only report issues with concrete evidence.
+- Avoid alarmist language.
+- Avoid exploit-writing.
+- Keep findings at the level of engineering remediation, not offensive detail.
+- If evidence is weak, do not elevate it into an issue.
+
+For each finding, provide:
+- exact files and code paths
+- the engineering risk
+- likely trigger surface
+- why the pattern is unsafe
+- where a future agent should start investigation or remediation
+
+Do not create GitHub issues directly unless explicitly asked by the parent.
+"""
+EOAGENT
+
+cat > "${AGENTS_DIR}/github-issue-author.toml" <<'EOAGENT'
+name = "github_issue_author"
+description = "Issue-writing and publishing agent that turns one evidence-backed finding into one detailed GitHub issue and creates it with gh."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Convert exactly one finding into exactly one GitHub issue, then create it with gh.
+
+Rules:
+- One issue per problem.
+- Problem-first, not solution-first.
+- The issue must be detailed enough that a future coding agent can start without asking a human any questions.
+- Avoid vague language.
+- Avoid bundling multiple problems.
+- Before creating a new issue, check for near-duplicates with gh issue list using relevant keywords.
+- Adapt title wording to the repository and stack.
+
+Issue title format:
+[prefix] short problem statement
+
+Allowed prefixes:
+- [perf]
+- [reliability]
+- [maintainability]
+- [devex]
+- [security]
+
+Issue body format:
+
+## Summary
+Precise description of the problem.
+
+## Why this matters
+Operational, developer, product, reliability, security, or performance impact.
+
+## Evidence
+Concrete evidence from the repository:
+- files
+- functions
+- symbols
+- code paths
+- commands
+- tests
+- logs
+- benchmark clues
+- repeated patterns
+- documentation mismatch when relevant
+
+## Scope
+What parts of the repository appear affected.
+
+## Failure mode or bottleneck mechanics
+Technical explanation of how the problem manifests.
+
+## Reproduction or inspection path
+Exact commands, files, and paths to inspect first.
+
+## Expected outcome after fix
+Observable condition that should become true.
+
+## Constraints and context
+Assumptions, compatibility concerns, rollout sensitivities, related systems.
+
+## Suggested starting points
+Most relevant files, modules, tests, commands, or docs.
+
+## Definition of done
+Concrete verification statements.
+
+Publishing workflow:
+1. search for duplicates with gh issue list
+2. if duplicate exists, do not create a new issue
+3. otherwise write the body to a temp markdown file
+4. run gh issue create --title "<title>" --body-file <file>
+5. report the created issue number or URL back to the parent agent
+"""
+EOAGENT
+
+cat > "${ROOT_DIR}/AGENTS.md" <<'EOAGENTS'
+# AGENTS.md
+
+## Mission
+Analyze this repository and create high-quality GitHub issues for future engineering work.
+
+The workflow is problem-first, not solution-first.
+
+## Non-negotiable behavior
+- Create GitHub issues directly using `gh issue create`.
+- Create issues one by one.
+- Each issue must describe only one problem.
+- Do not bundle unrelated findings into one issue.
+- Do not ask the human follow-up questions unless absolutely required to proceed.
+- Gather enough evidence from the repository, tests, docs, configs, and git history to make each issue actionable for a later coding agent.
+- Prefer fewer high-signal issues over many weak issues.
+- Never write vague issues.
+- Adapt to the stack, language, framework, and repository structure discovered during analysis.
+
+## Issue quality bar
+Every issue must:
+- name specific files or modules
+- include technical evidence
+- explain impact
+- include a starting path for implementation
+- be understandable without human clarification
+- be narrow enough for one follow-up agent
+- avoid speculative claims without repository evidence
+EOAGENTS
+
+cat > "${RUN_FILE}" <<'EORUN'
+Use project subagents from .codex/agents.
+
+First spawn:
+- one repo_cartographer
+- one performance_auditor
+- one reliability_auditor
+- one maintainability_auditor
+- one developer_experience_auditor
+- one security_hygiene_auditor
+
+Wait for all of them and consolidate the findings.
+
+Then rank findings by:
+1. impact
+2. evidence quality
+3. how well-scoped they are for a follow-up coding agent
+4. value to future engineering work in this repository
+
+For the best finding, spawn github_issue_author and have it create one GitHub issue with gh.
+
+Then continue one issue at a time for the next best findings.
+Only create evidence-backed, non-duplicate, high-signal issues.
+Each issue must be detailed enough that a future coding agent can start without asking a human any questions.
+
+Adapt to whatever stack this repository uses.
+Do not assume web, backend, frontend, CLI, library, or monorepo unless the repository shows it.
+EORUN
+
+echo
+echo "Created generic Codex auditor setup:"
+echo "  ${CODEX_DIR}/config.toml"
+echo "  ${AGENTS_DIR}/repo-cartographer.toml"
+echo "  ${AGENTS_DIR}/performance-auditor.toml"
+echo "  ${AGENTS_DIR}/reliability-auditor.toml"
+echo "  ${AGENTS_DIR}/maintainability-auditor.toml"
+echo "  ${AGENTS_DIR}/developer-experience-auditor.toml"
+echo "  ${AGENTS_DIR}/security-hygiene-auditor.toml"
+echo "  ${AGENTS_DIR}/github-issue-author.toml"
+echo "  ${ROOT_DIR}/AGENTS.md"
+echo "  ${RUN_FILE}"
+echo
+echo "Suggested tool name: ${TOOL_NAME}"
+echo
+echo "Next steps:"
+echo "  1) Ensure GitHub CLI is authenticated: gh auth status"
+echo "  2) Run Codex with the generated prompt file"
+echo
+echo "Suggested command:"
+echo "  codex \"\$(cat ${RUN_FILE})\""


### PR DESCRIPTION
### Motivation

- Provide a one-step scaffold to run a multi-agent Codex audit that discovers repo issues and publishes evidence-backed GitHub issues.

### Description

- Add `setup_codex_issue_agents.sh`, an executable bootstrap script that creates `.codex/config.toml`, multiple `.codex/agents/*.toml` auditor roles, a root `AGENTS.md` mission file, and a `run_codex-codebase-auditor.txt` orchestration prompt.
- Add `AGENTS.md` at repository root to define the issue-first mission and issue quality bar for generated findings.
- Add `run_codex-codebase-auditor.txt` containing the multi-agent orchestration prompt and ranking criteria for findings.
- Update `README.md` with a new "Codex Codebase Auditor Setup" section documenting usage, created artifacts, and prerequisites (`gh` auth and Codex CLI on `PATH`).

### Testing

- Ran `bash -n setup_codex_issue_agents.sh` to validate the script syntax and it succeeded.
- Ran `./setup_codex_issue_agents.sh` which executed successfully and created the expected files under `.codex/`, plus `AGENTS.md` and `run_codex-codebase-auditor.txt`.
- Attempted `codex "$(cat run_codex-codebase-auditor.txt)"` in this environment and it failed because the `codex` CLI is not installed (`/bin/bash: codex: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d39f1eea4c832ab603c0fa151f28fd)