### PR TITLE
refactor(session): make resume primarily structured, markdown optional

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -52,6 +52,9 @@ const DEFAULT_CONFIG = {
     memoryTurns: 6,
     memoryResults: 3,
     captureMaxKb: 48,
+    runHistoryMax: 10,
+    runSummaryMaxBytes: 256,
+    emitMarkdownArtifacts: true,
   },
   planner: {
     maxModules: 6,

--- a/src/core/exec.js
+++ b/src/core/exec.js
@@ -204,7 +204,7 @@ export async function runExec(root, config, agentCommand, flags) {
   const preFiles = await getChangedFiles(root);
   const preFileDigests = await captureDirtyFileDigests(root, preFiles);
   const preparedSessionMemory = flags.sessionRecord
-    ? await prepareSessionMemoryRun(root, flags.sessionRecord)
+    ? await prepareSessionMemoryRun(root, flags.sessionRecord, config)
     : null;
 
   let commandResult;

--- a/src/core/session-memory.js
+++ b/src/core/session-memory.js
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 
-import { ensureDir, exists, relative, writeText } from "./fs.js";
+import { ensureDir, exists, readJson, relative, writeJson, writeText } from "./fs.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -342,6 +342,36 @@ async function listSessionTranscripts(root) {
   return transcripts.sort((a, b) => b.mtimeMs - a.mtimeMs);
 }
 
+async function listStructuredSessionTurns(root) {
+  const sessionsDir = path.join(root, ".agents", "session");
+  if (!(await exists(sessionsDir))) {
+    return [];
+  }
+
+  const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
+  const results = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const turnsPath = path.join(sessionsDir, entry.name, "turns.jsonl");
+    if (!(await exists(turnsPath))) {
+      continue;
+    }
+    const stat = await fs.stat(turnsPath);
+    results.push({
+      sessionId: entry.name,
+      turnsPath,
+      turnsRelativePath: relative(root, turnsPath),
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+    });
+  }
+
+  return results.sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
+
 function getMemPalacePaths(root) {
   const baseDir = path.join(root, ".agents", "mempalace");
   return {
@@ -462,6 +492,8 @@ async function createMemPalaceBackend(root, query, config) {
 
 async function createTranscriptSearchBackend(root, query, config) {
   const transcripts = await listSessionTranscripts(root);
+  const structuredOnly = (await listStructuredSessionTurns(root))
+    .filter((item) => !transcripts.some((t) => t.sessionId === item.sessionId));
   const tokens = tokenizeQuery(query);
   const maxBytes = getSessionMemoryLimit(config, "memoryPromptMaxKb", 4) * 1024;
   const maxResults = getSessionMemoryLimit(config, "memoryResults", 3);
@@ -469,7 +501,7 @@ async function createTranscriptSearchBackend(root, query, config) {
   return {
     name: "local-session-search",
     async recall() {
-      if (transcripts.length === 0 || tokens.length === 0) {
+      if ((transcripts.length === 0 && structuredOnly.length === 0) || tokens.length === 0) {
         return null;
       }
 
@@ -494,6 +526,25 @@ async function createTranscriptSearchBackend(root, query, config) {
         }
       }
 
+      for (const item of structuredOnly) {
+        const turns = await readStructuredTurnsAsText(item.turnsPath);
+        const passages = buildPassages(turns);
+        for (const passage of passages) {
+          const score = scorePassage(query, tokens, passage);
+          if (score < 4) {
+            continue;
+          }
+          matches.push({
+            sessionId: item.sessionId,
+            transcriptPath: item.turnsPath,
+            transcriptRelativePath: item.turnsRelativePath,
+            score,
+            excerpt: passage,
+            mtimeMs: item.mtimeMs,
+          });
+        }
+      }
+
       matches.sort((a, b) => b.score - a.score || b.mtimeMs - a.mtimeMs);
       const hits = matches.slice(0, maxResults).map((hit) => ({
         ...hit,
@@ -511,6 +562,62 @@ async function createTranscriptSearchBackend(root, query, config) {
   };
 }
 
+async function createStructuredLineageBackend(root, manifest, config) {
+  const maxBytes = getSessionMemoryLimit(config, "memoryPromptMaxKb", 4) * 1024;
+  const candidates = [manifest?.session_id, manifest?.parent_id].filter(Boolean);
+
+  return {
+    name: "structured-lineage",
+    async recall() {
+      for (const sessionId of candidates) {
+        const paths = getSessionArtifactPaths(root, sessionId);
+        if (!(await exists(paths.contextPath))) {
+          continue;
+        }
+        let ctx;
+        try {
+          ctx = await readJson(paths.contextPath);
+        } catch {
+          continue;
+        }
+        const runs = Array.isArray(ctx?.run_history) ? ctx.run_history : [];
+        const rolling = String(ctx?.rolling_summary || "").trim();
+        if (runs.length === 0 && !rolling) {
+          continue;
+        }
+        const lines = [];
+        if (rolling) {
+          lines.push("Rolling summary:", rolling);
+        }
+        if (runs.length > 0) {
+          lines.push("", "Recent runs:");
+          for (const run of runs.slice(-5)) {
+            const when = run?.ended_at || run?.started_at || "";
+            lines.push(`- ${when} task="${(run?.task || "").trim()}" exit=${run?.exit_code ?? "?"} validation=${run?.validation || "not-run"}`);
+            if (run?.assistant_summary) {
+              lines.push(`  summary: ${run.assistant_summary}`);
+            }
+          }
+        }
+        const excerpt = clipToBytes(lines.join("\n").trim(), maxBytes);
+        if (!excerpt) {
+          continue;
+        }
+        return buildMemoryResult("structured-lineage", [{
+          sessionId,
+          transcriptPath: paths.contextPath,
+          transcriptRelativePath: relative(root, paths.contextPath),
+          score: Number.NaN,
+          excerpt,
+        }], [
+          "- Source: structured session state (context.json run_history + rolling_summary).",
+        ], maxBytes);
+      }
+      return null;
+    },
+  };
+}
+
 async function createLineageBackend(root, manifest, config) {
   const maxBytes = getSessionMemoryLimit(config, "memoryPromptMaxKb", 4) * 1024;
   const maxTurns = getSessionMemoryLimit(config, "memoryTurns", 6);
@@ -520,21 +627,28 @@ async function createLineageBackend(root, manifest, config) {
     name: "lineage-replay",
     async recall() {
       for (const sessionId of candidates) {
-        const { transcriptPath } = getSessionArtifactPaths(root, sessionId);
-        if (!(await exists(transcriptPath))) {
+        const { transcriptPath, turnsPath } = getSessionArtifactPaths(root, sessionId);
+        let turns = [];
+        let sourcePath = null;
+        if (await exists(transcriptPath)) {
+          const transcript = await fs.readFile(transcriptPath, "utf8");
+          turns = parseTranscriptTurns(transcript);
+          sourcePath = transcriptPath;
+        } else if (await exists(turnsPath)) {
+          turns = await readStructuredTurnsAsText(turnsPath);
+          sourcePath = turnsPath;
+        } else {
           continue;
         }
-
-        const transcript = await fs.readFile(transcriptPath, "utf8");
-        const excerpt = selectRecentTurns(parseTranscriptTurns(transcript), maxTurns, maxBytes);
+        const excerpt = selectRecentTurns(turns, maxTurns, maxBytes);
         if (!excerpt) {
           continue;
         }
 
         return buildMemoryResult("lineage-replay", [{
           sessionId,
-          transcriptPath,
-          transcriptRelativePath: relative(root, transcriptPath),
+          transcriptPath: sourcePath,
+          transcriptRelativePath: relative(root, sourcePath),
           score: Number.NaN,
           excerpt,
         }], [
@@ -549,6 +663,7 @@ async function createLineageBackend(root, manifest, config) {
 
 async function createMemoryBackends(root, options, config) {
   return [
+    await createStructuredLineageBackend(root, options.manifest || null, config),
     await createMemPalaceBackend(root, options.query || "", config),
     await createTranscriptSearchBackend(root, options.query || "", config),
     await createLineageBackend(root, options.manifest || null, config),
@@ -562,8 +677,99 @@ export function getSessionArtifactPaths(root, sessionId) {
     transcriptPath: path.join(sessionDir, "transcript.md"),
     memoryContextPath: path.join(sessionDir, "memory-context.md"),
     launchesPath: path.join(sessionDir, "launches.jsonl"),
+    turnsPath: path.join(sessionDir, "turns.jsonl"),
     rawInteractiveLogPath: path.join(sessionDir, "interactive.log"),
+    contextPath: path.join(sessionDir, "context.json"),
   };
+}
+
+async function readJsonlTurns(targetPath) {
+  if (!(await exists(targetPath))) {
+    return [];
+  }
+  const raw = await fs.readFile(targetPath, "utf8");
+  const turns = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    try {
+      turns.push(JSON.parse(trimmed));
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return turns;
+}
+
+function turnToTranscriptText(turn) {
+  if (!turn || typeof turn !== "object") {
+    return "";
+  }
+  const label = turn.role === "assistant"
+    ? "> Provider response"
+    : turn.role === "system"
+      ? "> System"
+      : "> Current task";
+  return `${label}\n${String(turn.content || "").trim()}`.trim();
+}
+
+async function readStructuredTurnsAsText(turnsPath) {
+  const turns = await readJsonlTurns(turnsPath);
+  return turns.map(turnToTranscriptText).filter(Boolean);
+}
+
+async function appendTurnsRecord(turnsPath, record) {
+  await ensureDir(path.dirname(turnsPath));
+  await fs.appendFile(turnsPath, `${JSON.stringify(record)}\n`, "utf8");
+}
+
+function clampRunHistoryEntry(entry, summaryMaxBytes) {
+  return {
+    started_at: entry.started_at,
+    ended_at: entry.ended_at,
+    task: clipToBytes(entry.task || "", Math.max(80, Math.floor(summaryMaxBytes / 2))),
+    assistant_summary: clipToBytes(entry.assistant_summary || "", summaryMaxBytes),
+    exit_code: Number.isFinite(entry.exit_code) ? entry.exit_code : null,
+    validation: entry.validation || "not-run",
+    phase: entry.phase || "complete",
+    memory_backend: entry.memory_backend || "none",
+  };
+}
+
+function buildRollingSummary(history) {
+  if (!Array.isArray(history) || history.length === 0) {
+    return "";
+  }
+  const latest = history[history.length - 1] || {};
+  const task = latest.task ? `Last task: ${latest.task}` : null;
+  const summary = latest.assistant_summary ? `Last outcome: ${latest.assistant_summary}` : null;
+  const status = latest.exit_code !== null && latest.exit_code !== undefined
+    ? `Last exit: ${latest.exit_code}, validation ${latest.validation || "not-run"}`
+    : null;
+  return [task, status, summary].filter(Boolean).join("\n");
+}
+
+export async function appendRunSummary(root, sessionId, entry, config) {
+  const paths = getSessionArtifactPaths(root, sessionId);
+  if (!(await exists(paths.contextPath))) {
+    return null;
+  }
+  let context;
+  try {
+    context = await readJson(paths.contextPath);
+  } catch {
+    return null;
+  }
+  const historyLimit = getSessionMemoryLimit(config, "runHistoryMax", 10);
+  const summaryBytes = getSessionMemoryLimit(config, "runSummaryMaxBytes", 256);
+  const previous = Array.isArray(context.run_history) ? context.run_history : [];
+  const next = [...previous, clampRunHistoryEntry(entry, summaryBytes)].slice(-historyLimit);
+  context.run_history = next;
+  context.rolling_summary = clipToBytes(buildRollingSummary(next), Math.max(summaryBytes * 2, 512));
+  await writeJson(paths.contextPath, context);
+  return { run_history: next, rolling_summary: context.rolling_summary };
 }
 
 export async function loadAutomaticMemory(root, options, config) {
@@ -594,45 +800,73 @@ export async function loadAutomaticSessionMemory(root, manifest, config, query =
   return loadAutomaticMemory(root, { manifest, query }, config);
 }
 
-export async function prepareSessionMemoryRun(root, sessionRecord) {
+export async function prepareSessionMemoryRun(root, sessionRecord, config) {
   const startedAt = new Date().toISOString();
   const paths = getSessionArtifactPaths(root, sessionRecord.sessionId);
   await ensureDir(paths.sessionDir);
+  const emitMarkdown = config?.session?.emitMarkdownArtifacts !== false;
 
-  const memoryMarkdown = sessionRecord.memoryContext?.markdown || buildNoMemoryMarkdown();
-  await writeText(paths.memoryContextPath, `${memoryMarkdown.trim()}\n`);
+  await appendTurnsRecord(paths.turnsPath, {
+    schema_version: "1.0",
+    turn_type: "run_start",
+    role: "system",
+    session_id: sessionRecord.sessionId,
+    provider: sessionRecord.provider,
+    started_at: startedAt,
+    capture_mode: sessionRecord.captureMode,
+    command: Array.isArray(sessionRecord.command) ? sessionRecord.command : [],
+    memory_backend: sessionRecord.memoryContext?.backend || "none",
+    memory_source_session_id: sessionRecord.memoryContext?.sourceSessionId || null,
+  });
+  await appendTurnsRecord(paths.turnsPath, {
+    schema_version: "1.0",
+    turn_type: "task",
+    role: "user",
+    session_id: sessionRecord.sessionId,
+    timestamp: startedAt,
+    content: sessionRecord.task || "Continue this session from the latest repository state.",
+  });
 
-  const transcriptLines = [];
-  if (await exists(paths.transcriptPath)) {
-    transcriptLines.push("", "---", "");
+  if (emitMarkdown) {
+    const memoryMarkdown = sessionRecord.memoryContext?.markdown || buildNoMemoryMarkdown();
+    await writeText(paths.memoryContextPath, `${memoryMarkdown.trim()}\n`);
+
+    const transcriptLines = [];
+    if (await exists(paths.transcriptPath)) {
+      transcriptLines.push("", "---", "");
+    }
+    transcriptLines.push(
+      "# Agentify Session Run",
+      `Session: ${sessionRecord.sessionId}`,
+      `Provider: ${sessionRecord.provider}`,
+      `Started: ${startedAt}`,
+      `Capture mode: ${sessionRecord.captureMode}`,
+      `Command: ${normalizeCommand(sessionRecord.command) || "n/a"}`,
+      `Bootstrap: .agents/session/${sessionRecord.sessionId}/bootstrap.md`,
+      `Memory context: ${relative(root, paths.memoryContextPath)}`,
+      "",
+      "> Session bootstrap reference",
+      `Bootstrap context is persisted in \`.agents/session/${sessionRecord.sessionId}/bootstrap.md\`.`,
+      "",
+      "> Automatic session memory",
+      sessionRecord.memoryContext?.excerpt || "No prior session transcript was available for automatic recall before this run.",
+      "",
+      "> Current task",
+      sessionRecord.task || "Continue this session from the latest repository state.",
+      ""
+    );
+
+    await fs.appendFile(paths.transcriptPath, `${transcriptLines.filter(Boolean).join("\n")}\n`, "utf8");
   }
-  transcriptLines.push(
-    "# Agentify Session Run",
-    `Session: ${sessionRecord.sessionId}`,
-    `Provider: ${sessionRecord.provider}`,
-    `Started: ${startedAt}`,
-    `Capture mode: ${sessionRecord.captureMode}`,
-    `Command: ${normalizeCommand(sessionRecord.command) || "n/a"}`,
-    `Bootstrap: .agents/session/${sessionRecord.sessionId}/bootstrap.md`,
-    `Memory context: ${relative(root, paths.memoryContextPath)}`,
-    "",
-    "> Session bootstrap reference",
-    `Bootstrap context is persisted in \`.agents/session/${sessionRecord.sessionId}/bootstrap.md\`.`,
-    "",
-    "> Automatic session memory",
-    sessionRecord.memoryContext?.excerpt || "No prior session transcript was available for automatic recall before this run.",
-    "",
-    "> Current task",
-    sessionRecord.task || "Continue this session from the latest repository state.",
-    ""
-  );
-
-  await fs.appendFile(paths.transcriptPath, `${transcriptLines.filter(Boolean).join("\n")}\n`, "utf8");
-  return { startedAt, paths };
+  return { startedAt, paths, emitMarkdown };
 }
 
 export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, outcome, config) {
   const captureMaxBytes = getSessionMemoryLimit(config, "captureMaxKb", 48) * 1024;
+  const summaryMaxBytes = getSessionMemoryLimit(config, "runSummaryMaxBytes", 256);
+  const emitMarkdown = prepared?.emitMarkdown !== undefined
+    ? prepared.emitMarkdown
+    : config?.session?.emitMarkdownArtifacts !== false;
   const providerOutput = outcome?.interactiveTranscript
     ? String(outcome.interactiveTranscript).trim()
     : [outcome?.stdout, outcome?.stderr]
@@ -648,20 +882,42 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
   const phase = outcome?.phase || "complete";
   const endedAt = new Date().toISOString();
 
-  const transcriptTail = [
-    "> Provider response",
-    assistantText,
-    "",
-    "> Run status",
-    `Command phase: ${phase}`,
-    `Exit code: ${outcome?.exitCode ?? 1}`,
-    `Validation: ${validationSummary}`,
-    `Capture mode used: ${sessionRecord.captureMode}`,
-    outcome?.rawInteractiveLogPath ? `Raw interactive log: ${relative(root, outcome.rawInteractiveLogPath)}` : null,
-    `Ended: ${endedAt}`,
-    ""
-  ].filter(Boolean).join("\n");
-  await fs.appendFile(prepared.paths.transcriptPath, transcriptTail, "utf8");
+  await appendTurnsRecord(prepared.paths.turnsPath, {
+    schema_version: "1.0",
+    turn_type: "assistant_response",
+    role: "assistant",
+    session_id: sessionRecord.sessionId,
+    timestamp: endedAt,
+    content: assistantText,
+  });
+  await appendTurnsRecord(prepared.paths.turnsPath, {
+    schema_version: "1.0",
+    turn_type: "run_end",
+    role: "system",
+    session_id: sessionRecord.sessionId,
+    ended_at: endedAt,
+    phase,
+    exit_code: outcome?.exitCode ?? 1,
+    validation: validationSummary,
+    capture_mode: sessionRecord.captureMode,
+  });
+
+  if (emitMarkdown) {
+    const transcriptTail = [
+      "> Provider response",
+      assistantText,
+      "",
+      "> Run status",
+      `Command phase: ${phase}`,
+      `Exit code: ${outcome?.exitCode ?? 1}`,
+      `Validation: ${validationSummary}`,
+      `Capture mode used: ${sessionRecord.captureMode}`,
+      outcome?.rawInteractiveLogPath ? `Raw interactive log: ${relative(root, outcome.rawInteractiveLogPath)}` : null,
+      `Ended: ${endedAt}`,
+      ""
+    ].filter(Boolean).join("\n");
+    await fs.appendFile(prepared.paths.transcriptPath, transcriptTail, "utf8");
+  }
 
   const launchRecord = {
     schema_version: "1.0",
@@ -675,6 +931,7 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
     prompt: sessionRecord.prompt,
     transcript_path: relative(root, prepared.paths.transcriptPath),
     memory_context_path: relative(root, prepared.paths.memoryContextPath),
+    turns_path: relative(root, prepared.paths.turnsPath),
     memory_backend: sessionRecord.memoryContext?.backend || "none",
     raw_interactive_log_path: outcome?.rawInteractiveLogPath
       ? relative(root, outcome.rawInteractiveLogPath)
@@ -688,4 +945,15 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
     stderr: clipToBytes(outcome?.stderr || "", captureMaxBytes),
   };
   await fs.appendFile(prepared.paths.launchesPath, `${JSON.stringify(launchRecord)}\n`, "utf8");
+
+  await appendRunSummary(root, sessionRecord.sessionId, {
+    started_at: prepared.startedAt,
+    ended_at: endedAt,
+    task: sessionRecord.task || "",
+    assistant_summary: clipToBytes(assistantText, summaryMaxBytes),
+    exit_code: outcome?.exitCode ?? null,
+    validation: validationSummary,
+    phase,
+    memory_backend: sessionRecord.memoryContext?.backend || "none",
+  }, config);
 }

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -84,6 +84,18 @@ function renderChecklistMarkdown(sessionId, checklist, totalItems) {
   return lines.join("\n");
 }
 
+function clampRunHistory(history, limit, perEntryBytes) {
+  if (!Array.isArray(history) || history.length === 0 || limit <= 0) {
+    return [];
+  }
+  const trimmed = history.slice(-limit);
+  return trimmed.map((entry) => ({
+    ...entry,
+    assistant_summary: clipToBytes(entry?.assistant_summary || "", perEntryBytes),
+    task: clipToBytes(entry?.task || "", Math.max(80, Math.floor(perEntryBytes / 2))),
+  }));
+}
+
 function fitContext(manifest, index, checklist, options, config) {
   const moduleIds = index?.modules?.map((m) => m.id) || [];
   const staleModules = [];
@@ -93,17 +105,19 @@ function fitContext(manifest, index, checklist, options, config) {
   const memoryContextRef = options.root ? `.agents/session/${manifest.session_id}/memory-context.md` : memoryArtifacts.memoryContextPath;
   const launchesRef = options.root ? `.agents/session/${manifest.session_id}/launches.jsonl` : memoryArtifacts.launchesPath;
   const rawInteractiveLogRef = options.root ? `.agents/session/${manifest.session_id}/interactive.log` : memoryArtifacts.rawInteractiveLogPath;
+  const turnsRef = options.root ? `.agents/session/${manifest.session_id}/turns.jsonl` : memoryArtifacts.turnsPath;
   const attempts = [
-    { moduleLimit: moduleIds.length, checklistLimit: checklist.length, checklistTextBytes: 240, parentSummaryBytes: 2048 },
-    { moduleLimit: 64, checklistLimit: 20, checklistTextBytes: 180, parentSummaryBytes: 1024 },
-    { moduleLimit: 24, checklistLimit: 10, checklistTextBytes: 140, parentSummaryBytes: 512 },
-    { moduleLimit: 8, checklistLimit: 5, checklistTextBytes: 100, parentSummaryBytes: 256 },
-    { moduleLimit: 0, checklistLimit: 0, checklistTextBytes: 0, parentSummaryBytes: 120 },
+    { moduleLimit: moduleIds.length, checklistLimit: checklist.length, checklistTextBytes: 240, parentSummaryBytes: 2048, runHistoryLimit: 10, runSummaryBytes: 256, rollingSummaryBytes: 1024 },
+    { moduleLimit: 64, checklistLimit: 20, checklistTextBytes: 180, parentSummaryBytes: 1024, runHistoryLimit: 6, runSummaryBytes: 180, rollingSummaryBytes: 512 },
+    { moduleLimit: 24, checklistLimit: 10, checklistTextBytes: 140, parentSummaryBytes: 512, runHistoryLimit: 4, runSummaryBytes: 140, rollingSummaryBytes: 256 },
+    { moduleLimit: 8, checklistLimit: 5, checklistTextBytes: 100, parentSummaryBytes: 256, runHistoryLimit: 2, runSummaryBytes: 96, rollingSummaryBytes: 128 },
+    { moduleLimit: 0, checklistLimit: 0, checklistTextBytes: 0, parentSummaryBytes: 120, runHistoryLimit: 0, runSummaryBytes: 0, rollingSummaryBytes: 0 },
   ];
 
   let selected = null;
   for (const attempt of attempts) {
     const previewChecklist = normalizeChecklist(checklist, attempt.checklistLimit, attempt.checklistTextBytes);
+    const runHistory = clampRunHistory(options.runHistory || [], attempt.runHistoryLimit, attempt.runSummaryBytes);
     const candidate = {
       schema_version: "1.0",
       session_id: manifest.session_id,
@@ -128,8 +142,11 @@ function fitContext(manifest, index, checklist, options, config) {
         memory_context: memoryContextRef,
         launches: launchesRef,
         raw_interactive_log: rawInteractiveLogRef,
+        turns: turnsRef,
       },
       parent_summary: clipToBytes(options.parentSummary || "", attempt.parentSummaryBytes),
+      run_history: runHistory,
+      rolling_summary: clipToBytes(options.rollingSummary || "", attempt.rollingSummaryBytes),
     };
 
     selected = candidate;
@@ -139,6 +156,52 @@ function fitContext(manifest, index, checklist, options, config) {
   }
 
   return { value: selected, truncated: true };
+}
+
+export function synthesizeBootstrapFromContext(manifest, context) {
+  const moduleIds = context?.index_snapshot?.module_ids || [];
+  const moduleCount = Number(context?.index_snapshot?.module_count || moduleIds.length);
+  const checklist = Array.isArray(context?.checklist) ? context.checklist : [];
+  const checklistSummary = context?.checklist_summary || {
+    total_items: checklist.length,
+    displayed_items: checklist.length,
+    remaining_items: 0,
+  };
+  const runs = Array.isArray(context?.run_history) ? context.run_history : [];
+  const rolling = String(context?.rolling_summary || "").trim();
+
+  const runsBlock = runs.length === 0
+    ? "- No prior runs recorded."
+    : runs.slice(-3).map((run) => {
+      const task = run?.task ? `task: ${run.task}` : "task: (unrecorded)";
+      const validation = run?.validation ? ` validation: ${run.validation}` : "";
+      const exit = Number.isFinite(run?.exit_code) ? ` exit: ${run.exit_code}` : "";
+      return `- ${run?.ended_at || run?.started_at || "run"} — ${task}${exit}${validation}`;
+    }).join("\n");
+
+  return `# Session Context
+
+## Session
+- ID: ${manifest.session_id}
+- Parent: ${manifest.parent_id || "none"}
+- Provider: ${manifest.provider || manifest.tool || "local"}
+- Created: ${manifest.created_at}
+
+## Repository State
+- HEAD: ${manifest.head_commit_at_creation}
+- Module count: ${moduleCount}
+- Module preview: ${summarizeModules(moduleIds, Math.min(moduleIds.length, 12))}
+- Full routing: host shell -> .agents/index.db
+
+## Checklist Status
+${renderChecklistMarkdown(manifest.session_id, checklist, checklistSummary.total_items ?? checklist.length)}
+
+## Recent Runs
+${runsBlock}
+
+## Rolling Summary
+${rolling || "- No rolling summary recorded yet."}
+`;
 }
 
 function fitBootstrap(manifest, index, checklist, options, config) {
@@ -208,6 +271,8 @@ export async function forkSession(root, config, options = {}) {
     }
   }
 
+  const emitMarkdown = config?.session?.emitMarkdownArtifacts !== false;
+
   const manifest = {
     schema_version: "1.0",
     session_id: sessionId,
@@ -220,31 +285,64 @@ export async function forkSession(root, config, options = {}) {
     head_commit_at_creation: headCommit,
     index_snapshot: ".agents/index.db",
     cache_refs: [
-      `.agents/session/${sessionId}/bootstrap.md`,
       `.agents/session/${sessionId}/context.json`,
       `.agents/session/${sessionId}/checklist.json`,
+      `.agents/session/${sessionId}/launches.jsonl`,
+      `.agents/session/${sessionId}/turns.jsonl`,
+      `.agents/session/${sessionId}/bootstrap.md`,
       `.agents/session/${sessionId}/transcript.md`,
       `.agents/session/${sessionId}/memory-context.md`,
-      `.agents/session/${sessionId}/launches.jsonl`,
       `.agents/session/${sessionId}/interactive.log`,
     ],
     metadata: {
       modules_indexed: index?.modules?.length || 0,
       total_tokens_used: 0,
       memory_adapter: "mempalace-compatible-session-v1",
+      emit_markdown_artifacts: emitMarkdown,
+      runtime_artifacts: [
+        "session-manifest.json",
+        "context.json",
+        "checklist.json",
+        "launches.jsonl",
+        "turns.jsonl",
+      ],
+      optional_markdown_artifacts: [
+        "bootstrap.md",
+        "transcript.md",
+        "memory-context.md",
+        "interactive.log",
+      ],
     },
   };
 
   let parentChecklist = [];
+  let parentRunHistory = [];
+  let parentRollingSummary = "";
   if (options.from) {
     const parentDir = path.join(root, ".agents", "session", options.from);
     const checklistPath = path.join(parentDir, "checklist.json");
     if (await exists(checklistPath)) {
       parentChecklist = await readJson(checklistPath);
     }
+    const parentContextPath = path.join(parentDir, "context.json");
+    if (await exists(parentContextPath)) {
+      try {
+        const parentContext = await readJson(parentContextPath);
+        parentRunHistory = Array.isArray(parentContext?.run_history) ? parentContext.run_history : [];
+        parentRollingSummary = String(parentContext?.rolling_summary || "");
+      } catch {
+        parentRunHistory = [];
+        parentRollingSummary = "";
+      }
+    }
   }
 
-  const contextResult = fitContext(manifest, index, parentChecklist, { ...options, root }, config);
+  const contextResult = fitContext(manifest, index, parentChecklist, {
+    ...options,
+    root,
+    runHistory: options.runHistory || parentRunHistory,
+    rollingSummary: options.rollingSummary || parentRollingSummary,
+  }, config);
   const bootstrapResult = fitBootstrap(manifest, index, parentChecklist, options, config);
   const context = contextResult.value;
   const bootstrap = bootstrapResult.value;
@@ -257,7 +355,9 @@ export async function forkSession(root, config, options = {}) {
   await writeJson(path.join(sessionDir, "session-manifest.json"), manifest);
   await writeJson(path.join(sessionDir, "checklist.json"), parentChecklist);
   await writeJson(path.join(sessionDir, "context.json"), context);
-  await writeText(path.join(sessionDir, "bootstrap.md"), bootstrap);
+  if (emitMarkdown) {
+    await writeText(path.join(sessionDir, "bootstrap.md"), bootstrap);
+  }
 
   return { sessionId, sessionDir, manifest, context, bootstrap };
 }
@@ -290,7 +390,10 @@ export async function resumeSession(root, sessionId) {
 
   const manifest = await readJson(manifestPath);
   const context = await readJson(path.join(sessionDir, "context.json"));
-  const bootstrap = await fs.readFile(path.join(sessionDir, "bootstrap.md"), "utf8");
+  const bootstrapPath = path.join(sessionDir, "bootstrap.md");
+  const bootstrap = (await exists(bootstrapPath))
+    ? await fs.readFile(bootstrapPath, "utf8")
+    : synthesizeBootstrapFromContext(manifest, context);
 
   return { manifest, context, bootstrap };
 }

--- a/test/session-structured.test.js
+++ b/test/session-structured.test.js
@@ -1,0 +1,236 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { loadConfig } from "../src/core/config.js";
+import {
+  forkSession,
+  resumeSession,
+  synthesizeBootstrapFromContext,
+} from "../src/core/session.js";
+import {
+  appendRunSummary,
+  getSessionArtifactPaths,
+  loadAutomaticSessionMemory,
+} from "../src/core/session-memory.js";
+
+const execFileAsync = promisify(execFile);
+
+async function initGitRepo(root) {
+  await execFileAsync("git", ["init"], { cwd: root });
+  await execFileAsync("git", ["config", "user.name", "Agentify Tests"], { cwd: root });
+  await execFileAsync("git", ["config", "user.email", "agentify-tests@example.com"], { cwd: root });
+  await execFileAsync("git", ["add", "."], { cwd: root });
+  await execFileAsync("git", ["commit", "-m", "initial"], { cwd: root });
+}
+
+async function fileExists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test("forkSession initializes structured run_history and rolling_summary in context.json", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-structured-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex" });
+  const result = await forkSession(root, config, { name: "structured" });
+
+  assert.deepEqual(result.context.run_history, []);
+  assert.equal(result.context.rolling_summary, "");
+  assert.ok(result.context.cache_refs.turns.endsWith("turns.jsonl"));
+  assert.ok(result.manifest.metadata.runtime_artifacts.includes("turns.jsonl"));
+  assert.ok(result.manifest.metadata.optional_markdown_artifacts.includes("bootstrap.md"));
+});
+
+test("resumeSession synthesizes bootstrap from context when markdown artifacts are disabled", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-no-markdown-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex" });
+  config.session.emitMarkdownArtifacts = false;
+
+  const created = await forkSession(root, config, { name: "no-markdown" });
+  const bootstrapPath = path.join(created.sessionDir, "bootstrap.md");
+  assert.equal(await fileExists(bootstrapPath), false);
+
+  const resumed = await resumeSession(root, created.sessionId);
+  assert.match(resumed.bootstrap, /Session Context/);
+  assert.match(resumed.bootstrap, /Provider: codex/);
+  assert.match(resumed.bootstrap, /Rolling Summary/);
+});
+
+test("synthesizeBootstrapFromContext renders recent runs from structured state", () => {
+  const manifest = {
+    session_id: "sess_synth",
+    parent_id: null,
+    provider: "codex",
+    created_at: "2026-04-21T10:00:00Z",
+    head_commit_at_creation: "deadbeef",
+  };
+  const context = {
+    index_snapshot: { module_ids: ["api", "web"], module_count: 2 },
+    checklist: [],
+    checklist_summary: { total_items: 0, displayed_items: 0, remaining_items: 0 },
+    run_history: [
+      {
+        started_at: "t1",
+        ended_at: "t2",
+        task: "ship feature X",
+        exit_code: 0,
+        validation: "passed",
+        assistant_summary: "done",
+      },
+    ],
+    rolling_summary: "Feature X shipped cleanly.",
+  };
+  const rendered = synthesizeBootstrapFromContext(manifest, context);
+  assert.match(rendered, /sess_synth/);
+  assert.match(rendered, /ship feature X/);
+  assert.match(rendered, /Feature X shipped cleanly/);
+});
+
+test("appendRunSummary keeps run_history bounded and updates rolling_summary", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-rollup-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex" });
+  config.session.runHistoryMax = 5;
+  config.session.runSummaryMaxBytes = 120;
+  const created = await forkSession(root, config, { name: "rollup" });
+
+  for (let index = 0; index < 12; index += 1) {
+    await appendRunSummary(root, created.sessionId, {
+      started_at: `s-${index}`,
+      ended_at: `e-${index}`,
+      task: `task ${index} ${"x".repeat(300)}`,
+      assistant_summary: `summary ${index} ${"y".repeat(300)}`,
+      exit_code: index % 2 === 0 ? 0 : 1,
+      validation: index % 2 === 0 ? "passed" : "failed",
+      phase: "complete",
+      memory_backend: "structured-lineage",
+    }, config);
+  }
+
+  const contextPath = path.join(created.sessionDir, "context.json");
+  const context = JSON.parse(await fs.readFile(contextPath, "utf8"));
+  assert.equal(context.run_history.length, 5);
+  assert.equal(context.run_history[0].started_at, "s-7");
+  assert.equal(context.run_history[4].started_at, "s-11");
+  for (const entry of context.run_history) {
+    assert.ok(Buffer.byteLength(entry.assistant_summary, "utf8") <= 120);
+  }
+  assert.match(context.rolling_summary, /Last task: task 11/);
+});
+
+test("forkSession inherits run_history and rolling_summary from parent", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-inherit-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex" });
+  const parent = await forkSession(root, config, { name: "parent" });
+  await appendRunSummary(root, parent.sessionId, {
+    started_at: "p-start",
+    ended_at: "p-end",
+    task: "investigate refresh bug",
+    assistant_summary: "refresh bug fixed after wrapping the refresh call.",
+    exit_code: 0,
+    validation: "passed",
+    phase: "complete",
+    memory_backend: "structured-lineage",
+  }, config);
+
+  const child = await forkSession(root, config, { from: parent.sessionId, name: "child" });
+  assert.equal(child.context.run_history.length, 1);
+  assert.equal(child.context.run_history[0].task, "investigate refresh bug");
+  assert.match(child.context.rolling_summary, /refresh bug fixed/);
+});
+
+test("loadAutomaticSessionMemory prefers structured lineage over transcript replay", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-structured-lineage-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex" });
+  const parent = await forkSession(root, config, { name: "parent" });
+  await appendRunSummary(root, parent.sessionId, {
+    started_at: "p-start",
+    ended_at: "p-end",
+    task: "wire up structured memory",
+    assistant_summary: "context.json now carries the rolling summary.",
+    exit_code: 0,
+    validation: "passed",
+    phase: "complete",
+    memory_backend: "structured-lineage",
+  }, config);
+
+  const paths = getSessionArtifactPaths(root, parent.sessionId);
+  await fs.writeFile(paths.transcriptPath, [
+    "# Agentify Session Run",
+    "",
+    "> Provider response",
+    "legacy transcript content",
+    "",
+  ].join("\n"), "utf8");
+
+  const child = await forkSession(root, config, { from: parent.sessionId, name: "child" });
+  const memory = await loadAutomaticSessionMemory(root, child.manifest, config);
+
+  assert.equal(memory.backend, "structured-lineage");
+  assert.equal(memory.sourceSessionId, child.sessionId);
+  assert.match(memory.markdown, /rolling summary/);
+  assert.match(memory.markdown, /wire up structured memory/);
+});
+
+test("lineage replay falls back to turns.jsonl when transcript.md is absent", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-turns-fallback-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex" });
+  config.session.emitMarkdownArtifacts = false;
+  const parent = await forkSession(root, config, { name: "parent" });
+  const paths = getSessionArtifactPaths(root, parent.sessionId);
+
+  const turns = [
+    {
+      schema_version: "1.0",
+      turn_type: "task",
+      role: "user",
+      session_id: parent.sessionId,
+      timestamp: "t1",
+      content: "Fix the refresh regression after commits.",
+    },
+    {
+      schema_version: "1.0",
+      turn_type: "assistant_response",
+      role: "assistant",
+      session_id: parent.sessionId,
+      timestamp: "t2",
+      content: "Refresh after the wrapped command lands, then validate.",
+    },
+  ];
+  for (const turn of turns) {
+    await fs.appendFile(paths.turnsPath, `${JSON.stringify(turn)}\n`, "utf8");
+  }
+  assert.equal(await fileExists(paths.transcriptPath), false);
+
+  const child = await forkSession(root, config, { from: parent.sessionId, name: "child" });
+  const memory = await loadAutomaticSessionMemory(root, child.manifest, config);
+
+  assert.equal(memory.backend, "lineage-replay");
+  assert.equal(memory.sourceSessionId, parent.sessionId);
+  assert.match(memory.markdown, /Refresh after the wrapped command lands/);
+});


### PR DESCRIPTION
## Summary

- Adds a compact rolling `run_history` + `rolling_summary` to `context.json`; each run updates it via a new `appendRunSummary` bounded by `session.runHistoryMax` and `session.runSummaryMaxBytes`. Forks inherit the parent's summary.
- Demotes `bootstrap.md`, `transcript.md`, and `memory-context.md` to optional exports. `resumeSession` synthesises a bootstrap view from `manifest + context.json` when markdown is absent, gated by a new `session.emitMarkdownArtifacts` flag (default `true` for back-compat).
- Adds `turns.jsonl` as the canonical structured turn log. Lineage/search memory backends now prefer transcripts but fall back to `turns.jsonl`. A new `structured-lineage` backend reads the parent's `context.json` first so recall uses the compact summary instead of replaying markdown.
- Splits manifest `cache_refs` into `runtime_artifacts` (JSON) vs `optional_markdown_artifacts` so tooling/tests can tell them apart.

Closes #68.

## Test plan

- [x] `node --test test/session.test.js test/session-structured.test.js` — 14/14 pass (7 existing + 7 new).
- [x] Full suite: `npm test` — no new regressions. Two pre-existing failing tests (`runExec refreshes...` / `runCli exec refreshes...`) fail on both `main` and this branch and are unrelated to session artifacts.
- [x] New coverage: structured run_history stays bounded across 12 repeated launches with `runHistoryMax=5`; resume synthesises bootstrap with markdown disabled; child fork inherits parent's `run_history` + `rolling_summary`; memory loader prefers `structured-lineage` over transcript replay; `lineage-replay` falls back to `turns.jsonl` when `transcript.md` is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)