### PR TITLE
docs: point public repo metadata at ixigo/agentify

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ agentify clean --dry-run
 ## Development
 
 ```bash
-git clone https://github.com/user/agentify.git
+git clone https://github.com/ixigo/agentify.git
 cd agentify
 pnpm install
 pnpm test

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/user/agentify.git"
+    "url": "git+https://github.com/ixigo/agentify.git"
   },
-  "homepage": "https://github.com/user/agentify",
+  "homepage": "https://github.com/ixigo/agentify",
   "bugs": {
-    "url": "https://github.com/user/agentify/issues"
+    "url": "https://github.com/ixigo/agentify/issues"
   },
   "dependencies": {
     "agentify": "link:../../.local/share/pnpm/global/5/node_modules/agentify",


### PR DESCRIPTION
## Summary
- update public package metadata to point at the real `ixigo/agentify` repository
- fix the README clone command so contributors land in the right repo
- remove the remaining placeholder public-facing GitHub URLs from the tree

## Verification
- rg -n "github.com/user/agentify" README.md package.json src usage.md test
- pnpm test

Closes #19
