### PR TITLE
Add glab-issues-autopilot skill and default author-scoped issue selection

### DIFF
--- a/.codex/skills/gh-issue-autopilot/SKILL.md
+++ b/.codex/skills/gh-issue-autopilot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-issue-autopilot
-description: Pick the first or latest open GitHub issue with gh CLI, implement it autonomously in a tight loop (code, validate, test, fix), and commit when all checks pass.
+description: Pick the first or latest open GitHub issue with gh CLI, implement it autonomously in a tight loop (code, validate, test, fix), and commit when all checks pass. Verify gh authentication first, and by default only pick issues authored by the authenticated user unless the human explicitly asks for all issues or a different author.
 ---
 
 # GH Issue Autopilot
@@ -12,9 +12,12 @@ Run end-to-end with minimal human interaction.
 1. Confirm repository and auth are ready:
    - `git rev-parse --is-inside-work-tree`
    - `gh auth status`
+   - `GH_USER="$(gh api user --jq .login)"`
 2. Select issue based on user mode:
    - `latest`: most recently created open issue
    - `first`: oldest open issue
+   - default scope: issues authored by `$GH_USER`
+   - only widen scope when the human explicitly asks
 3. Fetch issue details and convert to an execution checklist.
 4. Implement the smallest viable change.
 5. Run verification loop automatically:
@@ -27,17 +30,25 @@ Run end-to-end with minimal human interaction.
 
 ## Issue Selection Commands
 
-Latest open issue:
+Resolve current user:
 
 ```bash
-gh issue list --state open --limit 100 --json number,title,createdAt --jq 'sort_by(.createdAt) | reverse | .[0]'
+GH_USER="$(gh api user --jq .login)"
 ```
 
-First open issue:
+Latest open issue authored by current user (default):
 
 ```bash
-gh issue list --state open --limit 100 --json number,title,createdAt --jq 'sort_by(.createdAt) | .[0]'
+gh issue list --state open --limit 100 --author "$GH_USER" --json number,title,createdAt --jq 'sort_by(.createdAt) | reverse | .[0]'
 ```
+
+First open issue authored by current user (default):
+
+```bash
+gh issue list --state open --limit 100 --author "$GH_USER" --json number,title,createdAt --jq 'sort_by(.createdAt) | .[0]'
+```
+
+If explicitly requested to include all authors, drop `--author "$GH_USER"`.
 
 Load full issue:
 

--- a/.codex/skills/glab-issues-autopilot/SKILL.md
+++ b/.codex/skills/glab-issues-autopilot/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: glab-issues-autopilot
+description: Pick the first or latest open GitLab issue with glab CLI, implement it autonomously in a tight loop (code, validate, test, fix), and commit when all checks pass. Verify glab authentication and repository context first, and by default only pick issues authored by the authenticated user unless the human explicitly asks for all issues or a different author.
+---
+
+# GLab Issues Autopilot
+
+Run end-to-end with minimal human interaction.
+
+## Workflow
+
+1. Confirm repository and auth are ready:
+   - `git rev-parse --is-inside-work-tree`
+   - `glab auth status`
+   - `GLAB_USER="$(glab api user | jq -r .username)"`
+2. Resolve repository context:
+   - `glab repo view`
+3. Select issue based on user mode:
+   - `latest`: most recently created open issue
+   - `first`: oldest open issue
+   - default scope: issues authored by `$GLAB_USER`
+   - only widen scope when the human explicitly asks
+4. Fetch issue details and convert to an execution checklist.
+5. Implement the smallest viable change.
+6. Run verification loop automatically:
+   - format/lint/typecheck (if present)
+   - relevant unit/integration tests
+   - repository standard checks
+7. If checks fail, fix and rerun until pass or truly blocked.
+8. Commit with message referencing issue number.
+9. Report summary, checks, and commit hash.
+
+## Issue Selection Commands
+
+Resolve current user:
+
+```bash
+GLAB_USER="$(glab api user | jq -r .username)"
+```
+
+Latest open issue authored by current user (default):
+
+```bash
+glab issue list --state opened --author "$GLAB_USER" --per-page 100 --output json | jq 'sort_by(.created_at) | reverse | .[0]'
+```
+
+First open issue authored by current user (default):
+
+```bash
+glab issue list --state opened --author "$GLAB_USER" --per-page 100 --output json | jq 'sort_by(.created_at) | .[0]'
+```
+
+If explicitly requested to include all authors, drop `--author "$GLAB_USER"`.
+
+Load full issue:
+
+```bash
+glab issue view <number> --output json
+```
+
+## Operating Rules
+
+- Prefer repo scripts and existing CI-like commands.
+- Keep scope to the selected issue.
+- Use small commits and deterministic commands.
+- If blocked by external dependency, stop and report exact blocker and attempts.
+
+## Guardrails
+
+- Do not modify unrelated issues or backlog ordering.
+- Do not skip failing checks by weakening tests or protections.
+- Do not force-push or rewrite shared history.
+- Do not close an issue unless explicitly requested.

--- a/.codex/skills/glab-issues-autopilot/agents/openai.yaml
+++ b/.codex/skills/glab-issues-autopilot/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GLab Issues Autopilot"
+  short_description: "Pick a GitLab issue and implement it autonomously"
+  default_prompt: "Use $glab-issues-autopilot to select the latest open issue authored by me, implement it, run checks in a loop, and commit once green."


### PR DESCRIPTION
### Motivation

- Provide a GitLab equivalent of the existing GitHub autopilot skill so the agent can operate with `glab` in GitLab repositories.
- Ensure both `gh` and `glab` autopilot skills default to picking issues authored by the authenticated user to avoid acting on others' issues unless explicitly requested.

### Description

- Updated `.codex/skills/gh-issue-autopilot/SKILL.md` to resolve the current GitHub user with `GH_USER="$(gh api user --jq .login)"` and to default issue selection to issues authored by `GH_USER` unless explicitly asked to widen scope.
- Added new skill `.codex/skills/glab-issues-autopilot/SKILL.md` implementing the same autopilot workflow for GitLab using `glab`, including `GLAB_USER="$(glab api user | jq -r .username)"`, repo readiness checks, and author-scoped `glab issue list` commands.
- Added UI metadata `.codex/skills/glab-issues-autopilot/agents/openai.yaml` with `display_name`, `short_description`, and `default_prompt` for consistency with existing skills.
- Commit recorded (HEAD `5e000c1`) including the new `glab-issues-autopilot` skill and the `gh-issue-autopilot` update.

### Testing

- Committed changes with `git add`/`git commit` and verified with `git status --short`, which succeeded and produced commit `5e000c1`.
- Attempted to run skill validation via `python3 scripts/quick_validate.py` but `scripts/quick_validate.py` was not present in this repository so validation could not run.
- Checked presence of CLIs with `gh issue list --help` and `glab issue list --help`, which returned `command not found` in this environment, so runtime CLI checks could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d4a8cfad88832ab731890a80d7829d)