### PR TITLE
fix: keep live scan/doc locks from being reclaimed

### DIFF
--- a/src/core/lock.js
+++ b/src/core/lock.js
@@ -1,8 +1,34 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import process from "node:process";
 
 const LOCK_STALE_MS = 300000;
+
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function canReclaimLock(existing) {
+  if (!existing || typeof existing.acquired_at !== "number") {
+    return false;
+  }
+
+  if (Date.now() - existing.acquired_at <= LOCK_STALE_MS) {
+    return false;
+  }
+
+  return !(existing.host === os.hostname() && isProcessAlive(existing.pid));
+}
 
 export async function acquireLock(root, operation) {
   const lockPath = path.join(root, ".agents", ".lock");
@@ -30,7 +56,7 @@ export async function acquireLock(root, operation) {
 
     try {
       const existing = JSON.parse(await fs.readFile(lockPath, "utf8"));
-      if (Date.now() - existing.acquired_at > LOCK_STALE_MS) {
+      if (canReclaimLock(existing)) {
         await fs.unlink(lockPath);
         return acquireLock(root, operation);
       }

--- a/test/lock.test.js
+++ b/test/lock.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { acquireLock } from "../src/core/lock.js";
+
+test("acquireLock refuses to steal a stale lock from a live owner on the same host", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-lock-live-"));
+  await fs.mkdir(path.join(root, ".agents"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, ".agents", ".lock"),
+    JSON.stringify({
+      pid: process.pid,
+      operation: "scan",
+      acquired_at: Date.now() - 301000,
+      host: os.hostname(),
+    }),
+    "utf8",
+  );
+
+  const result = await acquireLock(root, "doc");
+
+  assert.equal(result.acquired, false);
+  assert.equal(result.holder.pid, process.pid);
+  assert.match(result.message, /Lock held by PID/);
+});
+
+test("acquireLock reclaims a stale lock when the recorded owner is gone", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-lock-dead-"));
+  await fs.mkdir(path.join(root, ".agents"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, ".agents", ".lock"),
+    JSON.stringify({
+      pid: 2147483647,
+      operation: "scan",
+      acquired_at: Date.now() - 301000,
+      host: os.hostname(),
+    }),
+    "utf8",
+  );
+
+  const result = await acquireLock(root, "doc");
+
+  assert.equal(result.acquired, true);
+  const lockData = JSON.parse(await fs.readFile(path.join(root, ".agents", ".lock"), "utf8"));
+  assert.equal(lockData.pid, process.pid);
+  assert.equal(lockData.operation, "doc");
+  await result.release();
+  await assert.rejects(() => fs.access(path.join(root, ".agents", ".lock")));
+});


### PR DESCRIPTION
## Summary
- block stale lock reclamation when the recorded same-host PID is still alive
- keep abandoned stale-lock recovery intact for scan/doc
- add regression coverage for live-owner and abandoned-lock cases

## Verification
- pnpm test

Closes #24
