### PR TITLE
Fix runExec refresh detection for dirty tracked files

### DIFF
--- a/src/core/exec.js
+++ b/src/core/exec.js
@@ -1,5 +1,7 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
+import path from "node:path";
 import { getChangedFiles, getHeadCommit } from "./git.js";
 import { runScan, runDoc } from "./commands.js";
 import { validateRepo } from "./validate.js";
@@ -10,9 +12,73 @@ const AGENTIFY_EXIT_VALIDATE_FAILED = 80;
 const AGENTIFY_EXIT_REFRESH_ERROR = 81;
 const DEFAULT_CAPTURE_MAX_KB = 48;
 
-function diffSnapshots(preFiles, postFiles) {
-  const preSet = new Set(preFiles.map((f) => `${f.status}:${f.path}`));
-  return postFiles.filter((f) => !preSet.has(`${f.status}:${f.path}`));
+function getSnapshotKey(file) {
+  return `${file.status}:${file.path}`;
+}
+
+function getTrackedDirtyPaths(files) {
+  return [...new Set(
+    files
+      .filter((file) => file?.path && file.status !== "??")
+      .map((file) => file.path)
+  )];
+}
+
+async function hashFile(root, filePath) {
+  try {
+    const content = await fs.readFile(path.join(root, filePath));
+    return createHash("sha1").update(content).digest("hex");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function captureDirtyFileDigests(root, files) {
+  const filePaths = getTrackedDirtyPaths(files);
+  if (filePaths.length === 0) {
+    return new Map();
+  }
+
+  const digestEntries = await Promise.all(
+    filePaths.map(async (filePath) => [filePath, await hashFile(root, filePath)])
+  );
+  return new Map(digestEntries);
+}
+
+function diffSnapshots(preFiles, postFiles, preDigests = new Map(), postDigests = new Map()) {
+  const preSet = new Set(preFiles.map(getSnapshotKey));
+  const changes = [];
+  const seen = new Set();
+
+  function recordChange(file) {
+    const key = getSnapshotKey(file);
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    changes.push(file);
+  }
+
+  for (const file of postFiles) {
+    const key = getSnapshotKey(file);
+    if (!preSet.has(key)) {
+      recordChange(file);
+      continue;
+    }
+
+    if (file.status === "??") {
+      continue;
+    }
+
+    if (preDigests.get(file.path) !== postDigests.get(file.path)) {
+      recordChange(file);
+    }
+  }
+
+  return changes;
 }
 
 function posixShellQuote(value) {
@@ -127,6 +193,7 @@ function runWrappedCommand(argv, options) {
 export async function runExec(root, config, agentCommand, flags) {
   const preHeadCommit = await getHeadCommit(root);
   const preFiles = await getChangedFiles(root);
+  const preFileDigests = await captureDirtyFileDigests(root, preFiles);
   const preparedSessionMemory = flags.sessionRecord
     ? await prepareSessionMemoryRun(root, flags.sessionRecord)
     : null;
@@ -198,7 +265,8 @@ export async function runExec(root, config, agentCommand, flags) {
 
   const postHeadCommit = await getHeadCommit(root);
   const postFiles = await getChangedFiles(root);
-  const agentChanges = diffSnapshots(preFiles, postFiles);
+  const postFileDigests = await captureDirtyFileDigests(root, postFiles);
+  const agentChanges = diffSnapshots(preFiles, postFiles, preFileDigests, postFileDigests);
   const headChanged = postHeadCommit !== preHeadCommit;
   if (agentChanges.length === 0 && !headChanged) {
     const validation = await validateRepo(root, config);

--- a/src/core/exec.js
+++ b/src/core/exec.js
@@ -25,9 +25,18 @@ function getTrackedDirtyPaths(files) {
 }
 
 async function hashFile(root, filePath) {
+  const fullPath = path.join(root, filePath);
   try {
-    const content = await fs.readFile(path.join(root, filePath));
-    return createHash("sha1").update(content).digest("hex");
+    const stats = await fs.lstat(fullPath);
+    if (stats.isSymbolicLink()) {
+      return `symlink:${await fs.readlink(fullPath)}`;
+    }
+    if (!stats.isFile()) {
+      return `kind:${stats.mode}`;
+    }
+
+    const content = await fs.readFile(fullPath);
+    return `file:${createHash("sha1").update(content).digest("hex")}`;
   } catch (error) {
     if (error?.code === "ENOENT") {
       return null;

--- a/test/exec.test.js
+++ b/test/exec.test.js
@@ -6,7 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
-import { runScan } from "../src/core/commands.js";
+import { runDoc, runScan } from "../src/core/commands.js";
 import { loadConfig } from "../src/core/config.js";
 import { getRepoMeta, openIndexDatabase, closeIndexDatabase } from "../src/core/db.js";
 import { runExec } from "../src/core/exec.js";
@@ -62,6 +62,37 @@ test("runExec refreshes when the wrapped command commits and exits clean", async
   } finally {
     closeIndexDatabase(db);
   }
+});
+
+test("runExec refreshes when the wrapped command edits an already-dirty tracked file", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-exec-dirty-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, "src", "index.js"), "export const version = 1;\n", "utf8");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "local", dryRun: false, tokenReport: false });
+  await runScan(root, config);
+  await runDoc(root, config);
+
+  const docPath = path.join(root, "AGENTIFY.md");
+  const beforeDocMtime = (await fs.stat(docPath)).mtimeMs;
+  await fs.appendFile(path.join(root, "src", "index.js"), "export const preexisting = true;\n", "utf8");
+  await new Promise((resolve) => setTimeout(resolve, 25));
+
+  const script = [
+    "import fs from 'node:fs/promises';",
+    "await fs.appendFile('src/index.js', 'export const fromRunExec = true;\\n', 'utf8');",
+  ].join("");
+
+  const result = await runExec(root, config, ["node", "--input-type=module", "-e", script], {});
+  const afterDocMtime = (await fs.stat(docPath)).mtimeMs;
+
+  assert.equal(result.phase, "complete");
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.skippedRefresh, undefined);
+  assert.equal(afterDocMtime > beforeDocMtime, true);
+  assert.equal(result.validation?.failures.some((failure) => failure.category === "code-body-changed"), true);
 });
 
 test("runExec writes MemPalace-compatible session memory artifacts when recording is enabled", async () => {

--- a/test/exec.test.js
+++ b/test/exec.test.js
@@ -23,6 +23,18 @@ async function initGitRepo(root) {
   await execFileAsync("git", ["commit", "-m", "initial"], { cwd: root });
 }
 
+async function addLocalSubmodule(root, submodulePath) {
+  const source = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-submodule-source-"));
+  await fs.writeFile(path.join(source, "readme.md"), "v1\n", "utf8");
+  await initGitRepo(source);
+  await execFileAsync(
+    "git",
+    ["-c", "protocol.file.allow=always", "submodule", "add", source, submodulePath],
+    { cwd: root }
+  );
+  await execFileAsync("git", ["commit", "-am", `add ${submodulePath}`], { cwd: root });
+}
+
 test("runExec refreshes when the wrapped command commits and exits clean", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-exec-commit-"));
   await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
@@ -93,6 +105,24 @@ test("runExec refreshes when the wrapped command edits an already-dirty tracked 
   assert.equal(result.skippedRefresh, undefined);
   assert.equal(afterDocMtime > beforeDocMtime, true);
   assert.equal(result.validation?.failures.some((failure) => failure.category === "code-body-changed"), true);
+});
+
+test("runExec tolerates dirty submodules when capturing dirty-path digests", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-exec-submodule-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await initGitRepo(root);
+  await addLocalSubmodule(root, ".codex/submod");
+
+  const config = await loadConfig(root, { provider: "local", dryRun: false, tokenReport: false });
+  await runScan(root, config);
+  await fs.appendFile(path.join(root, ".codex", "submod", "readme.md"), "dirty\n", "utf8");
+
+  const result = await runExec(root, config, ["node", "--input-type=module", "-e", ""], {});
+
+  assert.equal(result.phase, "complete");
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.skippedRefresh, true);
+  assert.equal(result.validation?.passed, true);
 });
 
 test("runExec writes MemPalace-compatible session memory artifacts when recording is enabled", async () => {


### PR DESCRIPTION
## Summary
- hash dirty tracked files before and after `runExec` so same-status edits still count as agent changes
- keep the normal scan/doc refresh path active when the wrapped command mutates an already-dirty tracked file
- add a regression test that proves `AGENTIFY.md` is regenerated for this dirty-worktree case

## Testing
- npm test

Closes #47