### PR TITLE
fix: tighten read-only snapshot permissions

### DIFF
--- a/src/core/db.js
+++ b/src/core/db.js
@@ -6,6 +6,8 @@ import process from "node:process";
 
 const require = createRequire(import.meta.url);
 const DB_SCHEMA_VERSION = "3.0";
+const SNAPSHOT_DIR_MODE = 0o700;
+const SNAPSHOT_FILE_MODE = 0o600;
 
 let driver = null;
 
@@ -78,16 +80,16 @@ export function getIndexDbPath(root) {
 function createIndexSnapshot(dbPath) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentify-index-"));
   const snapshotPath = path.join(tempDir, "index.db");
-  fs.chmodSync(tempDir, 0o755);
+  fs.chmodSync(tempDir, SNAPSHOT_DIR_MODE);
   fs.copyFileSync(dbPath, snapshotPath);
-  fs.chmodSync(snapshotPath, 0o644);
+  fs.chmodSync(snapshotPath, SNAPSHOT_FILE_MODE);
 
   for (const suffix of ["-wal", "-shm"]) {
     const sourcePath = `${dbPath}${suffix}`;
     if (fs.existsSync(sourcePath)) {
       const snapshotSidecarPath = `${snapshotPath}${suffix}`;
       fs.copyFileSync(sourcePath, snapshotSidecarPath);
-      fs.chmodSync(snapshotSidecarPath, 0o644);
+      fs.chmodSync(snapshotSidecarPath, SNAPSHOT_FILE_MODE);
     }
   }
 

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { runScan } from "../src/core/commands.js";
+import { loadConfig } from "../src/core/config.js";
+import { closeIndexDatabase, openIndexDatabase } from "../src/core/db.js";
+
+function octalMode(stats) {
+  return (stats.mode & 0o777).toString(8);
+}
+
+test("openIndexDatabase read-only snapshots use user-only permissions", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-db-readonly-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "src", "station.ts"),
+    "export function findMetroStation(query) { return query.trim(); }\n",
+    "utf8",
+  );
+
+  const config = await loadConfig(root, { provider: "local", dryRun: false });
+  await runScan(root, config);
+
+  const db = openIndexDatabase(root, { readOnly: true });
+  const tempDir = db.__agentifyTempDir;
+  const snapshotPath = path.join(tempDir, "index.db");
+
+  try {
+    assert.equal(octalMode(await fs.stat(tempDir)), "700");
+    assert.equal(octalMode(await fs.stat(snapshotPath)), "600");
+
+    for (const suffix of ["-wal", "-shm"]) {
+      const sidecarPath = `${snapshotPath}${suffix}`;
+      const exists = await fs.access(sidecarPath).then(() => true).catch(() => false);
+      if (exists) {
+        assert.equal(octalMode(await fs.stat(sidecarPath)), "600");
+      }
+    }
+  } finally {
+    closeIndexDatabase(db);
+  }
+
+  await assert.rejects(() => fs.access(tempDir));
+});


### PR DESCRIPTION
## Summary
- restrict read-only SQLite snapshot directories to 0700 and copied snapshot files to 0600
- keep the existing snapshot-based read path and cleanup behavior intact
- add regression coverage that inspects effective temp-path permissions before close

## Verification
- pnpm test

Closes #27
