### PR TITLE
fix: align Gemini exec auth home with bootstrap

### DIFF
--- a/src/core/provider.js
+++ b/src/core/provider.js
@@ -432,7 +432,18 @@ async function runClaudeExec({ root, prompt, schema, model }) {
   return parseClaudeJson(stdout);
 }
 
-async function runGeminiExec({ root, prompt, model }) {
+function buildGeminiExecEnv(env = process.env, homeDir = os.homedir()) {
+  const credentialHome = env.GEMINI_CLI_HOME || homeDir;
+  if (!credentialHome) {
+    return { ...env };
+  }
+  return {
+    ...env,
+    HOME: credentialHome
+  };
+}
+
+async function runGeminiExec({ root, prompt, model, env = process.env, homeDir = os.homedir() }) {
   const args = [
     "-p",
     prompt,
@@ -444,12 +455,9 @@ async function runGeminiExec({ root, prompt, model }) {
     args.push("--model", model);
   }
 
-  const home = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-gemini-home-"));
   const { stdout } = await runChild("gemini", args, {
     cwd: root,
-    env: {
-      HOME: home
-    }
+    env: buildGeminiExecEnv(env, homeDir)
   });
   return parseGeminiJson(stdout);
 }

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { loadConfig } from "../src/core/config.js";
-import { resolveBootstrapInputs, runBootstrapCommand } from "../src/core/bootstrap.js";
+import { probeProviderReadiness, resolveBootstrapInputs, runBootstrapCommand } from "../src/core/bootstrap.js";
 import { setSilent } from "../src/core/ui.js";
 
 function ok(stdout = "", stderr = "") {
@@ -297,4 +297,21 @@ test("runBootstrapCommand reports login required when auth cannot be verified", 
 
   assert.equal(result.status, "login_required");
   assert.equal(result.auth.nextStep, "gemini");
+});
+
+test("probeProviderReadiness accepts cached Gemini OAuth under GEMINI_CLI_HOME", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-bootstrap-gemini-home-"));
+  const geminiHome = path.join(root, "gemini-home");
+  await fs.mkdir(path.join(geminiHome, ".gemini"), { recursive: true });
+  await fs.writeFile(path.join(geminiHome, ".gemini", "oauth_creds.json"), "{}\n", "utf8");
+
+  const auth = await probeProviderReadiness("gemini", {
+    cwd: root,
+    env: { GEMINI_CLI_HOME: geminiHome },
+    homeDir: path.join(root, "unused-home"),
+  });
+
+  assert.equal(auth.state, "ready");
+  assert.equal(auth.detail, "oauth credentials cached");
+  assert.equal(auth.nextStep, null);
 });

--- a/test/provider.test.js
+++ b/test/provider.test.js
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
-import { parseCodexJsonl, runChild } from "../src/core/provider.js";
+import { createProvider, parseCodexJsonl, runChild } from "../src/core/provider.js";
 
 test("parseCodexJsonl extracts token usage from turn.completed", () => {
   const usage = parseCodexJsonl([
@@ -25,4 +28,77 @@ test("runChild times out stalled provider subprocesses", async () => {
     }),
     /timed out after 50ms/,
   );
+});
+
+test("gemini provider execution preserves the readiness credential home", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-provider-gemini-root-"));
+  const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-provider-gemini-bin-"));
+  const geminiPath = path.join(binDir, "gemini");
+  const loginHome = path.join(root, "gemini-login-home");
+  const shellHome = path.join(root, "shell-home");
+
+  await fs.mkdir(loginHome, { recursive: true });
+  await fs.mkdir(shellHome, { recursive: true });
+  await fs.writeFile(geminiPath, `#!/usr/bin/env node
+const payload = {
+  response: JSON.stringify({
+    repo_summary: \`HOME=\${process.env.HOME};GEMINI_CLI_HOME=\${process.env.GEMINI_CLI_HOME || ""}\`,
+    shared_conventions: [],
+    module_focus: [{ module_id: "auth", focus: "Keep Gemini auth state visible." }]
+  }),
+  stats: {
+    models: {
+      gemini: {
+        tokens: { input: 4, candidates: 2, total: 6 }
+      }
+    }
+  }
+};
+process.stdout.write(JSON.stringify(payload));
+`, "utf8");
+  await fs.chmod(geminiPath, 0o755);
+
+  const previousPath = process.env.PATH;
+  const previousHome = process.env.HOME;
+  const previousGeminiCliHome = process.env.GEMINI_CLI_HOME;
+
+  process.env.PATH = `${binDir}${path.delimiter}${previousPath || ""}`;
+  process.env.HOME = shellHome;
+  process.env.GEMINI_CLI_HOME = loginHome;
+
+  try {
+    const provider = createProvider("gemini");
+    const result = await provider.buildManagerPlan({
+      repoName: "agentify-fixture",
+      root,
+      defaultStack: "ts",
+      stacks: [{ name: "ts", confidence: 1 }],
+      entrypoints: [],
+      modules: [{ id: "auth", rootPath: "src/auth" }],
+      sampleFiles: [],
+    });
+
+    assert.equal(result.plan.repo_summary, `HOME=${loginHome};GEMINI_CLI_HOME=${loginHome}`);
+    assert.deepEqual(result.tokenUsage, {
+      input_tokens: 4,
+      output_tokens: 2,
+      total_tokens: 6
+    });
+  } finally {
+    if (previousPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = previousPath;
+    }
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    if (previousGeminiCliHome === undefined) {
+      delete process.env.GEMINI_CLI_HOME;
+    } else {
+      process.env.GEMINI_CLI_HOME = previousGeminiCliHome;
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- align Gemini execution with the same credential home that bootstrap readiness accepts
- stop replacing `HOME` with a throwaway temp directory during Gemini runs
- add regression tests for cached OAuth readiness and provider env propagation

## Testing
- `node --test test/bootstrap.test.js`
- `node --test test/provider.test.js test/provider-adapters.test.js`
- `npm test`

Fixes #49