### PR TITLE
fix: remove machine-local package self-link

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "url": "https://github.com/user/agentify/issues"
   },
   "dependencies": {
-    "agentify": "link:../../.local/share/pnpm/global/5/node_modules/agentify",
     "better-sqlite3": "^12.8.0",
     "cli-table3": "^0.6.5",
     "picocolors": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,16 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  agentify: link:../../.local/share/pnpm/global/5/node_modules/agentify
-
 importers:
 
   .:
     dependencies:
-      agentify:
-        specifier: link:../../.local/share/pnpm/global/5/node_modules/agentify
-        version: link:../../.local/share/pnpm/global/5/node_modules/agentify
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-overrides:
-  agentify: link:../../.local/share/pnpm/global/5/node_modules/agentify


### PR DESCRIPTION
## Summary
- remove the published package self-dependency on a machine-local PNPM link target
- drop the matching workspace override and regenerate the lockfile without the self-link
- keep the existing CLI/package surface intact while restoring portable publish metadata

## Verification
- pnpm test
- npm_config_cache=/tmp/agentify-npm-cache npm pack --dry-run

Closes #14
