### PR TITLE
fix: capture interactive session transcripts for #38

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Use this when you already manage local dependencies yourself or when `agentify t
 | `agentify sess fork` | Forks an existing session into a new branch of work. | Use when you want to preserve the old session but try a different implementation or direction. | `agentify sess fork --from sess_20260331_ab12cd --name "payments-alt" "try alternate design"` |
 | `agentify sess list` | Lists known sessions for the repo. | Use when you need to find an id to resume or audit previous work threads. | `agentify sess list` |
 
-Session memory is automatic for `sess *` commands. Each run now writes MemPalace-compatible artifacts such as `transcript.md`, `memory-context.md`, and `launches.jsonl` under `.agents/session/<id>/`, and `sess resume` / `sess fork` automatically inject recent transcript excerpts into the next prompt without requiring a separate memory command.
+Session memory is automatic for `sess *` commands. Each run now writes MemPalace-compatible artifacts such as `transcript.md`, `memory-context.md`, `launches.jsonl`, and, for interactive provider runs, a raw `interactive.log` under `.agents/session/<id>/`. `sess resume` / `sess fork` automatically inject recent transcript excerpts into the next prompt without requiring a separate memory command.
 
 ### Query, Skills, Hooks, And Cache
 
@@ -141,7 +141,7 @@ agentify sess fork --from <id> [--provider <name>] [--name <label>] "task"
 
 Use sessions when the work is multi-step, the prompt context is too expensive to rebuild every time, or you want a durable audit trail under `.agents/session/`.
 
-When a session is resumed or forked, Agentify automatically loads recent excerpts from the current or parent session transcript and appends them to the next provider prompt. The transcript format is compatible with MemPalace conversation mining, so external semantic memory remains optional rather than a manual prerequisite.
+When a session is resumed or forked, Agentify automatically loads recent excerpts from the current or parent session transcript and appends them to the next provider prompt. Interactive session runs now keep both the raw PTY log and a normalized transcript section, so the MemPalace-compatible transcript stays searchable even when the provider runs in TUI mode.
 
 ### `query` Commands
 

--- a/src/core/exec.js
+++ b/src/core/exec.js
@@ -1,8 +1,9 @@
 import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
 import { getChangedFiles, getHeadCommit } from "./git.js";
 import { runScan, runDoc } from "./commands.js";
 import { validateRepo } from "./validate.js";
-import { finalizeSessionMemoryRun, prepareSessionMemoryRun } from "./session-memory.js";
+import { finalizeSessionMemoryRun, normalizeInteractiveCapture, prepareSessionMemoryRun } from "./session-memory.js";
 import * as ui from "./ui.js";
 
 const AGENTIFY_EXIT_VALIDATE_FAILED = 80;
@@ -13,18 +14,45 @@ function diffSnapshots(preFiles, postFiles) {
   return postFiles.filter((f) => !preSet.has(`${f.status}:${f.path}`));
 }
 
+function posixShellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\"'\"'")}'`;
+}
+
+function buildScriptCommand(argv, capturePath) {
+  const [cmd, ...args] = argv;
+  if (process.platform === "darwin") {
+    return {
+      cmd: "script",
+      args: ["-q", capturePath, cmd, ...args],
+    };
+  }
+
+  return {
+    cmd: "script",
+    args: ["-q", "-e", "-c", argv.map(posixShellQuote).join(" "), capturePath],
+  };
+}
+
 function runWrappedCommand(argv, options) {
   return new Promise((resolve, reject) => {
-    const [cmd, ...args] = argv;
+    const captureMode = options.captureOutputMode || "inherit";
+    const command = captureMode === "pty"
+      ? buildScriptCommand(argv, options.capturePath)
+      : { cmd: argv[0], args: argv.slice(1) };
+    const stdio = captureMode === "pipe"
+      ? ["inherit", "pipe", "pipe"]
+      : captureMode === "pty" && !process.stdin.isTTY
+        ? ["ignore", "inherit", "inherit"]
+        : "inherit";
     const stdoutChunks = [];
     const stderrChunks = [];
-    const child = spawn(cmd, args, {
+    const child = spawn(command.cmd, command.args, {
       cwd: options.cwd,
-      stdio: options.captureOutput ? ["inherit", "pipe", "pipe"] : "inherit",
+      stdio,
       env: process.env,
     });
 
-    if (options.captureOutput) {
+    if (captureMode === "pipe") {
       child.stdout.on("data", (chunk) => {
         stdoutChunks.push(Buffer.from(chunk));
         process.stdout.write(chunk);
@@ -44,13 +72,25 @@ function runWrappedCommand(argv, options) {
     }
 
     child.on("error", reject);
-    child.on("close", (code) => {
+    child.on("close", async (code) => {
       if (timer) clearTimeout(timer);
-      resolve({
-        exitCode: code ?? 1,
-        stdout: options.captureOutput ? Buffer.concat(stdoutChunks).toString("utf8") : "",
-        stderr: options.captureOutput ? Buffer.concat(stderrChunks).toString("utf8") : "",
-      });
+      try {
+        let interactiveTranscript = "";
+        if (captureMode === "pty" && options.capturePath) {
+          const raw = await fs.readFile(options.capturePath, "utf8");
+          interactiveTranscript = normalizeInteractiveCapture(raw);
+        }
+
+        resolve({
+          exitCode: code ?? 1,
+          stdout: captureMode === "pipe" ? Buffer.concat(stdoutChunks).toString("utf8") : "",
+          stderr: captureMode === "pipe" ? Buffer.concat(stderrChunks).toString("utf8") : "",
+          interactiveTranscript,
+          rawInteractiveLogPath: captureMode === "pty" ? options.capturePath : null,
+        });
+      } catch (error) {
+        reject(error);
+      }
     });
   });
 }
@@ -67,23 +107,42 @@ export async function runExec(root, config, agentCommand, flags) {
     commandResult = await runWrappedCommand(agentCommand, {
       cwd: root,
       timeout: flags.timeout ? flags.timeout * 1000 : undefined,
-      captureOutput: flags.captureOutput || false,
+      captureOutputMode: flags.captureOutputMode || (flags.captureOutput ? "pipe" : "inherit"),
+      capturePath: preparedSessionMemory?.paths.rawInteractiveLogPath || null,
     });
   } catch (error) {
-    if (preparedSessionMemory) {
-      await finalizeSessionMemoryRun(root, flags.sessionRecord, preparedSessionMemory, {
-        phase: "spawn-error",
-        exitCode: 1,
-        stderr: error.message,
-      }, config);
+    if (flags.captureOutputMode === "pty" && error?.code === "ENOENT") {
+      if (flags.sessionRecord) {
+        flags.sessionRecord.captureMode = "interactive-fallback";
+      }
+      commandResult = await runWrappedCommand(agentCommand, {
+        cwd: root,
+        timeout: flags.timeout ? flags.timeout * 1000 : undefined,
+        captureOutputMode: "inherit",
+      });
+    } else {
+      if (preparedSessionMemory) {
+        await finalizeSessionMemoryRun(root, flags.sessionRecord, preparedSessionMemory, {
+          phase: "spawn-error",
+          exitCode: 1,
+          stderr: error.message,
+        }, config);
+      }
+      throw error;
     }
-    throw error;
   }
   const exitCode = commandResult.exitCode;
 
   if (exitCode !== 0) {
     process.exitCode = exitCode;
-    const result = { phase: "command", exitCode, stdout: commandResult.stdout, stderr: commandResult.stderr };
+    const result = {
+      phase: "command",
+      exitCode,
+      stdout: commandResult.stdout,
+      stderr: commandResult.stderr,
+      interactiveTranscript: commandResult.interactiveTranscript,
+      rawInteractiveLogPath: commandResult.rawInteractiveLogPath,
+    };
     if (preparedSessionMemory) {
       await finalizeSessionMemoryRun(root, flags.sessionRecord, preparedSessionMemory, result, config);
     }
@@ -97,6 +156,8 @@ export async function runExec(root, config, agentCommand, flags) {
       skippedRefresh: true,
       stdout: commandResult.stdout,
       stderr: commandResult.stderr,
+      interactiveTranscript: commandResult.interactiveTranscript,
+      rawInteractiveLogPath: commandResult.rawInteractiveLogPath,
     };
     if (preparedSessionMemory) {
       await finalizeSessionMemoryRun(root, flags.sessionRecord, preparedSessionMemory, result, config);
@@ -124,6 +185,8 @@ export async function runExec(root, config, agentCommand, flags) {
       skippedRefresh: true,
       stdout: commandResult.stdout,
       stderr: commandResult.stderr,
+      interactiveTranscript: commandResult.interactiveTranscript,
+      rawInteractiveLogPath: commandResult.rawInteractiveLogPath,
     };
     if (preparedSessionMemory) {
       await finalizeSessionMemoryRun(root, flags.sessionRecord, preparedSessionMemory, result, config);
@@ -143,6 +206,8 @@ export async function runExec(root, config, agentCommand, flags) {
         exitCode: AGENTIFY_EXIT_REFRESH_ERROR,
         stdout: commandResult.stdout,
         stderr: `${commandResult.stderr}${commandResult.stderr ? "\n" : ""}${error.message}`,
+        interactiveTranscript: commandResult.interactiveTranscript,
+        rawInteractiveLogPath: commandResult.rawInteractiveLogPath,
       };
       if (preparedSessionMemory) {
         await finalizeSessionMemoryRun(root, flags.sessionRecord, preparedSessionMemory, result, config);
@@ -169,6 +234,8 @@ export async function runExec(root, config, agentCommand, flags) {
     validation,
     stdout: commandResult.stdout,
     stderr: commandResult.stderr,
+    interactiveTranscript: commandResult.interactiveTranscript,
+    rawInteractiveLogPath: commandResult.rawInteractiveLogPath,
   };
   if (preparedSessionMemory) {
     await finalizeSessionMemoryRun(root, flags.sessionRecord, preparedSessionMemory, result, config);

--- a/src/core/session-memory.js
+++ b/src/core/session-memory.js
@@ -28,6 +28,47 @@ function clipToBytes(value, maxBytes) {
   return "";
 }
 
+function stripAnsiSequences(text) {
+  return String(text || "")
+    .replace(/\u001B\][^\u0007]*(?:\u0007|\u001B\\)/g, "")
+    .replace(/\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "");
+}
+
+function stripBackspaces(text) {
+  let value = String(text || "");
+  let previous = "";
+  while (value !== previous) {
+    previous = value;
+    value = value.replace(/[^\n]\u0008/g, "");
+  }
+  return value.replace(/\u0008+/g, "");
+}
+
+export function normalizeInteractiveCapture(text) {
+  const cleaned = stripBackspaces(
+    stripAnsiSequences(String(text || ""))
+      .replace(/\r\n/g, "\n")
+      .replace(/\r/g, "\n")
+      .replace(/[\u0000-\u0007\u000B-\u001F\u007F]/g, "")
+  );
+
+  const lines = cleaned
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        return true;
+      }
+      return !trimmed.startsWith("Script started on ") && !trimmed.startsWith("Script done on ");
+    });
+
+  return lines
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 function getSessionMemoryLimit(config, key, fallback) {
   const value = Number(config?.session?.[key]);
   return Number.isFinite(value) && value > 0 ? value : fallback;
@@ -114,6 +155,7 @@ export function getSessionArtifactPaths(root, sessionId) {
     transcriptPath: path.join(sessionDir, "transcript.md"),
     memoryContextPath: path.join(sessionDir, "memory-context.md"),
     launchesPath: path.join(sessionDir, "launches.jsonl"),
+    rawInteractiveLogPath: path.join(sessionDir, "interactive.log"),
   };
 }
 
@@ -192,16 +234,18 @@ export async function prepareSessionMemoryRun(root, sessionRecord) {
     ""
   );
 
-  await fs.appendFile(paths.transcriptPath, `${transcriptLines.join("\n")}\n`, "utf8");
+  await fs.appendFile(paths.transcriptPath, `${transcriptLines.filter(Boolean).join("\n")}\n`, "utf8");
   return { startedAt, paths };
 }
 
 export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, outcome, config) {
   const captureMaxBytes = getSessionMemoryLimit(config, "captureMaxKb", 48) * 1024;
-  const providerOutput = [outcome?.stdout, outcome?.stderr]
-    .filter(Boolean)
-    .join("\n")
-    .trim();
+  const providerOutput = outcome?.interactiveTranscript
+    ? String(outcome.interactiveTranscript).trim()
+    : [outcome?.stdout, outcome?.stderr]
+      .filter(Boolean)
+      .join("\n")
+      .trim();
   const assistantText = providerOutput
     ? clipToBytes(providerOutput, captureMaxBytes)
     : "Agentify launched the provider in inherited interactive mode, so the full assistant transcript was not captured for this run. The prompt, bootstrap, memory context, and launch record were still persisted automatically.";
@@ -219,9 +263,11 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
     `Command phase: ${phase}`,
     `Exit code: ${outcome?.exitCode ?? 1}`,
     `Validation: ${validationSummary}`,
+    `Capture mode used: ${sessionRecord.captureMode}`,
+    outcome?.rawInteractiveLogPath ? `Raw interactive log: ${relative(root, outcome.rawInteractiveLogPath)}` : null,
     `Ended: ${endedAt}`,
     ""
-  ].join("\n");
+  ].filter(Boolean).join("\n");
   await fs.appendFile(prepared.paths.transcriptPath, transcriptTail, "utf8");
 
   const launchRecord = {
@@ -236,6 +282,9 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
     prompt: sessionRecord.prompt,
     transcript_path: relative(root, prepared.paths.transcriptPath),
     memory_context_path: relative(root, prepared.paths.memoryContextPath),
+    raw_interactive_log_path: outcome?.rawInteractiveLogPath
+      ? relative(root, outcome.rawInteractiveLogPath)
+      : null,
     memory_source_session_id: sessionRecord.memoryContext?.sourceSessionId || null,
     memory_source_transcript: sessionRecord.memoryContext?.transcriptRelativePath || null,
     phase,

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -92,6 +92,7 @@ function fitContext(manifest, index, checklist, options, config) {
   const transcriptRef = options.root ? `.agents/session/${manifest.session_id}/transcript.md` : memoryArtifacts.transcriptPath;
   const memoryContextRef = options.root ? `.agents/session/${manifest.session_id}/memory-context.md` : memoryArtifacts.memoryContextPath;
   const launchesRef = options.root ? `.agents/session/${manifest.session_id}/launches.jsonl` : memoryArtifacts.launchesPath;
+  const rawInteractiveLogRef = options.root ? `.agents/session/${manifest.session_id}/interactive.log` : memoryArtifacts.rawInteractiveLogPath;
   const attempts = [
     { moduleLimit: moduleIds.length, checklistLimit: checklist.length, checklistTextBytes: 240, parentSummaryBytes: 2048 },
     { moduleLimit: 64, checklistLimit: 20, checklistTextBytes: 180, parentSummaryBytes: 1024 },
@@ -126,6 +127,7 @@ function fitContext(manifest, index, checklist, options, config) {
         transcript: transcriptRef,
         memory_context: memoryContextRef,
         launches: launchesRef,
+        raw_interactive_log: rawInteractiveLogRef,
       },
       parent_summary: clipToBytes(options.parentSummary || "", attempt.parentSummaryBytes),
     };
@@ -224,6 +226,7 @@ export async function forkSession(root, config, options = {}) {
       `.agents/session/${sessionId}/transcript.md`,
       `.agents/session/${sessionId}/memory-context.md`,
       `.agents/session/${sessionId}/launches.jsonl`,
+      `.agents/session/${sessionId}/interactive.log`,
     ],
     metadata: {
       modules_indexed: index?.modules?.length || 0,

--- a/src/main.js
+++ b/src/main.js
@@ -513,7 +513,7 @@ export async function runCli(argv) {
         }
 
         await runExec(root, { ...config, provider }, agentCommand, getExecFlags(args, {
-          captureOutput: !providerOptions.interactive,
+          captureOutputMode: providerOptions.interactive ? "pty" : "pipe",
           sessionRecord: {
             sessionId: result.manifest.session_id,
             provider,
@@ -521,7 +521,7 @@ export async function runCli(argv) {
             task: task || "Continue this session from the latest repository state.",
             command: agentCommand,
             memoryContext,
-            captureMode: providerOptions.interactive ? "interactive-fallback" : "captured-pipe",
+            captureMode: providerOptions.interactive ? "interactive-pty" : "captured-pipe",
           },
         }));
         return;
@@ -547,7 +547,7 @@ export async function runCli(argv) {
           );
 
         await runExec(root, { ...config, provider }, agentCommand, getExecFlags(args, {
-          captureOutput: !providerOptions.interactive,
+          captureOutputMode: providerOptions.interactive ? "pty" : "pipe",
           sessionRecord: {
             sessionId: result.manifest.session_id,
             provider,
@@ -555,7 +555,7 @@ export async function runCli(argv) {
             task: task || "Continue this session from the latest repository state.",
             command: agentCommand,
             memoryContext,
-            captureMode: providerOptions.interactive ? "interactive-fallback" : "captured-pipe",
+            captureMode: providerOptions.interactive ? "interactive-pty" : "captured-pipe",
           },
         }));
         return;
@@ -606,7 +606,7 @@ export async function runCli(argv) {
         }
 
         await runExec(root, { ...config, provider }, agentCommand, getExecFlags(args, {
-          captureOutput: !providerOptions.interactive,
+          captureOutputMode: providerOptions.interactive ? "pty" : "pipe",
           sessionRecord: {
             sessionId: sessionResult.manifest.session_id,
             provider,
@@ -614,7 +614,7 @@ export async function runCli(argv) {
             task: task || "Continue this session from the latest repository state.",
             command: agentCommand,
             memoryContext,
-            captureMode: providerOptions.interactive ? "interactive-fallback" : "captured-pipe",
+            captureMode: providerOptions.interactive ? "interactive-pty" : "captured-pipe",
           },
         }));
         return;

--- a/test/exec.test.js
+++ b/test/exec.test.js
@@ -107,3 +107,48 @@ test("runExec writes MemPalace-compatible session memory artifacts when recordin
   assert.match(launches, /captured-pipe/);
   assert.match(launches, /Continue this session using the remembered context/);
 });
+
+test("runExec records interactive provider output into a raw PTY log and normalized transcript", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-exec-interactive-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await initGitRepo(root);
+
+  for (const provider of ["codex", "claude"]) {
+    const config = await loadConfig(root, { provider, dryRun: false, tokenReport: false });
+    const session = await forkSession(root, config, { name: `${provider}-interactive` });
+    const result = await runExec(
+      root,
+      config,
+      ["node", "--input-type=module", "-e", "process.stdout.write('interactive transcript\\n')"],
+      {
+        captureOutputMode: "pty",
+        sessionRecord: {
+          sessionId: session.sessionId,
+          provider,
+          prompt: `Continue the ${provider} interactive session.`,
+          task: `Verify PTY capture for ${provider}.`,
+          command: ["node", "--input-type=module", "-e", "process.stdout.write('interactive transcript\\n')"],
+          memoryContext: {
+            sourceSessionId: null,
+            transcriptRelativePath: null,
+            excerpt: "",
+            markdown: "## Automatic Session Memory\nNo prior session transcript was available.\n",
+          },
+          captureMode: "interactive-pty",
+        },
+      }
+    );
+
+    const transcript = await fs.readFile(path.join(session.sessionDir, "transcript.md"), "utf8");
+    const launches = await fs.readFile(path.join(session.sessionDir, "launches.jsonl"), "utf8");
+    const rawLog = await fs.readFile(path.join(session.sessionDir, "interactive.log"), "utf8");
+
+    assert.equal(result.phase, "complete");
+    assert.equal(result.exitCode, 0);
+    assert.match(transcript, /interactive transcript/);
+    assert.match(transcript, /Raw interactive log:/);
+    assert.match(launches, /interactive-pty/);
+    assert.match(launches, /interactive\.log/);
+    assert.match(rawLog, /interactive transcript/);
+  }
+});

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -9,7 +9,7 @@ import { promisify } from "node:util";
 import { loadConfig } from "../src/core/config.js";
 import { closeIndexDatabase, inTransaction, openIndexDatabase, writeRepositoryIndex } from "../src/core/db.js";
 import { forkSession, resolveSessionProvider, resumeSession } from "../src/core/session.js";
-import { getSessionArtifactPaths, loadAutomaticSessionMemory } from "../src/core/session-memory.js";
+import { getSessionArtifactPaths, loadAutomaticSessionMemory, normalizeInteractiveCapture } from "../src/core/session-memory.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -146,4 +146,9 @@ test("loadAutomaticSessionMemory reuses the parent transcript automatically", as
   assert.match(memory.markdown, /Automatic Session Memory/);
   assert.match(memory.markdown, /Refresh after the wrapped command commit lands/);
   assert.match(memory.markdown, new RegExp(parent.sessionId));
+});
+
+test("normalizeInteractiveCapture strips script noise and ANSI sequences", () => {
+  const normalized = normalizeInteractiveCapture("\u0004\u0008\u0008Script started on now\n\u001b[31mhello\u001b[0m\r\nScript done on later\n");
+  assert.equal(normalized, "hello");
 });


### PR DESCRIPTION
## Summary
- record interactive session runs through a PTY-backed wrapper instead of dropping to interactive-fallback by default
- persist raw interactive logs alongside normalized transcript content for searchable session memory artifacts
- cover the new recording path with exec/session-memory tests and document the new artifact behavior

## Testing
- npm test

Closes #38