### PR TITLE
fix: refresh exec docs after mutating commands

### DIFF
--- a/src/core/exec.js
+++ b/src/core/exec.js
@@ -291,11 +291,7 @@ export async function runExec(root, config, agentCommand, flags) {
 
   try {
     await runScan(root, config, { skipFinalize: true });
-    if (config.docs) {
-      await runDoc(root, config, { skipFinalize: true });
-    } else {
-      ui.log("doc: skipped (set --docs=true to generate docs during refresh)");
-    }
+    await runDoc(root, config, { skipFinalize: true });
   } catch (error) {
     ui.error(`refresh error: ${error.message}`);
     if (flags.failOnStale && !commandFailed) {


### PR DESCRIPTION
## Summary
- Regenerate Agentify docs during exec post-command refresh whenever tracked files changed, even when config docs defaults to false.
- Keeps exec repair artifacts consistent after failing mutating commands while leaving the regular up command docs gate unchanged.

Fixes https://github.com/ixigo/agentify/issues/76

## Tests
- node --test test/exec.test.js test/main.test.js
- env -u AGENTIFY_MEMPALACE_CMD npm test

Note: plain npm test in this pane failed 150/152 because AGENTIFY_MEMPALACE_CMD points at a real external MemPalace binary, which changes the session-memory test backend selection. The isolated test run with that variable unset passed 152/152.