### PR TITLE
fix: ignore generated Agentify artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Depending on the command, Agentify can create or refresh:
 
 ```text
 .agentify.yaml
+.gitignore
 .agentignore
 .guardrails
 .agentify/work/
@@ -112,7 +113,7 @@ docs/repo-map.md
 docs/modules/
 ```
 
-These files give agents a stable map of the repo, guardrails for safe edits, durable session context, and validation evidence.
+Commit `.agentify.yaml`, `.agentignore`, `.guardrails`, and the managed `.gitignore` block when you want Agentify policy shared with the repo. The managed `.gitignore` block keeps local/generated runtime output such as `.agents/`, `.agentify/work/`, `AGENTIFY.md`, `docs/repo-map.md`, `docs/modules/`, `output.txt`, and `agentify-report.html` out of Git by default.
 
 ## Best First Workflow
 

--- a/docs/DETAILED_README.md
+++ b/docs/DETAILED_README.md
@@ -511,11 +511,16 @@ docs/modules/*.md
 
 What creates them:
 
-- `init` creates baseline config and working directories.
+- `init` creates baseline config and working directories, and installs a managed `.gitignore` block for local/generated Agentify output.
 - `index` or `scan` writes the SQLite index and refreshes repo map basics.
 - `doc` writes markdown docs, run reports, and eligible headers.
 - `sess *` writes session manifests and bootstrap context under `.agents/session/`.
 - `--ghost` writes isolated outputs under `.current_session/`.
+
+Git hygiene model:
+
+- Commit `.agentify.yaml`, `.agentignore`, `.guardrails`, and the managed `.gitignore` block when Agentify policy should be shared across the repository.
+- Keep `.agents/`, `.agentify/work/`, `.current_session/`, `AGENTIFY.md`, `docs/repo-map.md`, `docs/modules/`, `output.txt`, and `agentify-report.html` local/generated; Agentify ignores them in Git by default.
 
 ## Development
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -166,6 +166,7 @@ agentify check
 After `agentify this` or `agentify init`:
 
 - `.agentify.yaml`
+- `.gitignore` with a managed Agentify generated-artifact block
 - `.agentignore`
 - `.guardrails`
 - `.agentify/work/`
@@ -189,6 +190,8 @@ Most commands also write run evidence to:
 
 - `output.txt`
 - `agentify-report.html`
+
+Commit `.agentify.yaml`, `.agentignore`, `.guardrails`, and the managed `.gitignore` block when you want shared Agentify policy in the repo. The `.gitignore` block keeps `.agents/`, `.agentify/work/`, `.current_session/`, generated docs, and run reports out of normal Git status by default.
 
 ## How To Verify A Repo Is Really Ready
 

--- a/src/core/commands.js
+++ b/src/core/commands.js
@@ -7,6 +7,7 @@ import { ensureDir, exists, relative, walkFiles, writeJson, writeText } from "./
 import { getHeadCommit } from "./git.js";
 import { buildDependencyGraph, rankKeyFiles } from "./graph.js";
 import { stripLeadingAgentifyHeader, updateFileHeader } from "./headers.js";
+import { ensureAgentifyGitignore } from "./gitignore.js";
 import { createProvider, renderModuleMarkdown, summarizeModule } from "./provider.js";
 import { runProjectTests } from "./project-tests.js";
 import { createRunReporter } from "./run-report.js";
@@ -286,7 +287,7 @@ function renderDefaultGuardrails() {
 ## Files To Avoid Touching Without Intent
 - \`node_modules/\`
 - lockfiles unless the task changes dependencies
-- repo config such as \`.agentify.yaml\`, \`.agentignore\`, and \`.guardrails\` unless the task is about repo policy or tooling
+- repo config such as \`.agentify.yaml\`, \`.gitignore\`, \`.agentignore\`, and \`.guardrails\` unless the task is about repo policy or tooling
 `;
 }
 
@@ -308,6 +309,7 @@ export async function ensureBaselineArtifacts(root, config) {
   await ensureDir(path.join(root, "docs", "modules"));
   await writeTextIfMissing(path.join(root, ".agentignore"), renderDefaultAgentignore());
   await writeTextIfMissing(path.join(root, ".guardrails"), renderDefaultGuardrails());
+  await ensureAgentifyGitignore(root);
 }
 
 function resolveArtifactRoot(root, config, runId) {

--- a/src/core/gitignore.js
+++ b/src/core/gitignore.js
@@ -1,0 +1,82 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { writeText } from "./fs.js";
+
+export const AGENTIFY_GITIGNORE_START = "# >>> agentify generated artifacts";
+export const AGENTIFY_GITIGNORE_END = "# <<< agentify generated artifacts";
+
+export const AGENTIFY_GITIGNORE_PATTERNS = [
+  ".agents/",
+  ".agentify/work/",
+  ".current_session/",
+  "AGENTIFY.md",
+  "docs/repo-map.md",
+  "docs/modules/",
+  "output.txt",
+  "agentify-report.html",
+];
+
+export function renderAgentifyGitignoreBlock() {
+  return [
+    AGENTIFY_GITIGNORE_START,
+    "# Local/runtime Agentify output. Commit .agentify.yaml, .agentignore, and .guardrails when you want repo-shared policy.",
+    ...AGENTIFY_GITIGNORE_PATTERNS,
+    AGENTIFY_GITIGNORE_END,
+    "",
+  ].join("\n");
+}
+
+function normalizeText(text) {
+  return text.replace(/\r\n/g, "\n");
+}
+
+function applyAgentifyGitignoreBlock(existingText) {
+  const normalized = normalizeText(existingText || "");
+  const block = renderAgentifyGitignoreBlock();
+  const startIndex = normalized.indexOf(AGENTIFY_GITIGNORE_START);
+  const endIndex = normalized.indexOf(AGENTIFY_GITIGNORE_END);
+
+  if (startIndex !== -1 && endIndex !== -1 && endIndex >= startIndex) {
+    const afterEnd = endIndex + AGENTIFY_GITIGNORE_END.length;
+    const nextText = `${normalized.slice(0, startIndex)}${block}${normalized.slice(afterEnd).replace(/^\n+/, "")}`;
+    return nextText.endsWith("\n") ? nextText : `${nextText}\n`;
+  }
+
+  const prefix = normalized.trimEnd();
+  if (!prefix) {
+    return block;
+  }
+  return `${prefix}\n\n${block}`;
+}
+
+export async function ensureAgentifyGitignore(root, { dryRun = false } = {}) {
+  const gitignorePath = path.join(root, ".gitignore");
+  let existing = null;
+
+  try {
+    existing = await fs.readFile(gitignorePath, "utf8");
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  const next = applyAgentifyGitignoreBlock(existing || "");
+  const changed = existing === null || normalizeText(existing) !== next;
+
+  if (changed && !dryRun) {
+    await writeText(gitignorePath, next);
+  }
+
+  return {
+    path: gitignorePath,
+    existed: existing !== null,
+    changed,
+    status: existing === null
+      ? dryRun ? "would_create" : "created"
+      : changed
+        ? dryRun ? "would_update" : "updated"
+        : "unchanged",
+  };
+}

--- a/src/core/repo-sync.js
+++ b/src/core/repo-sync.js
@@ -3,6 +3,7 @@ import path from "node:path";
 import { ensureBaselineArtifacts, runUpdate } from "./commands.js";
 import { syncConfigFile } from "./config.js";
 import { exists } from "./fs.js";
+import { ensureAgentifyGitignore } from "./gitignore.js";
 import { syncManagedHooks } from "./hooks.js";
 import { syncProjectBuiltinSkills } from "./skills.js";
 import * as ui from "./ui.js";
@@ -22,16 +23,17 @@ async function syncBaselineArtifacts(root, config) {
     before.set(relativePath, await exists(path.join(root, relativePath)));
   }
 
+  const gitignore = await ensureAgentifyGitignore(root, { dryRun: config.dryRun });
   await ensureBaselineArtifacts(root, config);
 
-  return BASELINE_ARTIFACTS.map((relativePath) => {
+  return [gitignore, ...BASELINE_ARTIFACTS.map((relativePath) => {
     const existed = before.get(relativePath);
     return {
       path: path.join(root, relativePath),
       existed,
       status: existed ? "unchanged" : config.dryRun ? "would_create" : "created",
     };
-  });
+  })];
 }
 
 function logSyncSummary(result) {

--- a/src/core/validate.js
+++ b/src/core/validate.js
@@ -13,6 +13,7 @@ const ALLOWED_DOC_PATHS = [
   /^\.agentify\.yaml$/,
   /^\.agentignore$/,
   /^\.guardrails$/,
+  /^\.gitignore$/,
   /^\.agentify\/work\//,
   /^docs\//,
   /^\.agents\//,
@@ -33,7 +34,7 @@ export const FAILURE_CATEGORIES = {
 
 const REMEDIATION_HINTS = {
   [FAILURE_CATEGORIES.UNSAFE_PATH]:
-    "Only recognized Agentify paths (.agents/, docs/, .agentify/work/, provider skill dirs, .guardrails, .agentignore) and code files with header-only changes are allowed. Run 'git checkout -- <path>' to revert.",
+    "Only recognized Agentify paths (.agents/, docs/, .agentify/work/, provider skill dirs, .guardrails, .agentignore, .gitignore) and code files with header-only changes are allowed. Run 'git checkout -- <path>' to revert.",
   [FAILURE_CATEGORIES.CODE_BODY_CHANGED]:
     "Agentify only modifies @agentify headers. If you edited this file intentionally, commit it separately before running agentify.",
   [FAILURE_CATEGORIES.FRESHNESS_STALE]:

--- a/src/main.js
+++ b/src/main.js
@@ -362,7 +362,7 @@ export async function runCli(argv) {
             command: "init",
             root,
             dry_run: Boolean(config.dryRun),
-            wrote: config.dryRun ? [] : [".agentify.yaml", ".agentignore", ".guardrails", ".agentify/work", ".agents", "docs/modules"],
+            wrote: config.dryRun ? [] : [".agentify.yaml", ".gitignore", ".agentignore", ".guardrails", ".agentify/work", ".agents", "docs/modules"],
           }, null, 2));
         } else {
           success("Initialized agentify artifacts");

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -146,9 +146,42 @@ test("runCli init writes baseline local work and guardrail files", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-init-"));
   await runCli(["init", "--root", root]);
 
+  const gitignore = await fs.readFile(path.join(root, ".gitignore"), "utf8");
+  assert.match(gitignore, /# >>> agentify generated artifacts/);
+  assert.match(gitignore, /^\.agents\/$/m);
+  assert.match(gitignore, /^docs\/modules\/$/m);
+  assert.match(gitignore, /^agentify-report\.html$/m);
+  assert.doesNotMatch(gitignore, /^\.agentify\.yaml$/m);
   await assert.doesNotReject(() => fs.access(path.join(root, ".agentignore")));
   await assert.doesNotReject(() => fs.access(path.join(root, ".guardrails")));
   await assert.doesNotReject(() => fs.access(path.join(root, ".agentify", "work")));
+});
+
+test("runCli init preserves existing gitignore entries while adding Agentify ignores", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-init-gitignore-"));
+  await fs.writeFile(path.join(root, ".gitignore"), "node_modules/\n", "utf8");
+  await runCli(["init", "--root", root]);
+
+  const gitignore = await fs.readFile(path.join(root, ".gitignore"), "utf8");
+  assert.match(gitignore, /^node_modules\/$/m);
+  assert.match(gitignore, /# >>> agentify generated artifacts/);
+  assert.match(gitignore, /^AGENTIFY\.md$/m);
+  assert.match(gitignore, /^output\.txt$/m);
+});
+
+test("runCli generated artifacts stay out of git status after repo config is committed", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-gitignore-clean-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, "src", "auth"), { recursive: true });
+  await fs.writeFile(path.join(root, "src", "auth", "index.ts"), "export const login = () => true;\n", "utf8");
+
+  await runCli(["init", "--root", root]);
+  await initGitRepo(root);
+  await runCli(["scan", "--root", root]);
+  await runCli(["doc", "--root", root]);
+
+  const { stdout } = await execFileAsync("git", ["status", "--short"], { cwd: root });
+  assert.equal(stdout, "");
 });
 
 test("runCli plan reports actionable guidance when the index is missing", async () => {
@@ -251,11 +284,14 @@ test("runCli sync upgrades repo-owned Agentify assets and emits sync json", asyn
   assert.equal(payload.repo_sync.baseline.some((item) => item.status === "created"), true);
 
   const configText = await fs.readFile(path.join(root, ".agentify.yaml"), "utf8");
+  const gitignoreText = await fs.readFile(path.join(root, ".gitignore"), "utf8");
   const skillText = await fs.readFile(path.join(root, ".codex", "skills", "grill-me", "SKILL.md"), "utf8");
   const hookText = await fs.readFile(path.join(root, ".git", "hooks", "post-merge"), "utf8");
 
   assert.match(configText, /^semantic:/m);
   assert.match(configText, /^toolchain:/m);
+  assert.match(gitignoreText, /# >>> agentify generated artifacts/);
+  assert.match(gitignoreText, /^\.agents\/$/m);
   assert.match(skillText, /Interview the user relentlessly/);
   assert.match(hookText, /agentify scan --json >\/dev\/null 2>&1 \|\| true/);
   await assert.doesNotReject(() => fs.access(path.join(root, ".agentignore")));


### PR DESCRIPTION
## Summary
- add a managed Agentify `.gitignore` block for generated/runtime artifacts
- install the block through baseline creation and sync flows
- document committed config vs local generated outputs

Closes #66

## Tests
- npm test -- --test-name-pattern "runCli init|generated artifacts stay out|sync upgrades repo-owned|validateRepo allows"
- git diff --check

## Notes
- Full `npm test` was also run after installing dependencies. It still fails in unrelated existing areas: exec stale-artifact refresh expectations and concurrent MemPalace environment-sensitive session-memory tests.