### PR TITLE
fix: refresh after failed mutating exec runs

### DIFF
--- a/src/core/exec.js
+++ b/src/core/exec.js
@@ -238,28 +238,14 @@ export async function runExec(root, config, agentCommand, flags) {
       throw error;
     }
   }
-  const exitCode = commandResult.exitCode;
-
-  if (exitCode !== 0) {
-    process.exitCode = exitCode;
-    const result = {
-      phase: "command",
-      exitCode,
-      stdout: commandResult.stdout,
-      stderr: commandResult.stderr,
-      interactiveTranscript: commandResult.interactiveTranscript,
-      rawInteractiveLogPath: commandResult.rawInteractiveLogPath,
-    };
-    if (preparedSessionMemory) {
-      await finalizeSessionMemoryRun(root, flags.sessionRecord, preparedSessionMemory, result, config);
-    }
-    return result;
-  }
+  let exitCode = commandResult.exitCode || 0;
+  const commandFailed = exitCode !== 0;
 
   if (flags.skipRefresh) {
+    process.exitCode = exitCode;
     const result = {
-      phase: "complete",
-      exitCode: 0,
+      phase: commandFailed ? "command" : "complete",
+      exitCode,
       skippedRefresh: true,
       stdout: commandResult.stdout,
       stderr: commandResult.stderr,
@@ -279,16 +265,17 @@ export async function runExec(root, config, agentCommand, flags) {
   const headChanged = postHeadCommit !== preHeadCommit;
   if (agentChanges.length === 0 && !headChanged) {
     const validation = await validateRepo(root, config);
-    if (!validation.passed && flags.failOnStale) {
-      process.exitCode = AGENTIFY_EXIT_VALIDATE_FAILED;
+    if (!validation.passed && flags.failOnStale && !commandFailed) {
+      exitCode = AGENTIFY_EXIT_VALIDATE_FAILED;
     } else if (!validation.passed) {
       for (const f of validation.failures) {
         process.stderr.write(ui.formatFailure(f) + "\n");
       }
     }
+    process.exitCode = exitCode;
     const result = {
       phase: "complete",
-      exitCode: process.exitCode || 0,
+      exitCode,
       validation,
       skippedRefresh: true,
       stdout: commandResult.stdout,
@@ -307,28 +294,29 @@ export async function runExec(root, config, agentCommand, flags) {
     await runDoc(root, config, { skipFinalize: true });
   } catch (error) {
     ui.error(`refresh error: ${error.message}`);
-    if (flags.failOnStale) {
-      process.exitCode = AGENTIFY_EXIT_REFRESH_ERROR;
-      const result = {
-        phase: "refresh-error",
-        exitCode: AGENTIFY_EXIT_REFRESH_ERROR,
-        stdout: commandResult.stdout,
-        stderr: `${commandResult.stderr}${commandResult.stderr ? "\n" : ""}${error.message}`,
-        interactiveTranscript: commandResult.interactiveTranscript,
-        rawInteractiveLogPath: commandResult.rawInteractiveLogPath,
-      };
-      if (preparedSessionMemory) {
-        await finalizeSessionMemoryRun(root, flags.sessionRecord, preparedSessionMemory, result, config);
-      }
-      return result;
+    if (flags.failOnStale && !commandFailed) {
+      exitCode = AGENTIFY_EXIT_REFRESH_ERROR;
     }
+    process.exitCode = exitCode;
+    const result = {
+      phase: "refresh-error",
+      exitCode,
+      stdout: commandResult.stdout,
+      stderr: `${commandResult.stderr}${commandResult.stderr ? "\n" : ""}${error.message}`,
+      interactiveTranscript: commandResult.interactiveTranscript,
+      rawInteractiveLogPath: commandResult.rawInteractiveLogPath,
+    };
+    if (preparedSessionMemory) {
+      await finalizeSessionMemoryRun(root, flags.sessionRecord, preparedSessionMemory, result, config);
+    }
+    return result;
   }
 
   const validation = await validateRepo(root, config);
 
   if (!validation.passed) {
-    if (flags.failOnStale) {
-      process.exitCode = AGENTIFY_EXIT_VALIDATE_FAILED;
+    if (flags.failOnStale && !commandFailed) {
+      exitCode = AGENTIFY_EXIT_VALIDATE_FAILED;
     } else {
       for (const f of validation.failures) {
         process.stderr.write(ui.formatFailure(f) + "\n");
@@ -336,9 +324,10 @@ export async function runExec(root, config, agentCommand, flags) {
     }
   }
 
+  process.exitCode = exitCode;
   const result = {
     phase: "complete",
-    exitCode: process.exitCode || 0,
+    exitCode,
     validation,
     stdout: commandResult.stdout,
     stderr: commandResult.stderr,

--- a/test/exec.test.js
+++ b/test/exec.test.js
@@ -107,6 +107,50 @@ test("runExec refreshes when the wrapped command edits an already-dirty tracked 
   assert.equal(result.validation?.failures.some((failure) => failure.category === "code-body-changed"), true);
 });
 
+test("runExec refreshes and validates after a failing command mutates tracked files", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-exec-failed-refresh-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, "src", "index.js"), "export const version = 1;\n", "utf8");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "local", dryRun: false, tokenReport: false });
+  await runScan(root, config);
+  await runDoc(root, config);
+
+  const docPath = path.join(root, "AGENTIFY.md");
+  const beforeDocMtime = (await fs.stat(docPath)).mtimeMs;
+  await new Promise((resolve) => setTimeout(resolve, 25));
+
+  const script = [
+    "import fs from 'node:fs/promises';",
+    "await fs.appendFile('src/index.js', 'export const failedRunExec = true;\\n', 'utf8');",
+    "process.exit(1);",
+  ].join("");
+
+  const originalExitCode = process.exitCode;
+  process.exitCode = undefined;
+
+  try {
+    const result = await runExec(
+      root,
+      config,
+      ["node", "--input-type=module", "-e", script],
+      { failOnStale: true }
+    );
+    const afterDocMtime = (await fs.stat(docPath)).mtimeMs;
+
+    assert.equal(result.phase, "complete");
+    assert.equal(result.exitCode, 1);
+    assert.equal(result.skippedRefresh, undefined);
+    assert.equal(afterDocMtime > beforeDocMtime, true);
+    assert.equal(result.validation?.passed, false);
+    assert.equal(result.validation?.failures.some((failure) => failure.category === "code-body-changed"), true);
+  } finally {
+    process.exitCode = originalExitCode;
+  }
+});
+
 test("runExec tolerates dirty submodules when capturing dirty-path digests", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-exec-submodule-"));
   await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -328,3 +328,37 @@ test("runCli restores stderr output after a failing json invocation", async () =
 
   assert.match(stderrChunks.join(""), /Initialized agentify artifacts/);
 });
+
+test("runCli exec refreshes stale artifacts after a failing command mutates tracked files", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-exec-failed-refresh-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, "src", "index.js"), "export const version = 1;\n", "utf8");
+  await initGitRepo(root);
+
+  await runCli(["scan", "--root", root]);
+  await runCli(["doc", "--root", root]);
+
+  const docPath = path.join(root, "AGENTIFY.md");
+  const beforeDocMtime = (await fs.stat(docPath)).mtimeMs;
+  await new Promise((resolve) => setTimeout(resolve, 25));
+
+  const script = [
+    "import fs from 'node:fs/promises';",
+    "await fs.appendFile('src/index.js', 'export const failedViaCli = true;\\n', 'utf8');",
+    "process.exit(1);",
+  ].join("");
+
+  const originalExitCode = process.exitCode;
+  process.exitCode = undefined;
+
+  try {
+    await runCli(["exec", "--root", root, "--fail-on-stale", "--", "node", "--input-type=module", "-e", script]);
+    const afterDocMtime = (await fs.stat(docPath)).mtimeMs;
+
+    assert.equal(process.exitCode, 1);
+    assert.equal(afterDocMtime > beforeDocMtime, true);
+  } finally {
+    process.exitCode = originalExitCode;
+  }
+});


### PR DESCRIPTION
## Summary
- continue through refresh and validation after a non-zero wrapped command when `runExec` detects repository mutations
- preserve the wrapped command exit code instead of masking it with stale-validation exit codes
- add regressions for both `runExec` and `agentify exec --fail-on-stale` when a failing command edits tracked files

## Testing
- `node --test test/exec.test.js`
- `node --test test/main.test.js`
- `npm test`

Fixes #48