### PR TITLE
fix(session): validate session ids against path traversal

### DIFF
--- a/src/core/session.js
+++ b/src/core/session.js
@@ -13,6 +13,33 @@ function generateSessionId() {
   return `sess_${ts}_${rand}`;
 }
 
+const SESSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+const SESSION_ID_MAX_LENGTH = 128;
+
+export function validateSessionId(sessionId, label = "session id") {
+  if (typeof sessionId !== "string" || sessionId.length === 0) {
+    throw new Error(`Invalid ${label}: must be a non-empty string`);
+  }
+  if (sessionId.length > SESSION_ID_MAX_LENGTH) {
+    throw new Error(`Invalid ${label}: exceeds maximum length of ${SESSION_ID_MAX_LENGTH} characters`);
+  }
+  if (!SESSION_ID_PATTERN.test(sessionId)) {
+    throw new Error(`Invalid ${label}: must contain only letters, digits, "_" or "-" and start with a letter or digit`);
+  }
+  return sessionId;
+}
+
+function resolveSessionDirSafely(root, sessionId, label = "session id") {
+  validateSessionId(sessionId, label);
+  const sessionsRoot = path.resolve(root, ".agents", "session");
+  const sessionDir = path.resolve(sessionsRoot, sessionId);
+  const expectedPrefix = sessionsRoot + path.sep;
+  if (!sessionDir.startsWith(expectedPrefix) || path.dirname(sessionDir) !== sessionsRoot) {
+    throw new Error(`Invalid ${label}: resolved path escapes \`.agents/session/\``);
+  }
+  return sessionDir;
+}
+
 function bytes(value) {
   return Buffer.byteLength(value, "utf8");
 }
@@ -319,7 +346,15 @@ export async function forkSession(root, config, options = {}) {
   let parentRunHistory = [];
   let parentRollingSummary = "";
   if (options.from) {
-    const parentDir = path.join(root, ".agents", "session", options.from);
+    const parentDir = resolveSessionDirSafely(root, options.from, "parent session id");
+    const parentManifestPath = path.join(parentDir, "session-manifest.json");
+    if (!(await exists(parentManifestPath))) {
+      throw new Error(`Parent session ${options.from} not found`);
+    }
+    const parentManifest = await readJson(parentManifestPath);
+    if (parentManifest?.session_id !== options.from) {
+      throw new Error(`Parent session manifest session_id "${parentManifest?.session_id}" does not match requested id "${options.from}"`);
+    }
     const checklistPath = path.join(parentDir, "checklist.json");
     if (await exists(checklistPath)) {
       parentChecklist = await readJson(checklistPath);
@@ -381,7 +416,7 @@ export async function listSessions(root) {
 }
 
 export async function resumeSession(root, sessionId) {
-  const sessionDir = path.join(root, ".agents", "session", sessionId);
+  const sessionDir = resolveSessionDirSafely(root, sessionId);
   const manifestPath = path.join(sessionDir, "session-manifest.json");
 
   if (!(await exists(manifestPath))) {
@@ -389,6 +424,9 @@ export async function resumeSession(root, sessionId) {
   }
 
   const manifest = await readJson(manifestPath);
+  if (manifest?.session_id !== sessionId) {
+    throw new Error(`Session manifest session_id "${manifest?.session_id}" does not match requested id "${sessionId}"`);
+  }
   const context = await readJson(path.join(sessionDir, "context.json"));
   const bootstrapPath = path.join(sessionDir, "bootstrap.md");
   const bootstrap = (await exists(bootstrapPath))

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import { runExec } from "./core/exec.js";
 import { installHooks, removeHooks, statusHooks } from "./core/hooks.js";
 import { queryOwner, queryDeps, queryChanged, querySearch } from "./core/query.js";
 import { buildExecutionPlan } from "./core/planner.js";
-import { forkSession, listSessions, resolveSessionProvider, resumeSession } from "./core/session.js";
+import { forkSession, listSessions, resolveSessionProvider, resumeSession, validateSessionId } from "./core/session.js";
 import { loadAutomaticRunMemory, loadAutomaticSessionMemory } from "./core/session-memory.js";
 import { runDoctor } from "./core/toolchain.js";
 import { garbageCollect, cacheStatus } from "./core/cache.js";
@@ -168,11 +168,11 @@ export function buildSessionPrompt(bootstrap, userPrompt, memoryMarkdown = "") {
 
 function resolveSessionIdForResume(args) {
   if (args.session) {
-    return { sessionId: String(args.session), promptStartIndex: 2 };
+    return { sessionId: validateSessionId(String(args.session), "--session id"), promptStartIndex: 2 };
   }
   const positional = args._[2];
   if (positional) {
-    return { sessionId: String(positional), promptStartIndex: 3 };
+    return { sessionId: validateSessionId(String(positional), "session id"), promptStartIndex: 3 };
   }
   throw new Error("sess resume requires --session <id> or sess resume <id>");
 }
@@ -560,8 +560,9 @@ export async function runCli(argv) {
         }
 
         if (subcommand === "fork") {
+          const fromId = args.from ? validateSessionId(String(args.from), "--from id") : null;
           const result = await forkSession(root, config, {
-            from: args.from || null,
+            from: fromId,
             provider: args.provider || null,
             name: args.name || null,
           });
@@ -642,10 +643,11 @@ export async function runCli(argv) {
           let sessionDir;
 
           if (args.session) {
-            sessionResult = await resumeSession(root, String(args.session));
+            sessionResult = await resumeSession(root, validateSessionId(String(args.session), "--session id"));
           } else {
+            const fromId = args.from ? validateSessionId(String(args.from), "--from id") : null;
             const created = await forkSession(root, config, {
-              from: args.from || null,
+              from: fromId,
               provider: args.provider || null,
               name: args.name || null,
             });

--- a/test/sess-cli-security.test.js
+++ b/test/sess-cli-security.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const cliPath = path.resolve(fileURLToPath(import.meta.url), "..", "..", "src", "cli.js");
+
+async function initGitRepo(root) {
+  await execFileAsync("git", ["init"], { cwd: root });
+  await execFileAsync("git", ["config", "user.name", "Agentify Tests"], { cwd: root });
+  await execFileAsync("git", ["config", "user.email", "agentify-tests@example.com"], { cwd: root });
+  await execFileAsync("git", ["add", "."], { cwd: root });
+  await execFileAsync("git", ["commit", "-m", "initial"], { cwd: root });
+}
+
+async function runCli(args, cwd) {
+  try {
+    const result = await execFileAsync(process.execPath, [cliPath, ...args], { cwd });
+    return { code: 0, stdout: result.stdout, stderr: result.stderr };
+  } catch (err) {
+    return {
+      code: typeof err.code === "number" ? err.code : 1,
+      stdout: err.stdout || "",
+      stderr: err.stderr || String(err.message || err),
+    };
+  }
+}
+
+test("sess resume rejects path-like ids without touching the filesystem", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-cli-resume-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const probeDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-cli-probe-"));
+  await fs.writeFile(path.join(probeDir, "session-manifest.json"), JSON.stringify({ session_id: "forged" }));
+  await fs.writeFile(path.join(probeDir, "context.json"), JSON.stringify({}));
+  await fs.writeFile(path.join(probeDir, "bootstrap.md"), "forged");
+
+  const escapeId = path.relative(path.join(root, ".agents", "session"), probeDir);
+
+  for (const malicious of [escapeId, "../escape", "a/../b", "/abs/path", "with space"]) {
+    const result = await runCli(["sess", "resume", "--session", malicious, "--json"], root);
+    assert.notEqual(result.code, 0, `expected non-zero exit for ${JSON.stringify(malicious)}`);
+    assert.match(result.stderr, /Invalid .*id/, `expected validation error for ${JSON.stringify(malicious)}`);
+  }
+
+  const positional = await runCli(["sess", "resume", "../escape", "--json"], root);
+  assert.notEqual(positional.code, 0);
+  assert.match(positional.stderr, /Invalid .*id/);
+});
+
+test("sess fork rejects path-like --from values", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-cli-fork-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  for (const malicious of ["../escape", "a/../b", "/abs/path", "with space"]) {
+    const result = await runCli(["sess", "fork", "--from", malicious, "--json"], root);
+    assert.notEqual(result.code, 0, `expected non-zero exit for ${JSON.stringify(malicious)}`);
+    assert.match(result.stderr, /Invalid .*id/, `expected validation error for ${JSON.stringify(malicious)}`);
+  }
+});
+
+test("sess run rejects path-like --session and --from values", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-cli-run-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const session = await runCli(["sess", "run", "--session", "../escape", "--json"], root);
+  assert.notEqual(session.code, 0);
+  assert.match(session.stderr, /Invalid .*id/);
+
+  const from = await runCli(["sess", "run", "--from", "../escape", "--json"], root);
+  assert.notEqual(from.code, 0);
+  assert.match(from.stderr, /Invalid .*id/);
+});

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -8,7 +8,7 @@ import { promisify } from "node:util";
 
 import { loadConfig } from "../src/core/config.js";
 import { closeIndexDatabase, inTransaction, openIndexDatabase, writeRepositoryIndex } from "../src/core/db.js";
-import { forkSession, resolveSessionProvider, resumeSession } from "../src/core/session.js";
+import { forkSession, resolveSessionProvider, resumeSession, validateSessionId } from "../src/core/session.js";
 import {
   getSessionArtifactPaths,
   loadAutomaticRunMemory,
@@ -271,4 +271,97 @@ test("loadAutomaticRunMemory uses MemPalace automatically when the CLI is availa
 test("normalizeInteractiveCapture strips script noise and ANSI sequences", () => {
   const normalized = normalizeInteractiveCapture("\u0004\u0008\u0008Script started on now\n\u001b[31mhello\u001b[0m\r\nScript done on later\n");
   assert.equal(normalized, "hello");
+});
+
+test("validateSessionId accepts generated ids and rejects path-like values", () => {
+  assert.equal(validateSessionId("sess_20260101000000_abcdef"), "sess_20260101000000_abcdef");
+  assert.equal(validateSessionId("safe-id_42"), "safe-id_42");
+
+  for (const bad of [
+    "",
+    "../escape",
+    "a/../b",
+    "a/b",
+    "a\\b",
+    "/abs/path",
+    ".hidden",
+    "..",
+    "with space",
+    "has.dot",
+    "_leading-underscore",
+    "-leading-dash",
+  ]) {
+    assert.throws(() => validateSessionId(bad), /Invalid session id/, `expected ${JSON.stringify(bad)} to be rejected`);
+  }
+
+  assert.throws(() => validateSessionId(null), /Invalid session id/);
+  assert.throws(() => validateSessionId(123), /Invalid session id/);
+  assert.throws(() => validateSessionId("a".repeat(200)), /Invalid session id/);
+});
+
+test("resumeSession refuses path traversal ids before touching disk", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-traversal-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const probeDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-probe-"));
+  await fs.writeFile(path.join(probeDir, "session-manifest.json"), JSON.stringify({ session_id: "forged" }));
+  await fs.writeFile(path.join(probeDir, "context.json"), JSON.stringify({}));
+  await fs.writeFile(path.join(probeDir, "bootstrap.md"), "forged");
+
+  const relativeAttack = path.relative(path.join(root, ".agents", "session"), probeDir);
+
+  for (const malicious of [relativeAttack, "../escape", "a/../b", "/abs", "with space"]) {
+    await assert.rejects(
+      () => resumeSession(root, malicious),
+      /Invalid session id/,
+      `expected ${JSON.stringify(malicious)} to be rejected`,
+    );
+  }
+});
+
+test("resumeSession rejects manifests whose session_id does not match the directory", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-mismatch-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex" });
+  const created = await forkSession(root, config, { name: "real" });
+
+  const manifestPath = path.join(created.sessionDir, "session-manifest.json");
+  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+  manifest.session_id = "sess_forged_id";
+  await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+  await assert.rejects(
+    () => resumeSession(root, created.sessionId),
+    /does not match requested id/,
+  );
+});
+
+test("forkSession rejects path-like parent ids and mismatched parent manifests", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-fork-traversal-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex" });
+
+  for (const malicious of ["../escape", "a/../b", "/abs", "with space", ".."]) {
+    await assert.rejects(
+      () => forkSession(root, config, { from: malicious }),
+      /Invalid parent session id/,
+      `expected ${JSON.stringify(malicious)} to be rejected`,
+    );
+  }
+
+  const parent = await forkSession(root, config, { name: "parent" });
+  const parentManifestPath = path.join(parent.sessionDir, "session-manifest.json");
+  const parentManifest = JSON.parse(await fs.readFile(parentManifestPath, "utf8"));
+  parentManifest.session_id = "sess_forged_parent";
+  await fs.writeFile(parentManifestPath, JSON.stringify(parentManifest, null, 2));
+
+  await assert.rejects(
+    () => forkSession(root, config, { from: parent.sessionId }),
+    /does not match requested id/,
+  );
 });


### PR DESCRIPTION
## Summary
Closes #84.

`sess resume`, `sess run --session`, and `sess fork --from` accepted arbitrary CLI-supplied strings and joined them straight into `.agents/session/<id>/...`, letting `..` segments escape the session store and load forged manifests/artifacts from anywhere on disk.

## Changes
- Add `validateSessionId(id)` (strict allowlist: `/^[A-Za-z0-9][A-Za-z0-9_-]*$/`, max 128 chars) and a `resolveSessionDirSafely(root, id)` boundary check in `src/core/session.js`.
- Apply validation at the CLI layer in `src/main.js`: `--session`, the `sess resume` positional id, `sess fork --from`, and `sess run --session`/`--from`.
- Apply validation again at the helper layer (`forkSession`, `resumeSession`) — defense in depth, since helpers are the last boundary before disk access.
- Reject resumed/forked sessions whose on-disk `session-manifest.json` carries a `session_id` that disagrees with the requested directory name. This prevents a forged manifest from steering downstream artifact writes (`memory-context.md`, `transcript.md`, `launches.jsonl`, etc.).

## Test plan
- [x] `node --test test/session.test.js` — new helper-level coverage (validator, traversal rejection, manifest mismatch on resume + fork) plus all existing tests pass.
- [x] `node --test test/sess-cli-security.test.js` — new CLI-level coverage exercises `sess resume`, `sess fork --from`, and `sess run --session`/`--from` with path-like inputs and asserts non-zero exit + clear error.
- [x] `npm test` — only the two pre-existing failures (`runExec refreshes…` / `runCli exec refreshes…`) remain, and they reproduce on the untouched base branch — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)