### PR TITLE
fix: guide plan and query when index is missing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -91,6 +91,16 @@ function getExecFlags(args, extras = {}) {
   };
 }
 
+function isMissingIndexError(error) {
+  return error instanceof Error && /missing index database at /.test(error.message);
+}
+
+function createMissingIndexGuidance(root) {
+  return new Error(
+    `Agentify index missing for ${root}. Run "agentify scan --root ${root}" or "agentify up --root ${root}" before using plan/query commands.`
+  );
+}
+
 export function getProviderTemplateOptions(args, root, provider, usingTemplateCommand) {
   const interactiveByDefault = usingTemplateCommand;
   const interactive = args.interactive === true ? true : interactiveByDefault;
@@ -378,7 +388,15 @@ export async function runCli(argv) {
 
       case "plan": {
         const task = buildRunPrompt(getPromptFromArgs(args, 1));
-        const plan = await buildExecutionPlan(root, config, task);
+        let plan;
+        try {
+          plan = await buildExecutionPlan(root, config, task);
+        } catch (error) {
+          if (isMissingIndexError(error)) {
+            throw createMissingIndexGuidance(root);
+          }
+          throw error;
+        }
         console.log(JSON.stringify(plan, null, 2));
         return;
       }
@@ -418,20 +436,27 @@ export async function runCli(argv) {
 
       case "query": {
         let result;
-        if (subcommand === "owner") {
-          if (!args.file) throw new Error("query owner requires --file <path>");
-          result = await queryOwner(root, args.file);
-        } else if (subcommand === "deps") {
-          if (!args.module) throw new Error("query deps requires --module <id>");
-          result = await queryDeps(root, args.module);
-        } else if (subcommand === "changed") {
-          if (!args.since) throw new Error("query changed requires --since <commit>");
-          result = await queryChanged(root, args.since);
-        } else if (subcommand === "search") {
-          if (!args.term) throw new Error("query search requires --term <value>");
-          result = await querySearch(root, args.term);
-        } else {
-          throw new Error("query requires a subcommand: owner, deps, changed, or search");
+        try {
+          if (subcommand === "owner") {
+            if (!args.file) throw new Error("query owner requires --file <path>");
+            result = await queryOwner(root, args.file);
+          } else if (subcommand === "deps") {
+            if (!args.module) throw new Error("query deps requires --module <id>");
+            result = await queryDeps(root, args.module);
+          } else if (subcommand === "changed") {
+            if (!args.since) throw new Error("query changed requires --since <commit>");
+            result = await queryChanged(root, args.since);
+          } else if (subcommand === "search") {
+            if (!args.term) throw new Error("query search requires --term <value>");
+            result = await querySearch(root, args.term);
+          } else {
+            throw new Error("query requires a subcommand: owner, deps, changed, or search");
+          }
+        } catch (error) {
+          if (isMissingIndexError(error)) {
+            throw createMissingIndexGuidance(root);
+          }
+          throw error;
         }
         console.log(JSON.stringify(result, null, 2));
         return;

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -151,6 +151,30 @@ test("runCli init writes baseline local work and guardrail files", async () => {
   await assert.doesNotReject(() => fs.access(path.join(root, ".agentify", "work")));
 });
 
+test("runCli plan reports actionable guidance when the index is missing", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-plan-missing-index-"));
+  await runCli(["init", "--root", root]);
+
+  await assert.rejects(
+    () => runCli(["plan", "--root", root, "summarize setup"]),
+    new RegExp(`Agentify index missing for ${root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`),
+  );
+  await assert.rejects(
+    () => runCli(["plan", "--root", root, "summarize setup"]),
+    /Run "agentify scan --root .*" or "agentify up --root .*" before using plan\/query commands\./,
+  );
+});
+
+test("runCli query reports actionable guidance when the index is missing", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-query-missing-index-"));
+  await runCli(["init", "--root", root]);
+
+  await assert.rejects(
+    () => runCli(["query", "owner", "--root", root, "--file", "src/app.ts"]),
+    /before using plan\/query commands\./,
+  );
+});
+
 test("runCli init --json emits a single machine-readable payload", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-init-json-"));
   const output = [];


### PR DESCRIPTION
## Summary
- catch missing-index errors in `plan` and `query` at the CLI boundary
- replace the raw SQLite-style exception with actionable guidance to run `agentify scan` or `agentify up`
- add regression tests for `init -> plan` and `init -> query owner` on repos with no `.agents/index.db`

## Testing
- `node --test test/main.test.js`
- `node --test test/exec.test.js --test-name-pattern="runExec refreshes and validates after a failing command mutates tracked files"` on `main` still fails before this change
- `node --test test/main.test.js --test-name-pattern="runCli exec refreshes stale artifacts after a failing command mutates tracked files"` on `main` still fails before this change

## Notes
- Full `node --test` still reports two pre-existing failures unrelated to this patch:
  - `test/exec.test.js`: `runExec refreshes and validates after a failing command mutates tracked files`
  - `test/main.test.js`: `runCli exec refreshes stale artifacts after a failing command mutates tracked files`

Closes #62.
