### PR TITLE
fix(reliability): fail closed when scan/doc/up lock is held

### DIFF
--- a/src/core/commands.js
+++ b/src/core/commands.js
@@ -498,15 +498,44 @@ export async function runScan(root, config, options = {}) {
 
   const lock = await acquireLock(root, "scan");
   if (!lock.acquired) {
-    progress.log(`scan: ${lock.message}`);
-    return;
+    return emitLockContention("scan", lock, progress, config, options);
   }
 
   try {
-    await _runScanInner(root, config, options, progress);
+    return await _runScanInner(root, config, options, progress);
   } finally {
     await lock.release();
   }
+}
+
+async function emitLockContention(phase, lock, progress, config, options) {
+  const commandName = options.commandName || phase;
+  const result = {
+    command: commandName,
+    status: "blocked",
+    reason: "lock_contention",
+    phase,
+    holder: lock.holder || null,
+    message: lock.message,
+    wrote: [],
+  };
+  progress.log(`${phase}: ${lock.message}`);
+  if (!options.skipOutput) {
+    progress.setCommand(commandName);
+  }
+  if (phase === "scan") {
+    progress.setScan(result);
+  } else if (phase === "doc") {
+    progress.setDoc(result);
+  }
+  if (!options.skipOutput && (config.json || !config._suppressProgress)) {
+    progress.json(result);
+  }
+  if (!options.skipFinalize) {
+    await progress.finalize();
+  }
+  process.exitCode = 1;
+  return result;
 }
 
 async function _runScanInner(root, config, options, progress) {
@@ -552,6 +581,7 @@ async function _runScanInner(root, config, options, progress) {
   if (!options.skipFinalize) {
     await progress.finalize();
   }
+  return result;
 }
 
 function createDependencyMap(modules, imports) {
@@ -624,12 +654,11 @@ export async function runDoc(root, config, options = {}) {
 
   const lock = await acquireLock(root, "doc");
   if (!lock.acquired) {
-    progress.log(`doc: ${lock.message}`);
-    return;
+    return emitLockContention("doc", lock, progress, config, options);
   }
 
   try {
-    await _runDocInner(root, config, options, progress);
+    return await _runDocInner(root, config, options, progress);
   } finally {
     await lock.release();
   }
@@ -1033,6 +1062,7 @@ async function _runDocInner(root, config, options, progress) {
     if (!options.skipFinalize) {
       await progress.finalize();
     }
+    return result;
   } finally {
     if (db) {
       closeIndexDatabase(db);
@@ -1073,6 +1103,23 @@ export async function runValidate(root, config, options = {}) {
   }
 }
 
+async function emitBlockedUpdate(commandName, phase, phaseResult, progress, options) {
+  const blocked = {
+    command: commandName,
+    status: "blocked",
+    reason: "lock_contention",
+    blocked_phase: phase,
+    holder: phaseResult.holder || null,
+    message: phaseResult.message,
+    ...(options.preflight ? { repo_sync: options.preflight } : {}),
+  };
+  progress.log(`${commandName}: blocked at ${phase} phase — ${phaseResult.message}`);
+  progress.json(blocked);
+  await progress.finalize();
+  process.exitCode = 1;
+  return blocked;
+}
+
 export async function runUpdate(root, config, options = {}) {
   const commandName = options.commandName || "up";
   const ghostRunId = (config.ghost || config.ghostMode) ? `ghost_${Date.now()}` : null;
@@ -1081,10 +1128,16 @@ export async function runUpdate(root, config, options = {}) {
   const scanSnapshot = config.dryRun ? await buildRepositoryIndex(root, config) : null;
   progress.setCommand(commandName);
   progress.percent(commandName, 0, "starting");
-  await runScan(root, config, { reporter: progress, skipFinalize: true, skipOutput: true, ghostRunId, scanSnapshot });
+  const scanResult = await runScan(root, config, { reporter: progress, skipFinalize: true, skipOutput: true, ghostRunId, scanSnapshot });
+  if (scanResult?.status === "blocked") {
+    return emitBlockedUpdate(commandName, "scan", scanResult, progress, options);
+  }
   progress.percent(commandName, 33, "scan complete");
   if (config.docs) {
-    await runDoc(root, config, { reporter: progress, skipFinalize: true, skipOutput: true, ghostRunId, scanSnapshot });
+    const docResult = await runDoc(root, config, { reporter: progress, skipFinalize: true, skipOutput: true, ghostRunId, scanSnapshot });
+    if (docResult?.status === "blocked") {
+      return emitBlockedUpdate(commandName, "doc", docResult, progress, options);
+    }
     progress.percent(commandName, 67, "doc complete");
   } else {
     progress.log("doc: skipped (set --docs=true to generate docs during update)");

--- a/test/lock-contention.test.js
+++ b/test/lock-contention.test.js
@@ -1,0 +1,123 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { runCli } from "../src/main.js";
+
+async function setupBlockedRepo(prefix) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, ".agents"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, ".agents", ".lock"),
+    JSON.stringify({
+      pid: process.pid,
+      operation: "scan",
+      acquired_at: Date.now(),
+      host: os.hostname(),
+    }),
+    "utf8",
+  );
+  return root;
+}
+
+function captureStdout(fn) {
+  return async () => {
+    const originalLog = console.log;
+    const captured = [];
+    console.log = (...args) => {
+      captured.push(args.map((value) => (typeof value === "string" ? value : JSON.stringify(value))).join(" "));
+    };
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await fn(captured);
+    } finally {
+      console.log = originalLog;
+      process.exitCode = originalExitCode;
+    }
+  };
+}
+
+test("runCli scan exits non-zero and emits a blocked JSON payload when the lock is held", captureStdout(async (captured) => {
+  const root = await setupBlockedRepo("agentify-scan-blocked-");
+
+  await runCli(["scan", "--root", root, "--json"]);
+
+  assert.equal(process.exitCode, 1, "scan should exit non-zero on lock contention");
+
+  const dbExists = await fs.access(path.join(root, ".agents", "index.db")).then(() => true).catch(() => false);
+  assert.equal(dbExists, false, "scan must not write the index when blocked");
+
+  const payloads = captured
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+  const blocked = payloads.find((value) => value && value.status === "blocked");
+  assert.ok(blocked, "scan should emit a structured JSON payload on contention");
+  assert.equal(blocked.command, "scan");
+  assert.equal(blocked.reason, "lock_contention");
+  assert.equal(blocked.phase, "scan");
+  assert.ok(blocked.holder, "blocked payload should include the lock holder");
+  assert.match(blocked.message, /Lock held by PID/);
+}));
+
+test("runCli doc exits non-zero and emits a blocked JSON payload when the lock is held", captureStdout(async (captured) => {
+  const root = await setupBlockedRepo("agentify-doc-blocked-");
+
+  await runCli(["doc", "--root", root, "--json"]);
+
+  assert.equal(process.exitCode, 1, "doc should exit non-zero on lock contention");
+
+  const payloads = captured
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+  const blocked = payloads.find((value) => value && value.status === "blocked");
+  assert.ok(blocked, "doc should emit a structured JSON payload on contention");
+  assert.equal(blocked.command, "doc");
+  assert.equal(blocked.reason, "lock_contention");
+  assert.equal(blocked.phase, "doc");
+}));
+
+test("runCli up exits non-zero, reports the blocked phase, and does not claim scan completion", captureStdout(async (captured) => {
+  const root = await setupBlockedRepo("agentify-up-blocked-");
+
+  await runCli(["up", "--root", root, "--json"]);
+
+  assert.equal(process.exitCode, 1, "up should exit non-zero when scan is blocked");
+
+  const allOutput = captured.join("\n");
+  assert.ok(
+    !/scan complete/.test(allOutput),
+    "up must not log 'scan complete' when scan was skipped due to a held lock",
+  );
+
+  const payloads = captured
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+  const blocked = payloads.find((value) => value && value.status === "blocked");
+  assert.ok(blocked, "up should emit a structured JSON payload on contention");
+  assert.equal(blocked.command, "up");
+  assert.equal(blocked.reason, "lock_contention");
+  assert.equal(blocked.blocked_phase, "scan");
+  assert.ok(blocked.holder, "up blocked payload should include the lock holder");
+}));


### PR DESCRIPTION
## Summary
- `runScan` / `runDoc` now treat lock contention as a structured failure: they emit a `status: "blocked"` JSON payload (with the lock holder), set `process.exitCode = 1`, and skip writing artifacts.
- `runUpdate` checks the result of each phase and short-circuits with a `blocked` payload instead of logging `scan complete` / `doc complete` for a phase that never ran.
- Added regression coverage in `test/lock-contention.test.js` for blocked `scan`, blocked `doc`, and blocked `up` flows.

Closes #80

## Test plan
- [x] `node --test test/lock-contention.test.js` — 3 new tests pass
- [x] `node --test test/concurrency.test.js test/lock.test.js test/update.test.js` — green
- [x] Re-ran the issue's repro: exit code is `1`, structured JSON payload is emitted, `.agents/index.db` is not created
- [ ] Note: `test/main.test.js` has one pre-existing failure (`runCli exec refreshes stale artifacts after a failing command mutates tracked files`) that reproduces on `main` and is unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)