### PR TITLE
fix(cleanup): preserve referenced legacy module metadata files

### DIFF
--- a/src/core/cleanup.js
+++ b/src/core/cleanup.js
@@ -34,6 +34,7 @@ async function listDirs(dirPath) {
 
 async function pruneOrphanedModuleArtifacts(root, dryRun) {
   const expectedDocs = new Set();
+  const expectedMetadata = new Set();
   if (await exists(path.join(root, ".agents", "index.db"))) {
     const db = openIndexDatabase(root);
     try {
@@ -47,6 +48,9 @@ async function pruneOrphanedModuleArtifacts(root, dryRun) {
     const legacyIndex = await readJson(path.join(root, ".agents", "index.json"));
     for (const moduleInfo of legacyIndex.modules || []) {
       expectedDocs.add(path.basename(moduleInfo.doc_path || ""));
+      if (moduleInfo.metadata_path) {
+        expectedMetadata.add(path.basename(moduleInfo.metadata_path));
+      }
     }
   } else {
     return {
@@ -68,7 +72,7 @@ async function pruneOrphanedModuleArtifacts(root, dryRun) {
 
   const metadataDir = path.join(root, ".agents", "modules");
   for (const file of await listFiles(metadataDir)) {
-    if (!file.endsWith(".json")) {
+    if (!file.endsWith(".json") || expectedMetadata.has(file)) {
       continue;
     }
     await removePath(path.join(metadataDir, file), dryRun);

--- a/test/cleanup.test.js
+++ b/test/cleanup.test.js
@@ -62,7 +62,8 @@ test("runClean prunes orphaned Agentify artifacts and stale folders", async () =
   assert.equal(await fs.stat(path.join(root, ".agents", "session", "broken")).then(() => true).catch(() => false), false);
 
   assert.equal(await fs.stat(path.join(root, "docs", "modules", "auth.md")).then(() => true), true);
-  assert.equal(await fs.stat(path.join(root, ".agents", "modules", "auth.json")).then(() => true).catch(() => false), false);
+  assert.equal(await fs.stat(path.join(root, ".agents", "modules", "auth.json")).then(() => true), true);
+  assert.ok(!result.removed_paths.includes(".agents/modules/auth.json"));
   assert.equal(await fs.stat(path.join(root, ".agents", "runs", "keep.json")).then(() => true), true);
   assert.equal(await fs.stat(path.join(root, ".current_session", "ghost_keep")).then(() => true), true);
 });


### PR DESCRIPTION
## Summary
- `runClean()` was deleting every `.agents/modules/*.json` file even when the legacy `.agents/index.json` still referenced some of them via `metadata_path`.
- Now `pruneOrphanedModuleArtifacts` derives an `expectedMetadata` set from `legacyIndex.modules[*].metadata_path` and preserves those files; true orphans are still pruned.
- The SQLite (`.agents/index.db`) path keeps its existing behavior (the new schema sets `metadata_path: null`, so legacy `.json` files there remain unreferenced and are still cleaned).

## Test plan
- [x] Updated `test/cleanup.test.js` so the referenced `.agents/modules/auth.json` survives cleanup while orphan `dead.json` is still removed.
- [x] `node --test test/cleanup.test.js` — both cases pass.
- [x] `npm test` — only two pre-existing failures in `exec.test.js` / `main.test.js` (reproduced on `main` before this change), unrelated to cleanup.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)