### PR TITLE
perf(db): avoid files x symbols cross-product in loadModules

### DIFF
--- a/src/core/db.js
+++ b/src/core/db.js
@@ -524,22 +524,19 @@ export function loadModules(db) {
       m.fingerprint,
       m.entry_files_json,
       m.key_files_json,
-      COUNT(DISTINCT f.path) AS file_count,
-      COUNT(DISTINCT s.symbol_id) AS symbol_count
+      COALESCE(f.file_count, 0) AS file_count,
+      COALESCE(s.symbol_count, 0) AS symbol_count
     FROM modules m
-    LEFT JOIN files f ON f.module_id = m.id
-    LEFT JOIN symbols s ON s.module_id = m.id
-    GROUP BY
-      m.id,
-      m.name,
-      m.root_path,
-      m.stack,
-      m.package_name,
-      m.slug,
-      m.doc_path,
-      m.fingerprint,
-      m.entry_files_json,
-      m.key_files_json
+    LEFT JOIN (
+      SELECT module_id, COUNT(*) AS file_count
+      FROM files
+      GROUP BY module_id
+    ) f ON f.module_id = m.id
+    LEFT JOIN (
+      SELECT module_id, COUNT(*) AS symbol_count
+      FROM symbols
+      GROUP BY module_id
+    ) s ON s.module_id = m.id
     ORDER BY m.root_path
   `).all()).map((row) => ({
     ...row,


### PR DESCRIPTION
## Summary
- `loadModules()` previously joined `modules` to both `files` and `symbols`, then used `COUNT(DISTINCT ...)` to deduplicate. The intermediate join cardinality was `F * S` per module, making module-metadata reads scale with files-per-module × symbols-per-module instead of with raw row count.
- This PR replaces the doubly-joined `COUNT(DISTINCT ...)` with two pre-aggregated subqueries (`COUNT(*)` per `module_id`), which preserves the same shape of result columns while avoiding the cross-product.

## Test plan
- [x] `node --test test/db.test.js test/planner.test.js test/query.test.js test/session.test.js` — all 14 tests pass
- [x] Re-ran the benchmark from the issue (1 module, 100 files, 400 symbols, 10 runs):
  - Before: `viaApiMs ≈ 547`
  - After:  `viaApiMs ≈ 0.7`
- [x] Verified `file_count = 100`, `symbol_count = 400` on the sample row, matching prior semantics.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)