### PR TITLE
refactor: centralize provider metadata

### DIFF
--- a/src/core/bootstrap.js
+++ b/src/core/bootstrap.js
@@ -7,9 +7,10 @@ import { createInterface } from "node:readline/promises";
 import { ensureBaselineArtifacts } from "./commands.js";
 import { loadConfig, persistProviderPreference, writeDefaultConfig } from "./config.js";
 import { exists } from "./fs.js";
+import { BOOTSTRAP_PROVIDER_NAMES, getProviderBootstrap, getProviderDefinition, stripAnsi } from "./provider-registry.js";
 import * as ui from "./ui.js";
 
-export const BOOTSTRAP_PROVIDERS = ["codex", "claude", "gemini", "opencode"];
+export const BOOTSTRAP_PROVIDERS = BOOTSTRAP_PROVIDER_NAMES;
 
 const HOMEBREW_INSTALL_COMMAND = '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"';
 
@@ -52,41 +53,6 @@ const NODE_INSTALL = {
   install: ["brew", "install", "node"],
 };
 
-const PROVIDER_BOOTSTRAP = {
-  codex: {
-    id: "codex",
-    label: "Codex",
-    bin: "codex",
-    checkArgs: ["--version"],
-    install: ["npm", "install", "-g", "@openai/codex"],
-    loginCommand: "codex login",
-  },
-  claude: {
-    id: "claude",
-    label: "Claude Code",
-    bin: "claude",
-    checkArgs: ["--version"],
-    install: ["npm", "install", "-g", "@anthropic-ai/claude-code"],
-    loginCommand: "claude auth login",
-  },
-  gemini: {
-    id: "gemini",
-    label: "Gemini CLI",
-    bin: "gemini",
-    checkArgs: ["--version"],
-    install: ["brew", "install", "gemini-cli"],
-    loginCommand: "gemini",
-  },
-  opencode: {
-    id: "opencode",
-    label: "OpenCode",
-    bin: "opencode",
-    checkArgs: ["--version"],
-    install: ["brew", "install", "opencode"],
-    loginCommand: "opencode providers login",
-  },
-};
-
 function normalizeBootstrapProvider(value) {
   const provider = String(value || "").trim().toLowerCase();
   if (!provider) {
@@ -99,10 +65,6 @@ function normalizeBootstrapProvider(value) {
     throw new Error(`unsupported provider "${provider}". Supported providers: ${BOOTSTRAP_PROVIDERS.join(", ")}`);
   }
   return provider;
-}
-
-function stripAnsi(text) {
-  return String(text || "").replace(/\u001b\[[0-9;]*m/g, "");
 }
 
 function tailText(text, maxLines = 4) {
@@ -295,7 +257,7 @@ export async function buildBootstrapInstallPlan(provider, runtime = {}) {
     }
   }
 
-  const providerStep = PROVIDER_BOOTSTRAP[provider];
+  const providerStep = getProviderBootstrap(provider);
   if (!providerStep) {
     throw new Error(`unsupported provider "${provider}"`);
   }
@@ -311,76 +273,6 @@ export async function buildBootstrapInstallPlan(provider, runtime = {}) {
   return installPlan;
 }
 
-async function probeCodexAuth(runtime) {
-  const result = await runtime.exec(["codex", "login", "status"], {
-    cwd: runtime.cwd,
-    env: runtime.env,
-  });
-  const output = `${result.stdout}\n${result.stderr}`.toLowerCase();
-  if (result.code === 0 && output.includes("logged in")) {
-    return { state: "ready", detail: "logged in", nextStep: null };
-  }
-  if (output.includes("not logged in")) {
-    return { state: "missing", detail: "login required", nextStep: "codex login" };
-  }
-  return { state: "unknown", detail: "auth not verified", nextStep: "codex login" };
-}
-
-async function probeClaudeAuth(runtime) {
-  const result = await runtime.exec(["claude", "auth", "status"], {
-    cwd: runtime.cwd,
-    env: runtime.env,
-  });
-
-  try {
-    const parsed = JSON.parse(result.stdout || "{}");
-    if (parsed.loggedIn) {
-      return { state: "ready", detail: parsed.authMethod || "logged in", nextStep: null };
-    }
-    return { state: "missing", detail: "login required", nextStep: "claude auth login" };
-  } catch {
-    const output = `${result.stdout}\n${result.stderr}`.toLowerCase();
-    if (output.includes('"loggedin": true') || output.includes("logged in")) {
-      return { state: "ready", detail: "logged in", nextStep: null };
-    }
-    return { state: "unknown", detail: "auth not verified", nextStep: "claude auth login" };
-  }
-}
-
-async function probeGeminiAuth(runtime) {
-  if (runtime.env.GEMINI_API_KEY) {
-    return { state: "ready", detail: "GEMINI_API_KEY set", nextStep: null };
-  }
-  if (runtime.env.GOOGLE_API_KEY) {
-    return { state: "ready", detail: "GOOGLE_API_KEY set", nextStep: null };
-  }
-  if (runtime.env.GOOGLE_APPLICATION_CREDENTIALS && await exists(runtime.env.GOOGLE_APPLICATION_CREDENTIALS)) {
-    return { state: "ready", detail: "application default credentials configured", nextStep: null };
-  }
-
-  const geminiHome = runtime.env.GEMINI_CLI_HOME || runtime.homeDir;
-  const oauthFile = path.join(geminiHome, ".gemini", "oauth_creds.json");
-  if (await exists(oauthFile)) {
-    return { state: "ready", detail: "oauth credentials cached", nextStep: null };
-  }
-
-  return { state: "unknown", detail: "auth not verified", nextStep: "gemini" };
-}
-
-async function probeOpenCodeAuth(runtime) {
-  const result = await runtime.exec(["opencode", "providers", "list"], {
-    cwd: runtime.cwd,
-    env: runtime.env,
-  });
-  const cleaned = stripAnsi(`${result.stdout}\n${result.stderr}`);
-  const credentialsCount = Number(cleaned.match(/(\d+)\s+credentials?/i)?.[1] || 0);
-  const envCount = Number(cleaned.match(/(\d+)\s+environment variables?/i)?.[1] || 0);
-  if (result.code === 0 && (credentialsCount > 0 || envCount > 0)) {
-    return { state: "ready", detail: "credentials detected", nextStep: null };
-  }
-  return { state: "unknown", detail: "auth not verified", nextStep: "opencode providers login" };
-}
-
 export async function probeProviderReadiness(provider, runtime = {}) {
   const mergedRuntime = {
     cwd: runtime.cwd || process.cwd(),
@@ -389,17 +281,9 @@ export async function probeProviderReadiness(provider, runtime = {}) {
     exec: runtime.exec || runCommandCapture,
   };
 
-  if (provider === "codex") {
-    return probeCodexAuth(mergedRuntime);
-  }
-  if (provider === "claude") {
-    return probeClaudeAuth(mergedRuntime);
-  }
-  if (provider === "gemini") {
-    return probeGeminiAuth(mergedRuntime);
-  }
-  if (provider === "opencode") {
-    return probeOpenCodeAuth(mergedRuntime);
+  const definition = getProviderDefinition(provider);
+  if (definition?.probeAuth) {
+    return definition.probeAuth(mergedRuntime);
   }
   throw new Error(`unsupported provider "${provider}"`);
 }
@@ -642,7 +526,7 @@ export async function runBootstrapCommand(args, runtime = {}) {
   if (result.status === "ready") {
     progress.success(`100% ready: ${provider} configured in ${requestedRoot}`);
   } else {
-    const nextStep = auth.nextStep || PROVIDER_BOOTSTRAP[provider].loginCommand;
+    const nextStep = auth.nextStep || getProviderBootstrap(provider)?.loginCommand;
     progress.warn(`85% login required: run ${nextStep}`);
   }
 

--- a/src/core/provider-command.js
+++ b/src/core/provider-command.js
@@ -1,4 +1,6 @@
-export const SUPPORTED_PROVIDERS = ["local", "codex", "claude", "gemini", "opencode"];
+import { EXECUTABLE_PROVIDER_NAMES, SUPPORTED_PROVIDERS, getProviderDefinition } from "./provider-registry.js";
+
+export { SUPPORTED_PROVIDERS };
 
 export function assertSupportedProvider(provider) {
   if (!SUPPORTED_PROVIDERS.includes(provider)) {
@@ -21,67 +23,16 @@ export function buildProviderTemplateCommand(provider, prompt, {
 } = {}) {
   assertSupportedProvider(provider);
   const normalizedPrompt = normalizePrompt(prompt);
+  const definition = getProviderDefinition(provider);
 
-  if (provider === "local") {
-    throw new Error('provider "local" cannot execute agent commands. Pass --provider codex|claude|gemini|opencode.');
-  }
-
-  if (provider === "codex") {
-    if (interactive) {
-      const args = ["codex"];
-      if (root) {
-        args.push("--cd", root);
-      }
-      if (bypassPermissions) {
-        args.push("--dangerously-bypass-approvals-and-sandbox");
-      }
-      args.push(normalizedPrompt);
-      return args;
-    }
-    const args = ["codex", "exec"];
-    if (bypassPermissions) {
-      args.push("--dangerously-bypass-approvals-and-sandbox");
-    }
-    args.push(normalizedPrompt);
-    return args;
-  }
-  if (provider === "claude") {
-    if (interactive) {
-      const args = ["claude"];
-      if (bypassPermissions) {
-        args.push("--dangerously-skip-permissions", "--permission-mode", "bypassPermissions");
-      }
-      args.push(normalizedPrompt);
-      return args;
-    }
-    const args = ["claude"];
-    if (bypassPermissions) {
-      args.push("--dangerously-skip-permissions", "--permission-mode", "bypassPermissions");
-    }
-    args.push("-p", normalizedPrompt);
-    return args;
-  }
-  if (provider === "gemini") {
-    if (interactive) {
-      return ["gemini", normalizedPrompt];
-    }
-    return ["gemini", "-p", normalizedPrompt];
-  }
-  if (provider === "opencode") {
-    if (interactive) {
-      const args = ["opencode"];
-      if (root) {
-        args.push("--dir", root);
-      }
-      args.push(normalizedPrompt);
-      return args;
-    }
-    const args = ["opencode", "run", normalizedPrompt];
-    if (root) {
-      args.push("--dir", root);
-    }
-    return args;
+  if (!definition.executable || !definition.buildTemplateCommand) {
+    throw new Error(`provider "${provider}" cannot execute agent commands. Pass --provider ${EXECUTABLE_PROVIDER_NAMES.join("|")}.`);
   }
 
-  throw new Error(`unsupported provider "${provider}"`);
+  return definition.buildTemplateCommand({
+    prompt: normalizedPrompt,
+    root,
+    interactive,
+    bypassPermissions,
+  });
 }

--- a/src/core/provider-registry.js
+++ b/src/core/provider-registry.js
@@ -1,0 +1,242 @@
+import path from "node:path";
+
+import { exists } from "./fs.js";
+
+function codexTemplateCommand({ prompt, root, interactive, bypassPermissions }) {
+  if (interactive) {
+    const args = ["codex"];
+    if (root) {
+      args.push("--cd", root);
+    }
+    if (bypassPermissions) {
+      args.push("--dangerously-bypass-approvals-and-sandbox");
+    }
+    args.push(prompt);
+    return args;
+  }
+
+  const args = ["codex", "exec"];
+  if (bypassPermissions) {
+    args.push("--dangerously-bypass-approvals-and-sandbox");
+  }
+  args.push(prompt);
+  return args;
+}
+
+function claudeTemplateCommand({ prompt, interactive, bypassPermissions }) {
+  const args = ["claude"];
+  if (bypassPermissions) {
+    args.push("--dangerously-skip-permissions", "--permission-mode", "bypassPermissions");
+  }
+  if (!interactive) {
+    args.push("-p");
+  }
+  args.push(prompt);
+  return args;
+}
+
+function geminiTemplateCommand({ prompt, interactive }) {
+  if (interactive) {
+    return ["gemini", prompt];
+  }
+  return ["gemini", "-p", prompt];
+}
+
+function opencodeTemplateCommand({ prompt, root, interactive }) {
+  if (interactive) {
+    const args = ["opencode"];
+    if (root) {
+      args.push("--dir", root);
+    }
+    args.push(prompt);
+    return args;
+  }
+
+  const args = ["opencode", "run", prompt];
+  if (root) {
+    args.push("--dir", root);
+  }
+  return args;
+}
+
+async function probeCodexAuth(runtime) {
+  const result = await runtime.exec(["codex", "login", "status"], {
+    cwd: runtime.cwd,
+    env: runtime.env,
+  });
+  const output = `${result.stdout}\n${result.stderr}`.toLowerCase();
+  if (result.code === 0 && output.includes("logged in")) {
+    return { state: "ready", detail: "logged in", nextStep: null };
+  }
+  if (output.includes("not logged in")) {
+    return { state: "missing", detail: "login required", nextStep: "codex login" };
+  }
+  return { state: "unknown", detail: "auth not verified", nextStep: "codex login" };
+}
+
+async function probeClaudeAuth(runtime) {
+  const result = await runtime.exec(["claude", "auth", "status"], {
+    cwd: runtime.cwd,
+    env: runtime.env,
+  });
+
+  try {
+    const parsed = JSON.parse(result.stdout || "{}");
+    if (parsed.loggedIn) {
+      return { state: "ready", detail: parsed.authMethod || "logged in", nextStep: null };
+    }
+    return { state: "missing", detail: "login required", nextStep: "claude auth login" };
+  } catch {
+    const output = `${result.stdout}\n${result.stderr}`.toLowerCase();
+    if (output.includes('"loggedin": true') || output.includes("logged in")) {
+      return { state: "ready", detail: "logged in", nextStep: null };
+    }
+    return { state: "unknown", detail: "auth not verified", nextStep: "claude auth login" };
+  }
+}
+
+async function probeGeminiAuth(runtime) {
+  if (runtime.env.GEMINI_API_KEY) {
+    return { state: "ready", detail: "GEMINI_API_KEY set", nextStep: null };
+  }
+  if (runtime.env.GOOGLE_API_KEY) {
+    return { state: "ready", detail: "GOOGLE_API_KEY set", nextStep: null };
+  }
+  if (runtime.env.GOOGLE_APPLICATION_CREDENTIALS && await exists(runtime.env.GOOGLE_APPLICATION_CREDENTIALS)) {
+    return { state: "ready", detail: "application default credentials configured", nextStep: null };
+  }
+
+  const geminiHome = runtime.env.GEMINI_CLI_HOME || runtime.homeDir;
+  const oauthFile = path.join(geminiHome, ".gemini", "oauth_creds.json");
+  if (await exists(oauthFile)) {
+    return { state: "ready", detail: "oauth credentials cached", nextStep: null };
+  }
+
+  return { state: "unknown", detail: "auth not verified", nextStep: "gemini" };
+}
+
+export function stripAnsi(text) {
+  return String(text || "").replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+async function probeOpenCodeAuth(runtime) {
+  const result = await runtime.exec(["opencode", "providers", "list"], {
+    cwd: runtime.cwd,
+    env: runtime.env,
+  });
+  const cleaned = stripAnsi(`${result.stdout}\n${result.stderr}`);
+  const credentialsCount = Number(cleaned.match(/(\d+)\s+credentials?/i)?.[1] || 0);
+  const envCount = Number(cleaned.match(/(\d+)\s+environment variables?/i)?.[1] || 0);
+  if (result.code === 0 && (credentialsCount > 0 || envCount > 0)) {
+    return { state: "ready", detail: "credentials detected", nextStep: null };
+  }
+  return { state: "unknown", detail: "auth not verified", nextStep: "opencode providers login" };
+}
+
+export const PROVIDER_DEFINITIONS = {
+  local: {
+    name: "local",
+    executable: false,
+    skillInstall: false,
+    bootstrap: null,
+    runtime: {
+      kind: "local",
+    },
+  },
+  codex: {
+    name: "codex",
+    executable: true,
+    skillInstall: true,
+    buildTemplateCommand: codexTemplateCommand,
+    bootstrap: {
+      id: "codex",
+      label: "Codex",
+      bin: "codex",
+      checkArgs: ["--version"],
+      install: ["npm", "install", "-g", "@openai/codex"],
+      loginCommand: "codex login",
+    },
+    probeAuth: probeCodexAuth,
+    runtime: {
+      kind: "external",
+      defaultModel: "codex-default",
+      runner: "codex",
+    },
+  },
+  claude: {
+    name: "claude",
+    executable: true,
+    skillInstall: true,
+    buildTemplateCommand: claudeTemplateCommand,
+    bootstrap: {
+      id: "claude",
+      label: "Claude Code",
+      bin: "claude",
+      checkArgs: ["--version"],
+      install: ["npm", "install", "-g", "@anthropic-ai/claude-code"],
+      loginCommand: "claude auth login",
+    },
+    probeAuth: probeClaudeAuth,
+    runtime: {
+      kind: "external",
+      defaultModel: "claude-default",
+      runner: "claude",
+    },
+  },
+  gemini: {
+    name: "gemini",
+    executable: true,
+    skillInstall: true,
+    buildTemplateCommand: geminiTemplateCommand,
+    bootstrap: {
+      id: "gemini",
+      label: "Gemini CLI",
+      bin: "gemini",
+      checkArgs: ["--version"],
+      install: ["brew", "install", "gemini-cli"],
+      loginCommand: "gemini",
+    },
+    probeAuth: probeGeminiAuth,
+    runtime: {
+      kind: "external",
+      defaultModel: "gemini-default",
+      runner: "gemini",
+      appendJsonOnlyInstruction: true,
+    },
+  },
+  opencode: {
+    name: "opencode",
+    executable: true,
+    skillInstall: true,
+    buildTemplateCommand: opencodeTemplateCommand,
+    bootstrap: {
+      id: "opencode",
+      label: "OpenCode",
+      bin: "opencode",
+      checkArgs: ["--version"],
+      install: ["brew", "install", "opencode"],
+      loginCommand: "opencode providers login",
+    },
+    probeAuth: probeOpenCodeAuth,
+    runtime: {
+      kind: "external",
+      defaultModel: "opencode-default",
+      runner: "opencode",
+      appendJsonOnlyInstruction: true,
+    },
+  },
+};
+
+export const SUPPORTED_PROVIDERS = Object.keys(PROVIDER_DEFINITIONS);
+export const EXECUTABLE_PROVIDER_NAMES = SUPPORTED_PROVIDERS.filter((provider) => PROVIDER_DEFINITIONS[provider].executable);
+export const BOOTSTRAP_PROVIDER_NAMES = SUPPORTED_PROVIDERS.filter((provider) => PROVIDER_DEFINITIONS[provider].bootstrap);
+export const SKILL_INSTALL_PROVIDER_NAMES = SUPPORTED_PROVIDERS.filter((provider) => PROVIDER_DEFINITIONS[provider].skillInstall);
+
+export function getProviderDefinition(provider) {
+  return PROVIDER_DEFINITIONS[provider] || null;
+}
+
+export function getProviderBootstrap(provider) {
+  return getProviderDefinition(provider)?.bootstrap || null;
+}
+

--- a/src/core/provider.js
+++ b/src/core/provider.js
@@ -4,6 +4,7 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { sanitizeManagerPlan, sanitizeModuleResponse } from "./agent-contract.js";
 import { buildManagerPrompt, buildManagerSchema, buildModulePrompt, buildModuleSchema } from "./prompts.js";
+import { getProviderDefinition } from "./provider-registry.js";
 
 const DEFAULT_PROVIDER_TIMEOUT_MS = 120000;
 
@@ -615,37 +616,44 @@ function createExternalProvider(config, options) {
   };
 }
 
+const RUNTIME_RUNNERS = {
+  codex: runCodexExec,
+  claude: runClaudeExec,
+  gemini: runGeminiExec,
+  opencode: runOpenCodeExec,
+};
+
+function buildExternalRun(definition) {
+  const runner = RUNTIME_RUNNERS[definition.runtime.runner];
+  if (!runner) {
+    throw new Error(`unsupported provider runtime "${definition.runtime.runner}"`);
+  }
+  if (!definition.runtime.appendJsonOnlyInstruction) {
+    return runner;
+  }
+  return ({ prompt, ...args }) => runner({
+    ...args,
+    prompt: `${prompt}\n\nReturn only valid JSON matching the requested structure.`,
+  });
+}
+
 export function createProvider(name, config = {}) {
-  if (name === "local") {
+  const definition = getProviderDefinition(name);
+  if (!definition) {
+    throw new Error(`unsupported provider "${name}"`);
+  }
+
+  if (definition.runtime.kind === "local") {
     return createLocalProvider();
   }
-  if (name === "codex") {
+
+  if (definition.runtime.kind === "external") {
     return createExternalProvider(config, {
-      name: "codex",
-      defaultModel: "codex-default",
-      run: runCodexExec
+      name: definition.name,
+      defaultModel: definition.runtime.defaultModel,
+      run: buildExternalRun(definition),
     });
   }
-  if (name === "claude") {
-    return createExternalProvider(config, {
-      name: "claude",
-      defaultModel: "claude-default",
-      run: runClaudeExec
-    });
-  }
-  if (name === "gemini") {
-    return createExternalProvider(config, {
-      name: "gemini",
-      defaultModel: "gemini-default",
-      run: async ({ root, prompt, model }) => runGeminiExec({ root, prompt: `${prompt}\n\nReturn only valid JSON matching the requested structure.`, model })
-    });
-  }
-  if (name === "opencode") {
-    return createExternalProvider(config, {
-      name: "opencode",
-      defaultModel: "opencode-default",
-      run: async ({ root, prompt, model }) => runOpenCodeExec({ root, prompt: `${prompt}\n\nReturn only valid JSON matching the requested structure.`, model })
-    });
-  }
+
   throw new Error(`unsupported provider "${name}"`);
 }

--- a/src/core/skills.js
+++ b/src/core/skills.js
@@ -4,11 +4,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { ensureDir, exists } from "./fs.js";
-import { SUPPORTED_PROVIDERS } from "./provider-command.js";
+import { SKILL_INSTALL_PROVIDER_NAMES } from "./provider-registry.js";
 
 const BUILTIN_SKILL_ROOT = fileURLToPath(new URL("../builtin-skills", import.meta.url));
 
-export const SKILL_INSTALL_PROVIDERS = SUPPORTED_PROVIDERS.filter((provider) => provider !== "local");
+export const SKILL_INSTALL_PROVIDERS = SKILL_INSTALL_PROVIDER_NAMES;
 
 const BUILTIN_SKILLS = [
   {

--- a/test/provider-registry.test.js
+++ b/test/provider-registry.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { BOOTSTRAP_PROVIDERS } from "../src/core/bootstrap.js";
+import { SUPPORTED_PROVIDERS } from "../src/core/provider-command.js";
+import { SKILL_INSTALL_PROVIDERS } from "../src/core/skills.js";
+import {
+  BOOTSTRAP_PROVIDER_NAMES,
+  EXECUTABLE_PROVIDER_NAMES,
+  PROVIDER_DEFINITIONS,
+  SKILL_INSTALL_PROVIDER_NAMES,
+  getProviderBootstrap,
+} from "../src/core/provider-registry.js";
+
+test("provider registry is the canonical source for provider capability lists", () => {
+  assert.deepEqual(SUPPORTED_PROVIDERS, Object.keys(PROVIDER_DEFINITIONS));
+  assert.deepEqual(BOOTSTRAP_PROVIDERS, BOOTSTRAP_PROVIDER_NAMES);
+  assert.deepEqual(SKILL_INSTALL_PROVIDERS, SKILL_INSTALL_PROVIDER_NAMES);
+  assert.deepEqual(EXECUTABLE_PROVIDER_NAMES, ["codex", "claude", "gemini", "opencode"]);
+});
+
+test("executable providers declare command, bootstrap, auth, and runtime metadata", () => {
+  for (const provider of EXECUTABLE_PROVIDER_NAMES) {
+    const definition = PROVIDER_DEFINITIONS[provider];
+    assert.equal(typeof definition.buildTemplateCommand, "function");
+    assert.equal(typeof definition.probeAuth, "function");
+    assert.deepEqual(getProviderBootstrap(provider), definition.bootstrap);
+    assert.equal(definition.runtime.kind, "external");
+    assert.equal(typeof definition.runtime.defaultModel, "string");
+    assert.equal(typeof definition.runtime.runner, "string");
+  }
+});
+
+test("local provider remains validation-only and local-runtime only", () => {
+  const definition = PROVIDER_DEFINITIONS.local;
+  assert.equal(definition.executable, false);
+  assert.equal(definition.skillInstall, false);
+  assert.equal(definition.bootstrap, null);
+  assert.equal(definition.runtime.kind, "local");
+});
+


### PR DESCRIPTION
## Summary
- Add a canonical provider registry for provider names, command templates, bootstrap metadata, auth probes, skill install eligibility, and runtime adapter metadata.
- Route bootstrap, provider command building, skill provider derivation, and runtime provider creation through the shared registry.
- Add registry boundary tests to prevent drift across provider capability lists.

Closes #73

## Tests
- npm test -- test/provider-registry.test.js test/provider-command.test.js test/bootstrap.test.js test/provider.test.js test/skills.test.js
- git diff --check

## Notes
- Full npm test was run and currently has 4 failures outside this provider change: the existing failing-command doc mtime assertions in exec/main tests and the session MemPalace backend tests.