### PR TITLE
Extract shared session launch preparation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -48,6 +48,8 @@ const BOOLEAN_FLAGS = new Set([
   "hook",
 ]);
 
+const DEFAULT_SESSION_TASK = "Continue this session from the latest repository state.";
+
 function toCamelCaseFlag(key) {
   return key.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
 }
@@ -154,7 +156,7 @@ export function buildExecutionPrompt(basePrompt, memoryMarkdown = "") {
 }
 
 export function buildSessionPrompt(bootstrap, userPrompt, memoryMarkdown = "") {
-  const task = userPrompt || "Continue this session from the latest repository state.";
+  const task = userPrompt || DEFAULT_SESSION_TASK;
   const sections = [
     "You are continuing an Agentify session.",
     "",
@@ -165,6 +167,48 @@ export function buildSessionPrompt(bootstrap, userPrompt, memoryMarkdown = "") {
   }
   sections.push("", `Current task: ${task}`);
   return sections.join("\n");
+}
+
+export async function prepareSessionLaunch(root, config, args, sessionResult, task) {
+  const memoryQuery = task || sessionResult.manifest.name || "";
+  const memoryContext = await loadAutomaticSessionMemory(root, sessionResult.manifest, config, memoryQuery);
+  const provider = hasOwn(args, "provider")
+    ? normalizeProvider(args.provider)
+    : normalizeProvider(resolveSessionProvider(sessionResult.manifest, config.provider));
+  const usingTemplateCommand = !args._exec?.length;
+  const providerOptions = getProviderTemplateOptions(args, root, provider, usingTemplateCommand);
+  const captureSettings = getSessionCaptureSettings(usingTemplateCommand, providerOptions);
+  const prompt = buildSessionPrompt(sessionResult.bootstrap, task, memoryContext.markdown);
+  const agentCommand = args._exec?.length
+    ? args._exec
+    : buildProviderTemplateCommand(
+      provider,
+      prompt,
+      providerOptions,
+    );
+  const sessionRecord = {
+    sessionId: sessionResult.manifest.session_id,
+    provider,
+    prompt,
+    task: task || DEFAULT_SESSION_TASK,
+    command: agentCommand,
+    memoryContext,
+    captureMode: captureSettings.captureMode,
+  };
+
+  return {
+    provider,
+    memoryContext,
+    prompt,
+    captureSettings,
+    agentCommand,
+    sessionRecord,
+    runExecConfig: { ...config, provider },
+    runExecFlags: getExecFlags(args, {
+      captureOutputMode: captureSettings.captureOutputMode,
+      sessionRecord,
+    }),
+  };
 }
 
 function resolveSessionIdForResume(args) {
@@ -569,39 +613,14 @@ export async function runCli(argv) {
             name: args.name || null,
           });
           const task = getPromptFromArgs(args, 2);
-          const memoryContext = await loadAutomaticSessionMemory(root, result.manifest, config, task || result.manifest.name || "");
-          const provider = hasOwn(args, "provider")
-            ? normalizeProvider(args.provider)
-            : normalizeProvider(resolveSessionProvider(result.manifest, config.provider));
-          const usingTemplateCommand = !args._exec?.length;
-          const providerOptions = getProviderTemplateOptions(args, root, provider, usingTemplateCommand);
-          const captureSettings = getSessionCaptureSettings(usingTemplateCommand, providerOptions);
-          const prompt = buildSessionPrompt(result.bootstrap, task, memoryContext.markdown);
-          const agentCommand = args._exec?.length
-            ? args._exec
-            : buildProviderTemplateCommand(
-              provider,
-              prompt,
-              providerOptions,
-            );
+          const launch = await prepareSessionLaunch(root, config, args, result, task);
 
           if (!config.json) {
             success(`Session forked: ${result.manifest.session_id}`);
             log(`Path: ${dim(result.sessionDir)}`);
           }
 
-          await runExec(root, { ...config, provider }, agentCommand, getExecFlags(args, {
-            captureOutputMode: captureSettings.captureOutputMode,
-            sessionRecord: {
-              sessionId: result.manifest.session_id,
-              provider,
-              prompt,
-              task: task || "Continue this session from the latest repository state.",
-              command: agentCommand,
-              memoryContext,
-              captureMode: captureSettings.captureMode,
-            },
-          }));
+          await runExec(root, launch.runExecConfig, launch.agentCommand, launch.runExecFlags);
           return;
         }
 
@@ -609,34 +628,9 @@ export async function runCli(argv) {
           const { sessionId, promptStartIndex } = resolveSessionIdForResume(args);
           const result = await resumeSession(root, sessionId);
           const task = getPromptFromArgs(args, promptStartIndex);
-          const memoryContext = await loadAutomaticSessionMemory(root, result.manifest, config, task || result.manifest.name || "");
-          const provider = hasOwn(args, "provider")
-            ? normalizeProvider(args.provider)
-            : normalizeProvider(resolveSessionProvider(result.manifest, config.provider));
-          const usingTemplateCommand = !args._exec?.length;
-          const providerOptions = getProviderTemplateOptions(args, root, provider, usingTemplateCommand);
-          const captureSettings = getSessionCaptureSettings(usingTemplateCommand, providerOptions);
-          const prompt = buildSessionPrompt(result.bootstrap, task, memoryContext.markdown);
-          const agentCommand = args._exec?.length
-            ? args._exec
-            : buildProviderTemplateCommand(
-              provider,
-              prompt,
-              providerOptions,
-            );
+          const launch = await prepareSessionLaunch(root, config, args, result, task);
 
-          await runExec(root, { ...config, provider }, agentCommand, getExecFlags(args, {
-            captureOutputMode: captureSettings.captureOutputMode,
-            sessionRecord: {
-              sessionId: result.manifest.session_id,
-              provider,
-              prompt,
-              task: task || "Continue this session from the latest repository state.",
-              command: agentCommand,
-              memoryContext,
-              captureMode: captureSettings.captureMode,
-            },
-          }));
+          await runExec(root, launch.runExecConfig, launch.agentCommand, launch.runExecFlags);
           return;
         }
 
@@ -665,39 +659,14 @@ export async function runCli(argv) {
             }
           }
 
-          const provider = hasOwn(args, "provider")
-            ? normalizeProvider(args.provider)
-            : normalizeProvider(resolveSessionProvider(sessionResult.manifest, config.provider));
-          const usingTemplateCommand = !args._exec?.length;
-          const providerOptions = getProviderTemplateOptions(args, root, provider, usingTemplateCommand);
-          const captureSettings = getSessionCaptureSettings(usingTemplateCommand, providerOptions);
           const task = getPromptFromArgs(args, 2);
-          const memoryContext = await loadAutomaticSessionMemory(root, sessionResult.manifest, config, task || sessionResult.manifest.name || "");
-          const prompt = buildSessionPrompt(sessionResult.bootstrap, task, memoryContext.markdown);
-          const agentCommand = args._exec?.length
-            ? args._exec
-            : buildProviderTemplateCommand(
-              provider,
-              prompt,
-              providerOptions,
-            );
+          const launch = await prepareSessionLaunch(root, config, args, sessionResult, task);
 
           if (config.json && sessionDir) {
             console.log(JSON.stringify({ ...sessionResult.manifest, session_dir: sessionDir }, null, 2));
           }
 
-          await runExec(root, { ...config, provider }, agentCommand, getExecFlags(args, {
-            captureOutputMode: captureSettings.captureOutputMode,
-            sessionRecord: {
-              sessionId: sessionResult.manifest.session_id,
-              provider,
-              prompt,
-              task: task || "Continue this session from the latest repository state.",
-              command: agentCommand,
-              memoryContext,
-              captureMode: captureSettings.captureMode,
-            },
-          }));
+          await runExec(root, launch.runExecConfig, launch.agentCommand, launch.runExecFlags);
           return;
         }
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -6,7 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
-import { buildExecutionPrompt, buildSessionPrompt, getProviderTemplateOptions, getSessionCaptureSettings, parseArgs, runCli } from "../src/main.js";
+import { buildExecutionPrompt, buildSessionPrompt, getProviderTemplateOptions, getSessionCaptureSettings, parseArgs, prepareSessionLaunch, runCli } from "../src/main.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -117,6 +117,56 @@ test("buildExecutionPrompt prepends automatic memory before a normal run prompt"
 
   assert.match(prompt, /Automatic Session Memory/);
   assert.ok(prompt.indexOf("Automatic Session Memory") < prompt.indexOf("Implement retry handling"));
+});
+
+test("prepareSessionLaunch keeps sess subcommands on the same runExec payload path", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-session-launch-"));
+  const sessionResult = {
+    manifest: {
+      session_id: "sess_shared_launch",
+      provider: "opencode",
+      name: "Shared launch session",
+    },
+    bootstrap: "# Session Context\n- Provider: opencode",
+  };
+  const config = {
+    provider: "claude",
+    session: {
+      memoryPromptMaxKb: 4,
+      memoryResults: 3,
+      memoryTurns: 6,
+    },
+  };
+  const task = "Finish launch preparation";
+  const commandArgs = {
+    fork: parseArgs(["sess", "fork", task]),
+    resume: parseArgs(["sess", "resume", "sess_shared_launch", task]),
+    run: parseArgs(["sess", "run", task]),
+  };
+
+  const launches = {};
+  for (const [subcommand, args] of Object.entries(commandArgs)) {
+    launches[subcommand] = await prepareSessionLaunch(root, config, args, sessionResult, task);
+  }
+
+  const baseline = launches.fork;
+  for (const launch of Object.values(launches)) {
+    assert.equal(launch.provider, "opencode");
+    assert.equal(launch.captureSettings.captureMode, "interactive-pty");
+    assert.equal(launch.runExecFlags.captureOutputMode, "pty");
+    assert.equal(launch.sessionRecord.sessionId, "sess_shared_launch");
+    assert.equal(launch.sessionRecord.provider, "opencode");
+    assert.equal(launch.sessionRecord.task, task);
+    assert.equal(launch.sessionRecord.memoryContext.backend, "none");
+    assert.equal(launch.sessionRecord.prompt, baseline.sessionRecord.prompt);
+    assert.deepEqual(launch.sessionRecord.command, baseline.sessionRecord.command);
+    assert.equal(launch.runExecConfig.provider, "opencode");
+    assert.equal(launch.runExecFlags.sessionRecord, launch.sessionRecord);
+  }
+
+  assert.match(baseline.prompt, /Current task: Finish launch preparation/);
+  assert.match(baseline.prompt, /Automatic Session Memory/);
+  assert.deepEqual(baseline.agentCommand.slice(0, 3), ["opencode", "--dir", root]);
 });
 
 test("runCli supports skill install with provider all", async () => {


### PR DESCRIPTION
## Summary
- Extract shared `prepareSessionLaunch()` for `sess fork`, `sess resume`, and `sess run`.
- Route provider resolution, automatic memory loading, prompt rendering, capture settings, agent command construction, and sessionRecord/runExec flags through the shared helper.
- Add a parity test covering prompt, capture mode, provider resolution, memory context, and session-record fields across the three sess subcommands.

Fixes #74

## Tests
- PASS: `node --test --test-name-pattern 'prepareSessionLaunch|buildSessionPrompt|getSessionCaptureSettings|getProviderTemplateOptions' test/main.test.js`\n- PASS: `node --test test/session.test.js test/session-structured.test.js`\n- FAIL: `pnpm test` currently fails in the pre-existing exec stale-doc mtime assertions at `test/exec.test.js:146` and `test/main.test.js:434`; those paths are outside this session-launch refactor and show `AGENTIFY.md` mtime unchanged after a failing command mutation while docs refresh is skipped.