### PR TITLE
feat: add automatic cross-session memory for #39

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Use this when you already manage local dependencies yourself or when `agentify t
 | `agentify sess fork` | Forks an existing session into a new branch of work. | Use when you want to preserve the old session but try a different implementation or direction. | `agentify sess fork --from sess_20260331_ab12cd --name "payments-alt" "try alternate design"` |
 | `agentify sess list` | Lists known sessions for the repo. | Use when you need to find an id to resume or audit previous work threads. | `agentify sess list` |
 
-Session memory is automatic for `sess *` commands. Each run now writes MemPalace-compatible artifacts such as `transcript.md`, `memory-context.md`, and `launches.jsonl` under `.agents/session/<id>/`, and `sess resume` / `sess fork` automatically inject recent transcript excerpts into the next prompt without requiring a separate memory command.
+Session memory is automatic for both `run` and `sess *` commands. Agentify writes MemPalace-compatible artifacts such as `transcript.md`, `memory-context.md`, and `launches.jsonl` under `.agents/session/<id>/`, then automatically recalls relevant prior history before the next provider launch. When the `mempalace` CLI is installed, Agentify also builds and queries a repo-local MemPalace index under `.agents/mempalace/` with no extra user command.
 
 ### Query, Skills, Hooks, And Cache
 
@@ -141,7 +141,7 @@ agentify sess fork --from <id> [--provider <name>] [--name <label>] "task"
 
 Use sessions when the work is multi-step, the prompt context is too expensive to rebuild every time, or you want a durable audit trail under `.agents/session/`.
 
-When a session is resumed or forked, Agentify automatically loads recent excerpts from the current or parent session transcript and appends them to the next provider prompt. The transcript format is compatible with MemPalace conversation mining, so external semantic memory remains optional rather than a manual prerequisite.
+When a session is resumed or forked, Agentify first tries an automatic MemPalace-backed search across prior session transcripts for the current repo, then falls back to Agentify's built-in ranked transcript search, and finally to direct lineage replay if no broader match is found. Normal `run` prompts use the same automatic recall path, so relevant older session decisions can surface even without a session id or explicit memory command.
 
 ### `query` Commands
 

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -48,6 +48,7 @@ const DEFAULT_CONFIG = {
     contextMaxKb: 16,
     memoryPromptMaxKb: 4,
     memoryTurns: 6,
+    memoryResults: 3,
     captureMaxKb: 48,
   },
   planner: {

--- a/src/core/session-memory.js
+++ b/src/core/session-memory.js
@@ -1,7 +1,50 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { promisify } from "node:util";
 
 import { ensureDir, exists, relative, writeText } from "./fs.js";
+
+const execFileAsync = promisify(execFile);
+
+const MEMORY_STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "be",
+  "before",
+  "continue",
+  "current",
+  "for",
+  "from",
+  "how",
+  "in",
+  "into",
+  "is",
+  "it",
+  "latest",
+  "new",
+  "of",
+  "on",
+  "or",
+  "repo",
+  "repository",
+  "run",
+  "session",
+  "state",
+  "task",
+  "that",
+  "the",
+  "this",
+  "to",
+  "use",
+  "using",
+  "we",
+  "with",
+  "work",
+]);
 
 function bytes(value) {
   return Buffer.byteLength(String(value || ""), "utf8");
@@ -47,6 +90,21 @@ function normalizeCommand(command) {
     const text = String(part);
     return /\s/.test(text) ? `"${shellEscape(text)}"` : text;
   }).join(" ");
+}
+
+function normalizeQuery(text) {
+  return String(text || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function tokenizeQuery(text) {
+  return Array.from(new Set(
+    normalizeQuery(text)
+      .split(/\s+/)
+      .filter((token) => token.length >= 3 && !MEMORY_STOP_WORDS.has(token))
+  ));
 }
 
 function parseTranscriptTurns(text) {
@@ -100,11 +158,360 @@ function selectRecentTurns(turns, maxTurns, maxBytes) {
 function buildNoMemoryMarkdown() {
   return [
     "## Automatic Session Memory",
-    "- No prior session transcript was available for this run.",
+    "- Backend: none",
+    "- No relevant prior Agentify memory matched this run.",
     "- Agentify still writes MemPalace-compatible transcript artifacts automatically for future reuse.",
     "",
-    "No recalled transcript excerpt was injected before this run.",
+    "No recalled memory excerpt was injected before this run.",
   ].join("\n");
+}
+
+function buildPassages(turns) {
+  const passages = [];
+
+  for (let index = 0; index < turns.length; index += 1) {
+    const single = turns[index];
+    if (single) {
+      passages.push(single);
+    }
+
+    const pair = [turns[index], turns[index + 1]].filter(Boolean).join("\n\n").trim();
+    if (pair) {
+      passages.push(pair);
+    }
+  }
+
+  return Array.from(new Set(passages.filter(Boolean)));
+}
+
+function scorePassage(query, tokens, passage) {
+  if (!passage) {
+    return 0;
+  }
+
+  const normalizedPassage = normalizeQuery(passage);
+  if (!normalizedPassage) {
+    return 0;
+  }
+
+  let score = 0;
+  const normalizedQuery = normalizeQuery(query);
+  if (normalizedQuery && normalizedPassage.includes(normalizedQuery)) {
+    score += 12;
+  }
+
+  for (const token of tokens) {
+    if (normalizedPassage.includes(token)) {
+      score += token.length >= 6 ? 3 : 2;
+    }
+  }
+
+  if (passage.includes("> Provider response")) {
+    score += 1;
+  }
+  if (passage.includes("> Current task")) {
+    score += 1;
+  }
+
+  return score;
+}
+
+function buildMemoryMarkdown(backend, hits, extraBullets, maxBytes) {
+  const header = [
+    "## Automatic Session Memory",
+    `- Backend: ${backend}`,
+    ...extraBullets.filter(Boolean),
+    "- Loaded automatically from prior Agentify history. Verify against the current repo state if stale.",
+    "",
+  ].join("\n");
+
+  let markdown = header;
+  for (let index = 0; index < hits.length; index += 1) {
+    const hit = hits[index];
+    const block = [
+      `### Hit ${index + 1}`,
+      hit.sessionId ? `- Source session: ${hit.sessionId}` : null,
+      hit.transcriptRelativePath ? `- Source transcript: \`${hit.transcriptRelativePath}\`` : null,
+      Number.isFinite(hit.score) ? `- Match score: ${hit.score}` : null,
+      "",
+      hit.excerpt,
+      "",
+    ].filter(Boolean).join("\n");
+
+    if (bytes(markdown) + bytes(block) <= maxBytes) {
+      markdown += block;
+      continue;
+    }
+
+    const remaining = maxBytes - bytes(markdown);
+    if (remaining > 0) {
+      markdown += clipToBytes(block, remaining);
+    }
+    break;
+  }
+
+  return markdown.trim();
+}
+
+function buildMemoryResult(backend, hits, extraBullets, maxBytes) {
+  const source = hits[0] || {};
+  const excerpt = clipToBytes(hits.map((hit) => hit.excerpt).join("\n\n"), maxBytes);
+  return {
+    backend,
+    sourceSessionId: source.sessionId || null,
+    transcriptPath: source.transcriptPath || null,
+    transcriptRelativePath: source.transcriptRelativePath || null,
+    excerpt,
+    hits,
+    markdown: buildMemoryMarkdown(backend, hits, extraBullets, maxBytes),
+  };
+}
+
+function getRepoWing(root) {
+  return path.basename(root).toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "") || "agentify_repo";
+}
+
+async function listSessionTranscripts(root) {
+  const sessionsDir = path.join(root, ".agents", "session");
+  if (!(await exists(sessionsDir))) {
+    return [];
+  }
+
+  const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
+  const transcripts = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const transcriptPath = path.join(sessionsDir, entry.name, "transcript.md");
+    if (!(await exists(transcriptPath))) {
+      continue;
+    }
+    const stat = await fs.stat(transcriptPath);
+    transcripts.push({
+      sessionId: entry.name,
+      transcriptPath,
+      transcriptRelativePath: relative(root, transcriptPath),
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+    });
+  }
+
+  return transcripts.sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
+
+function getMemPalacePaths(root) {
+  const baseDir = path.join(root, ".agents", "mempalace");
+  return {
+    baseDir,
+    palacePath: path.join(baseDir, "palace"),
+    exportDir: path.join(baseDir, "session-exports"),
+    syncStatePath: path.join(baseDir, "session-sync.json"),
+  };
+}
+
+async function syncMemPalaceSessionExports(root, transcripts) {
+  const { palacePath, exportDir, syncStatePath } = getMemPalacePaths(root);
+  const fingerprint = createHash("sha1")
+    .update(JSON.stringify(transcripts.map((item) => ({
+      sessionId: item.sessionId,
+      path: item.transcriptRelativePath,
+      mtimeMs: item.mtimeMs,
+      size: item.size,
+    }))))
+    .digest("hex");
+
+  let cachedState = null;
+  if (await exists(syncStatePath)) {
+    try {
+      cachedState = JSON.parse(await fs.readFile(syncStatePath, "utf8"));
+    } catch {
+      cachedState = null;
+    }
+  }
+
+  if (cachedState?.fingerprint === fingerprint && await exists(palacePath)) {
+    return { synced: true, fingerprint, palacePath, exportDir, cached: true };
+  }
+
+  await fs.rm(palacePath, { recursive: true, force: true });
+  await fs.rm(exportDir, { recursive: true, force: true });
+  await ensureDir(exportDir);
+
+  for (const item of transcripts) {
+    const transcript = await fs.readFile(item.transcriptPath, "utf8");
+    const exportPath = path.join(exportDir, `${item.sessionId}.md`);
+    await writeText(exportPath, [
+      "# Agentify Transcript Export",
+      `Source session: ${item.sessionId}`,
+      `Source transcript: ${item.transcriptRelativePath}`,
+      "",
+      transcript.trim(),
+      "",
+    ].join("\n"));
+  }
+
+  return { synced: false, fingerprint, palacePath, exportDir, syncStatePath, cached: false, transcriptCount: transcripts.length };
+}
+
+async function runMemPalace(root, args, palacePath) {
+  const env = {
+    ...process.env,
+    MEMPALACE_PALACE_PATH: palacePath,
+  };
+  return execFileAsync(process.env.AGENTIFY_MEMPALACE_CMD || "mempalace", args, {
+    cwd: root,
+    env,
+    maxBuffer: 8 * 1024 * 1024,
+  });
+}
+
+async function createMemPalaceBackend(root, query, config) {
+  const transcripts = await listSessionTranscripts(root);
+  const tokens = tokenizeQuery(query);
+
+  return {
+    name: "mempalace",
+    async recall() {
+      if (transcripts.length === 0 || tokens.length === 0) {
+        return null;
+      }
+
+      const wing = getRepoWing(root);
+      const { palacePath, exportDir } = getMemPalacePaths(root);
+      try {
+        const sync = await syncMemPalaceSessionExports(root, transcripts);
+        if (!sync.cached) {
+          await runMemPalace(root, ["mine", exportDir, "--mode", "convos", "--wing", wing, "--agent", "agentify"], palacePath);
+          await writeText(sync.syncStatePath, `${JSON.stringify({
+            schema_version: "1.0",
+            fingerprint: sync.fingerprint,
+            transcript_count: sync.transcriptCount,
+            updated_at: new Date().toISOString(),
+          }, null, 2)}\n`);
+        }
+        const resultCount = String(getSessionMemoryLimit(config, "memoryResults", 3));
+        const { stdout } = await runMemPalace(root, ["search", query, "--wing", wing, "--results", resultCount], palacePath);
+        const excerpt = clipToBytes(stdout.trim(), getSessionMemoryLimit(config, "memoryPromptMaxKb", 4) * 1024);
+        if (!excerpt || excerpt.includes("No results found")) {
+          return null;
+        }
+
+        return buildMemoryResult("mempalace", [{
+          sessionId: null,
+          transcriptPath: exportDir,
+          transcriptRelativePath: relative(root, exportDir),
+          score: Number.NaN,
+          excerpt,
+        }], [
+          `- Query: ${query}`,
+          `- Wing: ${wing}`,
+          "- Source: repo-local MemPalace session export index.",
+        ], getSessionMemoryLimit(config, "memoryPromptMaxKb", 4) * 1024);
+      } catch (error) {
+        if (error?.code === "ENOENT") {
+          return null;
+        }
+        return null;
+      }
+    },
+  };
+}
+
+async function createTranscriptSearchBackend(root, query, config) {
+  const transcripts = await listSessionTranscripts(root);
+  const tokens = tokenizeQuery(query);
+  const maxBytes = getSessionMemoryLimit(config, "memoryPromptMaxKb", 4) * 1024;
+  const maxResults = getSessionMemoryLimit(config, "memoryResults", 3);
+
+  return {
+    name: "local-session-search",
+    async recall() {
+      if (transcripts.length === 0 || tokens.length === 0) {
+        return null;
+      }
+
+      const matches = [];
+
+      for (const item of transcripts) {
+        const transcript = await fs.readFile(item.transcriptPath, "utf8");
+        const passages = buildPassages(parseTranscriptTurns(transcript));
+        for (const passage of passages) {
+          const score = scorePassage(query, tokens, passage);
+          if (score < 4) {
+            continue;
+          }
+          matches.push({
+            sessionId: item.sessionId,
+            transcriptPath: item.transcriptPath,
+            transcriptRelativePath: item.transcriptRelativePath,
+            score,
+            excerpt: passage,
+            mtimeMs: item.mtimeMs,
+          });
+        }
+      }
+
+      matches.sort((a, b) => b.score - a.score || b.mtimeMs - a.mtimeMs);
+      const hits = matches.slice(0, maxResults).map((hit) => ({
+        ...hit,
+        excerpt: clipToBytes(hit.excerpt, Math.max(256, Math.floor(maxBytes / Math.max(1, maxResults)))),
+      }));
+      if (hits.length === 0) {
+        return null;
+      }
+
+      return buildMemoryResult("local-session-search", hits, [
+        `- Query: ${query}`,
+        `- Search scope: \`${relative(root, path.join(root, ".agents", "session"))}/\``,
+      ], maxBytes);
+    },
+  };
+}
+
+async function createLineageBackend(root, manifest, config) {
+  const maxBytes = getSessionMemoryLimit(config, "memoryPromptMaxKb", 4) * 1024;
+  const maxTurns = getSessionMemoryLimit(config, "memoryTurns", 6);
+  const candidates = [manifest?.session_id, manifest?.parent_id].filter(Boolean);
+
+  return {
+    name: "lineage-replay",
+    async recall() {
+      for (const sessionId of candidates) {
+        const { transcriptPath } = getSessionArtifactPaths(root, sessionId);
+        if (!(await exists(transcriptPath))) {
+          continue;
+        }
+
+        const transcript = await fs.readFile(transcriptPath, "utf8");
+        const excerpt = selectRecentTurns(parseTranscriptTurns(transcript), maxTurns, maxBytes);
+        if (!excerpt) {
+          continue;
+        }
+
+        return buildMemoryResult("lineage-replay", [{
+          sessionId,
+          transcriptPath,
+          transcriptRelativePath: relative(root, transcriptPath),
+          score: Number.NaN,
+          excerpt,
+        }], [
+          "- Source: direct session lineage replay.",
+        ], maxBytes);
+      }
+
+      return null;
+    },
+  };
+}
+
+async function createMemoryBackends(root, options, config) {
+  return [
+    await createMemPalaceBackend(root, options.query || "", config),
+    await createTranscriptSearchBackend(root, options.query || "", config),
+    await createLineageBackend(root, options.manifest || null, config),
+  ];
 }
 
 export function getSessionArtifactPaths(root, sessionId) {
@@ -117,46 +524,32 @@ export function getSessionArtifactPaths(root, sessionId) {
   };
 }
 
-export async function loadAutomaticSessionMemory(root, manifest, config) {
-  const maxBytes = getSessionMemoryLimit(config, "memoryPromptMaxKb", 4) * 1024;
-  const maxTurns = getSessionMemoryLimit(config, "memoryTurns", 6);
-  const candidates = [manifest?.session_id, manifest?.parent_id].filter(Boolean);
-
-  for (const sessionId of candidates) {
-    const { transcriptPath } = getSessionArtifactPaths(root, sessionId);
-    if (!(await exists(transcriptPath))) {
-      continue;
+export async function loadAutomaticMemory(root, options, config) {
+  const backends = await createMemoryBackends(root, options, config);
+  for (const backend of backends) {
+    const result = await backend.recall();
+    if (result?.excerpt) {
+      return result;
     }
-
-    const transcript = await fs.readFile(transcriptPath, "utf8");
-    const excerpt = selectRecentTurns(parseTranscriptTurns(transcript), maxTurns, maxBytes);
-    if (!excerpt) {
-      continue;
-    }
-
-    return {
-      sourceSessionId: sessionId,
-      transcriptPath,
-      transcriptRelativePath: relative(root, transcriptPath),
-      excerpt,
-      markdown: [
-        "## Automatic Session Memory",
-        `- Source session: ${sessionId}`,
-        `- Source transcript: \`${relative(root, transcriptPath)}\``,
-        "- Loaded automatically from prior Agentify session history. Verify against the current repo state if stale.",
-        "",
-        excerpt,
-      ].join("\n"),
-    };
   }
 
   return {
+    backend: "none",
     sourceSessionId: null,
     transcriptPath: null,
     transcriptRelativePath: null,
     excerpt: "",
+    hits: [],
     markdown: buildNoMemoryMarkdown(),
   };
+}
+
+export async function loadAutomaticRunMemory(root, query, config) {
+  return loadAutomaticMemory(root, { query }, config);
+}
+
+export async function loadAutomaticSessionMemory(root, manifest, config, query = "") {
+  return loadAutomaticMemory(root, { manifest, query }, config);
 }
 
 export async function prepareSessionMemoryRun(root, sessionRecord) {
@@ -236,6 +629,7 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
     prompt: sessionRecord.prompt,
     transcript_path: relative(root, prepared.paths.transcriptPath),
     memory_context_path: relative(root, prepared.paths.memoryContextPath),
+    memory_backend: sessionRecord.memoryContext?.backend || "none",
     memory_source_session_id: sessionRecord.memoryContext?.sourceSessionId || null,
     memory_source_transcript: sessionRecord.memoryContext?.transcriptRelativePath || null,
     phase,

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import { installHooks, removeHooks, statusHooks } from "./core/hooks.js";
 import { queryOwner, queryDeps, queryChanged, querySearch } from "./core/query.js";
 import { buildExecutionPlan } from "./core/planner.js";
 import { forkSession, listSessions, resolveSessionProvider, resumeSession } from "./core/session.js";
-import { loadAutomaticSessionMemory } from "./core/session-memory.js";
+import { loadAutomaticRunMemory, loadAutomaticSessionMemory } from "./core/session-memory.js";
 import { runDoctor } from "./core/toolchain.js";
 import { garbageCollect, cacheStatus } from "./core/cache.js";
 import { runClean } from "./core/cleanup.js";
@@ -107,6 +107,14 @@ function buildRunPrompt(userPrompt) {
     return userPrompt;
   }
   return "Continue implementation in this repository using small, validated changes.";
+}
+
+export function buildExecutionPrompt(basePrompt, memoryMarkdown = "") {
+  const prompt = String(basePrompt || "").trim();
+  if (!memoryMarkdown.trim()) {
+    return prompt;
+  }
+  return [memoryMarkdown.trim(), prompt].filter(Boolean).join("\n\n");
 }
 
 export function buildSessionPrompt(bootstrap, userPrompt, memoryMarkdown = "") {
@@ -339,27 +347,29 @@ export async function runCli(argv) {
       return;
 
     case "plan": {
-      const prompt = buildRunPrompt(getPromptFromArgs(args, 1));
-      const plan = await buildExecutionPlan(root, config, prompt);
+      const task = buildRunPrompt(getPromptFromArgs(args, 1));
+      const plan = await buildExecutionPlan(root, config, task);
       console.log(JSON.stringify(plan, null, 2));
       return;
     }
 
     case "run": {
-      const prompt = buildRunPrompt(getPromptFromArgs(args, 1));
+      const task = buildRunPrompt(getPromptFromArgs(args, 1));
+      const memoryContext = await loadAutomaticRunMemory(root, task, config);
       const usingTemplateCommand = !args._exec?.length;
       const providerOptions = getProviderTemplateOptions(args, root, config.provider, usingTemplateCommand);
       const plan = !args._exec?.length
-        ? await buildExecutionPlan(root, config, prompt)
+        ? await buildExecutionPlan(root, config, task)
         : null;
       if (args.explainPlan && plan) {
         console.log(JSON.stringify(plan, null, 2));
       }
+      const prompt = buildExecutionPrompt(plan?.prompt || task, memoryContext.markdown);
       const agentCommand = args._exec?.length
         ? args._exec
         : buildProviderTemplateCommand(
           config.provider,
-          plan.prompt,
+          prompt,
           providerOptions,
         );
 
@@ -491,13 +501,13 @@ export async function runCli(argv) {
           provider: args.provider || null,
           name: args.name || null,
         });
-        const memoryContext = await loadAutomaticSessionMemory(root, result.manifest, config);
+        const task = getPromptFromArgs(args, 2);
+        const memoryContext = await loadAutomaticSessionMemory(root, result.manifest, config, task || result.manifest.name || "");
         const provider = hasOwn(args, "provider")
           ? normalizeProvider(args.provider)
           : normalizeProvider(resolveSessionProvider(result.manifest, config.provider));
         const usingTemplateCommand = !args._exec?.length;
         const providerOptions = getProviderTemplateOptions(args, root, provider, usingTemplateCommand);
-        const task = getPromptFromArgs(args, 2);
         const prompt = buildSessionPrompt(result.bootstrap, task, memoryContext.markdown);
         const agentCommand = args._exec?.length
           ? args._exec
@@ -530,13 +540,13 @@ export async function runCli(argv) {
       if (subcommand === "resume") {
         const { sessionId, promptStartIndex } = resolveSessionIdForResume(args);
         const result = await resumeSession(root, sessionId);
-        const memoryContext = await loadAutomaticSessionMemory(root, result.manifest, config);
+        const task = getPromptFromArgs(args, promptStartIndex);
+        const memoryContext = await loadAutomaticSessionMemory(root, result.manifest, config, task || result.manifest.name || "");
         const provider = hasOwn(args, "provider")
           ? normalizeProvider(args.provider)
           : normalizeProvider(resolveSessionProvider(result.manifest, config.provider));
         const usingTemplateCommand = !args._exec?.length;
         const providerOptions = getProviderTemplateOptions(args, root, provider, usingTemplateCommand);
-        const task = getPromptFromArgs(args, promptStartIndex);
         const prompt = buildSessionPrompt(result.bootstrap, task, memoryContext.markdown);
         const agentCommand = args._exec?.length
           ? args._exec
@@ -590,8 +600,8 @@ export async function runCli(argv) {
           : normalizeProvider(resolveSessionProvider(sessionResult.manifest, config.provider));
         const usingTemplateCommand = !args._exec?.length;
         const providerOptions = getProviderTemplateOptions(args, root, provider, usingTemplateCommand);
-        const memoryContext = await loadAutomaticSessionMemory(root, sessionResult.manifest, config);
         const task = getPromptFromArgs(args, 2);
+        const memoryContext = await loadAutomaticSessionMemory(root, sessionResult.manifest, config, task || sessionResult.manifest.name || "");
         const prompt = buildSessionPrompt(sessionResult.bootstrap, task, memoryContext.markdown);
         const agentCommand = args._exec?.length
           ? args._exec

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { buildSessionPrompt, getProviderTemplateOptions, parseArgs, runCli } from "../src/main.js";
+import { buildExecutionPrompt, buildSessionPrompt, getProviderTemplateOptions, parseArgs, runCli } from "../src/main.js";
 import { setSilent } from "../src/core/ui.js";
 
 test("parseArgs normalizes dashed flags to camelCase", () => {
@@ -70,6 +70,16 @@ test("buildSessionPrompt injects automatic memory excerpts before the current ta
   assert.match(prompt, /Automatic Session Memory/);
   assert.match(prompt, /Source session: sess_parent/);
   assert.match(prompt, /Current task: Fix the failing refresh path\./);
+});
+
+test("buildExecutionPrompt prepends automatic memory before a normal run prompt", () => {
+  const prompt = buildExecutionPrompt(
+    "Implement retry handling for checkout refresh.",
+    "## Automatic Session Memory\n- Backend: local-session-search\n- Source session: sess_parent"
+  );
+
+  assert.match(prompt, /Automatic Session Memory/);
+  assert.ok(prompt.indexOf("Automatic Session Memory") < prompt.indexOf("Implement retry handling"));
 });
 
 test("runCli supports skill install with provider all", async () => {

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -9,7 +9,7 @@ import { promisify } from "node:util";
 import { loadConfig } from "../src/core/config.js";
 import { closeIndexDatabase, inTransaction, openIndexDatabase, writeRepositoryIndex } from "../src/core/db.js";
 import { forkSession, resolveSessionProvider, resumeSession } from "../src/core/session.js";
-import { getSessionArtifactPaths, loadAutomaticSessionMemory } from "../src/core/session-memory.js";
+import { getSessionArtifactPaths, loadAutomaticRunMemory, loadAutomaticSessionMemory } from "../src/core/session-memory.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -19,6 +19,39 @@ async function initGitRepo(root) {
   await execFileAsync("git", ["config", "user.email", "agentify-tests@example.com"], { cwd: root });
   await execFileAsync("git", ["add", "."], { cwd: root });
   await execFileAsync("git", ["commit", "-m", "initial"], { cwd: root });
+}
+
+async function installFakeMemPalace(binDir, logPath) {
+  const scriptPath = path.join(binDir, "mempalace");
+  await fs.writeFile(scriptPath, `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${logPath}"
+if [ "$1" = "mine" ]; then
+  mkdir -p "\${MEMPALACE_PALACE_PATH}"
+  echo "mined"
+  exit 0
+fi
+if [ "$1" = "search" ]; then
+  cat <<'EOF'
+============================================================
+  Results for: "jsonl transcript decision"
+============================================================
+
+  [1] agentify / decisions
+      Source: sess_memory.md
+      Match:  0.98
+
+      Source transcript: .agents/session/sess_memory/transcript.md
+      We chose JSONL transcripts because they are append-friendly for durable memory capture.
+
+  ────────────────────────────────────────────────────────
+EOF
+  exit 0
+fi
+exit 1
+`, "utf8");
+  await fs.chmod(scriptPath, 0o755);
+  return scriptPath;
 }
 
 test("forkSession writes provider in manifest and bootstrap", async () => {
@@ -146,4 +179,86 @@ test("loadAutomaticSessionMemory reuses the parent transcript automatically", as
   assert.match(memory.markdown, /Automatic Session Memory/);
   assert.match(memory.markdown, /Refresh after the wrapped command commit lands/);
   assert.match(memory.markdown, new RegExp(parent.sessionId));
+});
+
+test("loadAutomaticSessionMemory searches older sessions when the direct parent is not relevant", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-search-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex" });
+  const earlier = await forkSession(root, config, { name: "jsonl-decision" });
+  const earlierPaths = getSessionArtifactPaths(root, earlier.sessionId);
+  await fs.writeFile(earlierPaths.transcriptPath, [
+    "# Agentify Session Run",
+    "",
+    "> Current task",
+    "Choose a durable transcript format for session memory.",
+    "",
+    "> Provider response",
+    "Use JSONL transcripts because they append cleanly and are easier for memory miners to ingest later.",
+    "",
+  ].join("\n"), "utf8");
+
+  const parent = await forkSession(root, config, { name: "refresh-fix" });
+  const parentPaths = getSessionArtifactPaths(root, parent.sessionId);
+  await fs.writeFile(parentPaths.transcriptPath, [
+    "# Agentify Session Run",
+    "",
+    "> Current task",
+    "Fix refresh after commits.",
+    "",
+    "> Provider response",
+    "Refresh after the wrapped command exits.",
+    "",
+  ].join("\n"), "utf8");
+
+  const child = await forkSession(root, config, { from: parent.sessionId, name: "new-task" });
+  const memory = await loadAutomaticSessionMemory(root, child.manifest, config, "why did we choose JSONL transcripts");
+
+  assert.equal(memory.backend, "local-session-search");
+  assert.equal(memory.sourceSessionId, earlier.sessionId);
+  assert.match(memory.markdown, /Source transcript:/);
+  assert.match(memory.markdown, /JSONL transcripts because they append cleanly/);
+});
+
+test("loadAutomaticRunMemory uses MemPalace automatically when the CLI is available", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-run-memory-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex" });
+  const session = await forkSession(root, config, { name: "memory" });
+  const paths = getSessionArtifactPaths(root, session.sessionId);
+  await fs.writeFile(paths.transcriptPath, [
+    "# Agentify Session Run",
+    "",
+    "> Current task",
+    "Pick a durable transcript format.",
+    "",
+    "> Provider response",
+    "Use JSONL transcripts because they are append-friendly for durable memory capture.",
+    "",
+  ].join("\n"), "utf8");
+
+  const binDir = path.join(root, "bin");
+  const logPath = path.join(root, "mempalace-calls.log");
+  await fs.mkdir(binDir, { recursive: true });
+  await installFakeMemPalace(binDir, logPath);
+
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${binDir}:${originalPath}`;
+  try {
+    const memory = await loadAutomaticRunMemory(root, "jsonl transcript decision", config);
+    const calls = await fs.readFile(logPath, "utf8");
+
+    assert.equal(memory.backend, "mempalace");
+    assert.match(memory.markdown, /Backend: mempalace/);
+    assert.match(memory.markdown, /repo-local MemPalace session export index/);
+    assert.match(memory.markdown, /append-friendly for durable memory capture/);
+    assert.match(calls, /^mine /m);
+    assert.match(calls, /^search /m);
+  } finally {
+    process.env.PATH = originalPath;
+  }
 });


### PR DESCRIPTION
## Summary
- replace lineage-only transcript replay with a pluggable automatic memory backend stack
- search prior Agentify sessions automatically for both run and sess prompts, with direct-lineage replay kept as the last fallback
- use a repo-local MemPalace index automatically when the mempalace CLI is available, without making it a hard dependency

## Testing
- npm test

Closes #39