### PR TITLE
perf(indexer): walk repository once for stack detection and indexing

### DIFF
--- a/src/core/commands.js
+++ b/src/core/commands.js
@@ -129,10 +129,10 @@ function findModuleDeps(modules, graph) {
 }
 
 async function buildScanState(root, config) {
-  const stacks = await detectStacks(root, config);
+  const files = (await walkFiles(root, { respectIgnore: true })).map((file) => relative(root, file));
+  const stacks = await detectStacks(root, config, { relFiles: files });
   const defaultStack = stacks[0]?.name || "ts";
   const modules = await detectModules(root, config, defaultStack);
-  const files = (await walkFiles(root, { respectIgnore: true })).map((file) => relative(root, file));
   const graph = await buildDependencyGraph(root, defaultStack);
   const moduleDeps = findModuleDeps(modules, graph);
 

--- a/src/core/detect.js
+++ b/src/core/detect.js
@@ -160,13 +160,14 @@ async function detectSwiftModules(root) {
     : [{ id: path.basename(root), name: path.basename(root), rootPath: ".", stack: "swift" }];
 }
 
-export async function detectStacks(root, config) {
+export async function detectStacks(root, config, options = {}) {
   if (config.languages && config.languages !== "auto") {
     return [{ name: config.languages, confidence: 1 }];
   }
 
-  const files = await walkFiles(root, { respectIgnore: true });
-  const relFiles = files.map((file) => relative(root, file));
+  const relFiles = options.relFiles
+    ? options.relFiles
+    : (await walkFiles(root, { respectIgnore: true })).map((file) => relative(root, file));
 
   const tsSignals = [
     await exists(path.join(root, "package.json")),

--- a/src/core/indexer.js
+++ b/src/core/indexer.js
@@ -1178,10 +1178,10 @@ async function buildModuleCommands(root, rootFiles, moduleInfo) {
 
 export async function buildRepositoryIndex(root, config) {
   const generatedAt = new Date().toISOString();
-  const stacks = await detectStacks(root, config);
-  const defaultStack = stacks[0]?.name || "ts";
   const filePaths = (await walkFiles(root, { respectIgnore: true })).map((file) => relative(root, file));
-  const repoFiles = filePaths.sort();
+  const stacks = await detectStacks(root, config, { relFiles: filePaths });
+  const defaultStack = stacks[0]?.name || "ts";
+  const repoFiles = filePaths.slice().sort();
   const repoFileSet = new Set(repoFiles);
 
   const detectedModules = defaultStack === "ts"


### PR DESCRIPTION
## Summary
- `buildRepositoryIndex` was walking the tree twice — once via `detectStacks` and again before the per-file indexing loop. Threaded a precomputed relative file list into `detectStacks` via `options.relFiles` so the walk happens once.
- Same single-walk pattern applied to `buildScanState` in `commands.js`.

## Validation
Reproduction script from the issue (synthetic 42-file repo):

| metric  | before | after |
| ------- | -----: | ----: |
| readdir |      9 |     5 |
| stat    |     42 |    42 |
| readFile|     52 |    52 |

`readdir` drops by exactly one full-tree walk (4 dirs), matching the expected improvement.

`npm test -- --test-name-pattern='update|main|semantic'` → 31/31 pass.

Full `npm test` shows 4 pre-existing failures (issue-killer/Worktrunk Node 25 ESM issues) that reproduce on the unmodified base.

Closes #83

## Test plan
- [x] Re-ran the issue's instrumentation script — readdir count drops by ~1 full tree walk
- [x] `npm test -- --test-name-pattern='update|main|semantic'` passes
- [x] Confirmed remaining test failures are pre-existing on base branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)