### PR TITLE
perf(session-memory): skip MemPalace export sync when binary is missing

### DIFF
--- a/src/core/session-memory.js
+++ b/src/core/session-memory.js
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -438,8 +439,43 @@ async function runMemPalace(root, args, palacePath) {
   });
 }
 
-async function createMemPalaceBackend(root, query, config) {
-  const transcripts = await listSessionTranscripts(root);
+async function resolveMemPalaceBinary() {
+  const cmd = process.env.AGENTIFY_MEMPALACE_CMD || "mempalace";
+  if (cmd.includes("/") || cmd.includes("\\") || path.isAbsolute(cmd)) {
+    try {
+      await fs.access(cmd, fsConstants.X_OK);
+      return cmd;
+    } catch {
+      return null;
+    }
+  }
+  const pathEnv = process.env.PATH || "";
+  if (!pathEnv) {
+    return null;
+  }
+  const sep = process.platform === "win32" ? ";" : ":";
+  const exts = process.platform === "win32"
+    ? (process.env.PATHEXT || ".EXE;.CMD;.BAT").split(";")
+    : [""];
+  for (const dir of pathEnv.split(sep)) {
+    if (!dir) {
+      continue;
+    }
+    for (const ext of exts) {
+      const candidate = path.join(dir, cmd + ext);
+      try {
+        await fs.access(candidate, fsConstants.X_OK);
+        return candidate;
+      } catch {
+        // try next candidate
+      }
+    }
+  }
+  return null;
+}
+
+async function createMemPalaceBackend(root, query, config, sharedInventory = {}) {
+  const transcripts = sharedInventory.transcripts ?? await listSessionTranscripts(root);
   const tokens = tokenizeQuery(query);
 
   return {
@@ -490,10 +526,10 @@ async function createMemPalaceBackend(root, query, config) {
   };
 }
 
-async function createTranscriptSearchBackend(root, query, config) {
-  const transcripts = await listSessionTranscripts(root);
-  const structuredOnly = (await listStructuredSessionTurns(root))
-    .filter((item) => !transcripts.some((t) => t.sessionId === item.sessionId));
+async function createTranscriptSearchBackend(root, query, config, sharedInventory = {}) {
+  const transcripts = sharedInventory.transcripts ?? await listSessionTranscripts(root);
+  const structuredAll = sharedInventory.structuredTurns ?? await listStructuredSessionTurns(root);
+  const structuredOnly = structuredAll.filter((item) => !transcripts.some((t) => t.sessionId === item.sessionId));
   const tokens = tokenizeQuery(query);
   const maxBytes = getSessionMemoryLimit(config, "memoryPromptMaxKb", 4) * 1024;
   const maxResults = getSessionMemoryLimit(config, "memoryResults", 3);
@@ -662,12 +698,32 @@ async function createLineageBackend(root, manifest, config) {
 }
 
 async function createMemoryBackends(root, options, config) {
-  return [
-    await createStructuredLineageBackend(root, options.manifest || null, config),
-    await createMemPalaceBackend(root, options.query || "", config),
-    await createTranscriptSearchBackend(root, options.query || "", config),
-    await createLineageBackend(root, options.manifest || null, config),
-  ];
+  const query = options.query || "";
+  const manifest = options.manifest || null;
+  const tokens = tokenizeQuery(query);
+  const needsTranscriptInventory = tokens.length > 0;
+  const sharedInventory = {};
+  if (needsTranscriptInventory) {
+    const [transcripts, structuredTurns] = await Promise.all([
+      listSessionTranscripts(root),
+      listStructuredSessionTurns(root),
+    ]);
+    sharedInventory.transcripts = transcripts;
+    sharedInventory.structuredTurns = structuredTurns;
+  }
+
+  const backends = [await createStructuredLineageBackend(root, manifest, config)];
+
+  if (needsTranscriptInventory) {
+    const mempalaceBinary = await resolveMemPalaceBinary();
+    if (mempalaceBinary) {
+      backends.push(await createMemPalaceBackend(root, query, config, sharedInventory));
+    }
+    backends.push(await createTranscriptSearchBackend(root, query, config, sharedInventory));
+  }
+
+  backends.push(await createLineageBackend(root, manifest, config));
+  return backends;
 }
 
 export function getSessionArtifactPaths(root, sessionId) {


### PR DESCRIPTION
Closes #82

## Summary
- Probe for the `mempalace` binary (PATH or `AGENTIFY_MEMPALACE_CMD`) before constructing the MemPalace backend; skip the backend entirely when the binary is unavailable.
- Stop reading every transcript twice on the no-MemPalace path. The export-sync pass (`syncMemPalaceSessionExports`) is now bypassed and `.agents/mempalace/session-exports/` is no longer rewritten when the backend cannot run.
- Share the transcript and structured-turns inventory between MemPalace and the local-search fallback so the fallback does not rescan `.agents/session/`.
- Skip transcript-search backends when the query has no usable tokens (they returned null anyway).

## Why
Per #82, the previous flow always called `syncMemPalaceSessionExports()` before discovering `ENOENT`, which read every transcript in `.agents/session/` and rewrote the exports. The local fallback then read every transcript again. Startup latency for `agentify run` / `sess fork|resume|run` scaled with `2 * transcriptCount` even on machines without `mempalace` installed.

## Benchmark (from the issue)
60 synthetic transcripts, `mempalace` absent:

| metric                          | before | after |
|---------------------------------|--------|-------|
| `readFile` calls                | 120    | 60    |
| elapsed (ms)                    | ~36    | ~12   |
| `mempalace/session-exports/` written | yes | no    |

## Test plan
- [x] `node --test test/session.test.js test/session-structured.test.js` — all 14 pass, including the existing `loadAutomaticRunMemory uses MemPalace automatically when the CLI is available` test (PATH-based detection still picks up the fake binary).
- [x] Re-ran the issue's benchmark — `readFileCalls` dropped from 120 to 60, exports dir not created.
- [x] Confirmed the two pre-existing failures in `test/exec.test.js` / `test/main.test.js` (`refreshes ... after a failing command mutates tracked files`) reproduce on `main` and are unrelated to this change.