### PR TITLE
feat(skills): add copy-pr built-in skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Published built-in skill bundles also live under the repository-level [`skills/`
 Built-in skills:
 
 - `copy-mode`
+- `copy-pr`
 - `grill-me`
 - `improve-codebase-architecture`
 - `gh-autopilot` (alias: `gh-issue-autopilot`)

--- a/skills/copy-pr/SKILL.md
+++ b/skills/copy-pr/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: copy-pr
+description: Clone the code changes from a GitHub or Azure DevOps pull request URL into a fresh local branch, validate the copied diff, commit it, and push it automatically with minimal interaction.
+---
+
+# Copy PR
+
+Use this skill when the user provides a PR URL and wants the same code change recreated on a new local branch automatically.
+
+## Workflow
+
+1. Validate inputs and repo context:
+   - require a PR URL
+   - ensure current directory is a git repository
+   - capture current branch and clean/dirty status
+2. Detect provider from the PR URL:
+   - GitHub (`github.com`)
+   - Azure DevOps (`dev.azure.com` or `visualstudio.com`)
+3. Validate CLI auth for the provider:
+   - GitHub: `gh auth status`
+   - Azure DevOps: `az auth status` and `az devops configure --list`
+4. Resolve PR metadata from the URL:
+   - source branch
+   - target branch
+   - title
+   - head commit
+   - patch or file diff
+5. Create a fresh local branch from the PR target branch (never reuse an old task branch):
+   - naming: `copy-pr/<pr-number>-<slug>`
+   - if the branch exists, create a suffixed variant such as `copy-pr/<pr-number>-<slug>-2`
+6. Copy changes autonomously with no extra user interaction:
+   - prefer fetching PR refs then cherry-picking or applying patch in order
+   - if there are multiple commits, preserve commit order when feasible
+   - resolve minor conflicts directly; if blocked, report exact blocker
+7. Verify equivalence against the original PR diff:
+   - compare changed files list
+   - compare aggregated unified diff where practical
+   - report any intentional or unavoidable differences
+8. Run relevant project checks for touched areas (tests/lint/format when available).
+9. Commit changes locally with a clear message summarizing PR parity.
+10. Push branch to origin automatically.
+11. Return:
+    - provider and PR URL
+    - new branch name
+    - commit hash
+    - push result
+    - diff comparison summary and any deviations
+
+## Provider Command Hints
+
+### GitHub
+
+- Parse owner/repo/pr-number from URL.
+- Suggested metadata command:
+
+```bash
+gh pr view <url> --json number,title,baseRefName,headRefName,commits,files,url
+```
+
+- Suggested patch/diff retrieval:
+
+```bash
+gh pr diff <url>
+```
+
+- Suggested ref fetch (fallback):
+
+```bash
+git fetch origin pull/<pr-number>/head:copy-pr/source-<pr-number>
+```
+
+### Azure DevOps
+
+- Parse organization/project/repository/pull request id from URL.
+- Suggested metadata command:
+
+```bash
+az repos pr show --id <pr-id> --repository <repo> --project <project>
+```
+
+- Suggested changes retrieval:
+
+```bash
+az repos pr show --id <pr-id> --repository <repo> --project <project> --query changes
+```
+
+- If CLI output is insufficient, use `git fetch` PR refs from origin and derive diff locally.
+
+## Operating Rules
+
+- Default to autonomous execution once URL is provided.
+- Do not ask follow-up questions unless a required credential or input is missing.
+- Prefer deterministic shell commands over manual editing.
+- Preserve semantic parity with the original PR over textual perfection.
+- Keep scope limited strictly to the referenced PR.
+
+## Guardrails
+
+- Do not force-push.
+- Do not rewrite shared history.
+- Do not merge into protected branches automatically.
+- Do not silently skip failed verification; report failures explicitly.

--- a/skills/copy-pr/agents/openai.yaml
+++ b/skills/copy-pr/agents/openai.yaml
@@ -1,0 +1,2 @@
+prompt:
+  default_prompt: "Use $copy-pr to parse a GitHub or Azure DevOps pull request URL, recreate that PR's code changes on a fresh local branch, verify diff parity, commit, and push automatically."

--- a/src/builtin-skills/copy-pr/SKILL.md
+++ b/src/builtin-skills/copy-pr/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: copy-pr
+description: Clone the code changes from a GitHub or Azure DevOps pull request URL into a fresh local branch, validate the copied diff, commit it, and push it automatically with minimal interaction.
+---
+
+# Copy PR
+
+Use this skill when the user provides a PR URL and wants the same code change recreated on a new local branch automatically.
+
+## Workflow
+
+1. Validate inputs and repo context:
+   - require a PR URL
+   - ensure current directory is a git repository
+   - capture current branch and clean/dirty status
+2. Detect provider from the PR URL:
+   - GitHub (`github.com`)
+   - Azure DevOps (`dev.azure.com` or `visualstudio.com`)
+3. Validate CLI auth for the provider:
+   - GitHub: `gh auth status`
+   - Azure DevOps: `az auth status` and `az devops configure --list`
+4. Resolve PR metadata from the URL:
+   - source branch
+   - target branch
+   - title
+   - head commit
+   - patch or file diff
+5. Create a fresh local branch from the PR target branch (never reuse an old task branch):
+   - naming: `copy-pr/<pr-number>-<slug>`
+   - if the branch exists, create a suffixed variant such as `copy-pr/<pr-number>-<slug>-2`
+6. Copy changes autonomously with no extra user interaction:
+   - prefer fetching PR refs then cherry-picking or applying patch in order
+   - if there are multiple commits, preserve commit order when feasible
+   - resolve minor conflicts directly; if blocked, report exact blocker
+7. Verify equivalence against the original PR diff:
+   - compare changed files list
+   - compare aggregated unified diff where practical
+   - report any intentional or unavoidable differences
+8. Run relevant project checks for touched areas (tests/lint/format when available).
+9. Commit changes locally with a clear message summarizing PR parity.
+10. Push branch to origin automatically.
+11. Return:
+    - provider and PR URL
+    - new branch name
+    - commit hash
+    - push result
+    - diff comparison summary and any deviations
+
+## Provider Command Hints
+
+### GitHub
+
+- Parse owner/repo/pr-number from URL.
+- Suggested metadata command:
+
+```bash
+gh pr view <url> --json number,title,baseRefName,headRefName,commits,files,url
+```
+
+- Suggested patch/diff retrieval:
+
+```bash
+gh pr diff <url>
+```
+
+- Suggested ref fetch (fallback):
+
+```bash
+git fetch origin pull/<pr-number>/head:copy-pr/source-<pr-number>
+```
+
+### Azure DevOps
+
+- Parse organization/project/repository/pull request id from URL.
+- Suggested metadata command:
+
+```bash
+az repos pr show --id <pr-id> --repository <repo> --project <project>
+```
+
+- Suggested changes retrieval:
+
+```bash
+az repos pr show --id <pr-id> --repository <repo> --project <project> --query changes
+```
+
+- If CLI output is insufficient, use `git fetch` PR refs from origin and derive diff locally.
+
+## Operating Rules
+
+- Default to autonomous execution once URL is provided.
+- Do not ask follow-up questions unless a required credential or input is missing.
+- Prefer deterministic shell commands over manual editing.
+- Preserve semantic parity with the original PR over textual perfection.
+- Keep scope limited strictly to the referenced PR.
+
+## Guardrails
+
+- Do not force-push.
+- Do not rewrite shared history.
+- Do not merge into protected branches automatically.
+- Do not silently skip failed verification; report failures explicitly.

--- a/src/builtin-skills/copy-pr/agents/openai.yaml
+++ b/src/builtin-skills/copy-pr/agents/openai.yaml
@@ -1,0 +1,2 @@
+prompt:
+  default_prompt: "Use $copy-pr to parse a GitHub or Azure DevOps pull request URL, recreate that PR's code changes on a fresh local branch, verify diff parity, commit, and push automatically."

--- a/src/core/skills.js
+++ b/src/core/skills.js
@@ -36,6 +36,12 @@ const BUILTIN_SKILLS = [
       "Analyze a repository, extract architecture and conventions, and write agent-ready handoff docs to docs/architecture.md, prd.md, and summary.md.",
   },
   {
+    name: "copy-pr",
+    aliases: [],
+    description:
+      "Copy a GitHub or Azure DevOps PR URL onto a fresh local branch, verify diff parity, commit the recreated changes, and push automatically.",
+  },
+  {
     name: "worktree-autopilot",
     aliases: ["god-mode", "worktree-verifier"],
     description:

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -41,7 +41,7 @@ test("listBuiltinSkills exposes built-in catalog and alias", () => {
   const skills = listBuiltinSkills();
   const names = skills.map((skill) => skill.name);
 
-  assert.deepEqual(names.sort(), ["commit-creator", "copy-mode", "gh-autopilot", "grill-me", "improve-codebase-architecture", "pr-creator", "worktree-autopilot"]);
+  assert.deepEqual(names.sort(), ["commit-creator", "copy-mode", "copy-pr", "gh-autopilot", "grill-me", "improve-codebase-architecture", "pr-creator", "worktree-autopilot"]);
   assert.deepEqual(resolveBuiltinSkill("god-mode").name, "worktree-autopilot");
   assert.deepEqual(resolveBuiltinSkill("worktree-verifier").name, "worktree-autopilot");
   assert.deepEqual(resolveBuiltinSkill("gh-issue-autopilot").name, "gh-autopilot");
@@ -214,7 +214,7 @@ test("installAllBuiltinSkills installs every built-in skill for codex project sc
 
   assert.deepEqual(
     result.installed_skills.sort(),
-    ["commit-creator", "copy-mode", "gh-autopilot", "grill-me", "improve-codebase-architecture", "pr-creator", "worktree-autopilot"]
+    ["commit-creator", "copy-mode", "copy-pr", "gh-autopilot", "grill-me", "improve-codebase-architecture", "pr-creator", "worktree-autopilot"]
   );
 
   for (const skillName of result.installed_skills) {


### PR DESCRIPTION
### Motivation
- Provide an autonomous skill that takes a GitHub or Azure DevOps pull request URL and reproduces that PR's code changes on a fresh local branch so users can inspect, test, and push parity branches without manual patching.
- Make the skill discoverable and installable like existing built-in skills so external installers can copy the bundle from `skills/` or `src/builtin-skills/`.

### Description
- Add a new `copy-pr` skill bundle under `skills/copy-pr/` with a detailed SKILL.md describing an autonomous workflow for parsing a PR URL, fetching/applying changes, verifying diff parity, committing, and pushing. 
- Mirror the same skill bundle into `src/builtin-skills/copy-pr/` so built-in and published copies remain aligned for installers. 
- Add an OpenAI agent prompt file at `skills/copy-pr/agents/openai.yaml` and the mirrored `src/builtin-skills/copy-pr/agents/openai.yaml`. 
- Register `copy-pr` in the built-in catalog by updating `src/core/skills.js`, update `README.md` built-in skills list, and update `test/skills.test.js` expectations so `copy-pr` is included in installer tests. 

### Testing
- Ran `node --test test/skills.test.js`, which executed the skill-installation-focused tests and passed (all assertions succeeded). 
- Ran full `npm test` in this environment where unrelated existing tests fail (e.g., `test/exec.test.js`); those unrelated failures remained and are not caused by this skill addition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e5d50e33ac832ab9fcc70a7acbe8e5)