### PR TITLE
fix(session-memory): repair MemPalace recall guard and expand setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ agentify sess resume --session <session-id> "<next task>"
 agentify check
 ```
 
+## Optional Accelerators
+
+- **MemPalace** — local AI memory backend that mines `agentify sess` transcripts and surfaces relevant prior context on recall. Install with `pipx install mempalace` (Python 3.9+); keep `mempalace` on `PATH` or set `AGENTIFY_MEMPALACE_CMD`. Setup details in [docs/usage.md § 6](./docs/usage.md).
+
 ## Learn More
 
 - [docs/DETAILED_README.md](./docs/DETAILED_README.md) has the full command guide, provider behavior, semantic indexing, session memory, generated artifacts, and development notes.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -360,11 +360,18 @@ Use `agentify doctor` afterward to confirm semantic projects are being reported.
 
 MemPalace is optional, but it is the most useful add-on when you use `sess *` frequently.
 
-How to turn it on:
+How to install (Python 3.9+ required):
 
-- install `mempalace` and keep it on `PATH`, or set `AGENTIFY_MEMPALACE_CMD`
-- run `agentify doctor` and confirm MemPalace is detected
-- prefer `agentify sess run`, `sess resume`, and `sess fork` for multi-step work so Agentify has durable session transcripts to mine
+- `pipx install mempalace` is the recommended path. Plain `pip install mempalace` works too, but pulls ChromaDB and a ~300 MB embedding model on first index — prefer a virtualenv if you do not use `pipx`.
+- Keep the resolved `mempalace` binary on `PATH`, or set `AGENTIFY_MEMPALACE_CMD` to its absolute path (useful when installed in a project-local venv).
+- You do **not** need to run `mempalace init` yourself. Agentify lazily creates the per-repo palace under `.agents/mempalace/palace/` on the first `mine` call.
+- Run `agentify doctor` and confirm MemPalace is detected.
+- Prefer `agentify sess run`, `sess resume`, and `sess fork` for multi-step work so Agentify has durable session transcripts to mine.
+
+Setup reference: <https://mempalaceofficial.com/guide/getting-started>.
+
+> [!NOTE]
+> Agentify binds the per-repo palace by setting `MEMPALACE_PALACE_PATH` when invoking `mempalace`. That env var is honored by `mempalace/config.py` but is not documented in `mempalace --help`; do not strip it as "dead" in future refactors of `src/core/session-memory.js`.
 
 Important:
 

--- a/src/core/session-memory.js
+++ b/src/core/session-memory.js
@@ -465,7 +465,9 @@ async function createMemPalaceBackend(root, query, config) {
         const resultCount = String(getSessionMemoryLimit(config, "memoryResults", 3));
         const { stdout } = await runMemPalace(root, ["search", query, "--wing", wing, "--results", resultCount], palacePath);
         const excerpt = clipToBytes(stdout.trim(), getSessionMemoryLimit(config, "memoryPromptMaxKb", 4) * 1024);
-        if (!excerpt || excerpt.includes("No results found")) {
+        const hasResultRow = /^\s*\[\d+\]\s/m.test(excerpt);
+        const hasErrorStdout = /No palace found|Run: mempalace init/.test(excerpt);
+        if (!excerpt || hasErrorStdout || !hasResultRow) {
           return null;
         }
 

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -268,6 +268,139 @@ test("loadAutomaticRunMemory uses MemPalace automatically when the CLI is availa
   }
 });
 
+async function installMemPalaceShim(binDir, searchStdout) {
+  const stdoutPath = path.join(binDir, "search-stdout.txt");
+  await fs.writeFile(stdoutPath, searchStdout, "utf8");
+  const scriptPath = path.join(binDir, "mempalace");
+  await fs.writeFile(scriptPath, `#!/bin/sh
+set -eu
+if [ "$1" = "mine" ]; then
+  mkdir -p "\${MEMPALACE_PALACE_PATH}"
+  echo "mined"
+  exit 0
+fi
+if [ "$1" = "search" ]; then
+  cat "${stdoutPath}"
+  exit 0
+fi
+exit 1
+`, "utf8");
+  await fs.chmod(scriptPath, 0o755);
+  return scriptPath;
+}
+
+async function setupMemPalaceTestRepo() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-mp-guard-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+  const config = await loadConfig(root, { provider: "codex" });
+  const session = await forkSession(root, config, { name: "memory" });
+  const paths = getSessionArtifactPaths(root, session.sessionId);
+  await fs.writeFile(paths.transcriptPath, [
+    "# Agentify Session Run",
+    "",
+    "> Current task",
+    "Pick a transcript format.",
+    "",
+    "> Provider response",
+    "Use JSONL transcripts because they are append-friendly for durable memory capture.",
+    "",
+  ].join("\n"), "utf8");
+  return { root, config };
+}
+
+test("loadAutomaticRunMemory rejects MemPalace stdout that reports a missing palace", async () => {
+  const { root, config } = await setupMemPalaceTestRepo();
+  const binDir = path.join(root, "bin");
+  await fs.mkdir(binDir, { recursive: true });
+  await installMemPalaceShim(binDir, [
+    "  No palace found at /tmp/agentify-test/.agents/mempalace/palace",
+    "  Run: mempalace init <dir> then mempalace mine <dir>",
+    "",
+  ].join("\n"));
+
+  const originalPath = process.env.PATH;
+  const originalCmd = process.env.AGENTIFY_MEMPALACE_CMD;
+  process.env.PATH = `${binDir}:${originalPath}`;
+  delete process.env.AGENTIFY_MEMPALACE_CMD;
+  try {
+    const memory = await loadAutomaticRunMemory(root, "transcript decision query", config);
+    assert.notEqual(memory.backend, "mempalace", "MemPalace must not be selected when stdout reports no palace");
+    if (memory.markdown) {
+      assert.doesNotMatch(memory.markdown, /No palace found/);
+      assert.doesNotMatch(memory.markdown, /mempalace init/);
+    }
+  } finally {
+    process.env.PATH = originalPath;
+    if (originalCmd === undefined) {
+      delete process.env.AGENTIFY_MEMPALACE_CMD;
+    } else {
+      process.env.AGENTIFY_MEMPALACE_CMD = originalCmd;
+    }
+  }
+});
+
+test("loadAutomaticRunMemory rejects MemPalace stdout that contains zero result rows", async () => {
+  const { root, config } = await setupMemPalaceTestRepo();
+  const binDir = path.join(root, "bin");
+  await fs.mkdir(binDir, { recursive: true });
+  await installMemPalaceShim(binDir, [
+    "============================================================",
+    '  Results for: "transcript decision query"',
+    "  Wing: agentify",
+    "============================================================",
+    "",
+    "",
+  ].join("\n"));
+
+  const originalPath = process.env.PATH;
+  const originalCmd = process.env.AGENTIFY_MEMPALACE_CMD;
+  process.env.PATH = `${binDir}:${originalPath}`;
+  delete process.env.AGENTIFY_MEMPALACE_CMD;
+  try {
+    const memory = await loadAutomaticRunMemory(root, "transcript decision query", config);
+    assert.notEqual(memory.backend, "mempalace", "MemPalace must not be selected when no result rows are present");
+  } finally {
+    process.env.PATH = originalPath;
+    if (originalCmd === undefined) {
+      delete process.env.AGENTIFY_MEMPALACE_CMD;
+    } else {
+      process.env.AGENTIFY_MEMPALACE_CMD = originalCmd;
+    }
+  }
+});
+
+test("loadAutomaticRunMemory exercises the real MemPalace CLI when available", async (t) => {
+  const candidate = process.env.AGENTIFY_MEMPALACE_CMD || "mempalace";
+  let probeOk = false;
+  try {
+    await execFileAsync(candidate, ["--version"]);
+    probeOk = true;
+  } catch {
+    /* not available */
+  }
+  if (!probeOk) {
+    t.skip(`real mempalace not invokable (set AGENTIFY_MEMPALACE_CMD or place mempalace on PATH; tried ${candidate})`);
+    return;
+  }
+
+  const { root, config } = await setupMemPalaceTestRepo();
+  const originalCmd = process.env.AGENTIFY_MEMPALACE_CMD;
+  process.env.AGENTIFY_MEMPALACE_CMD = candidate;
+  try {
+    const memory = await loadAutomaticRunMemory(root, "JSONL transcript decision", config);
+    assert.equal(memory.backend, "mempalace");
+    assert.match(memory.markdown, /Backend: mempalace/);
+    assert.match(memory.markdown, /JSONL transcripts/i, "excerpt should contain the seeded term from the synthetic transcript");
+  } finally {
+    if (originalCmd === undefined) {
+      delete process.env.AGENTIFY_MEMPALACE_CMD;
+    } else {
+      process.env.AGENTIFY_MEMPALACE_CMD = originalCmd;
+    }
+  }
+});
+
 test("normalizeInteractiveCapture strips script noise and ANSI sequences", () => {
   const normalized = normalizeInteractiveCapture("\u0004\u0008\u0008Script started on now\n\u001b[31mhello\u001b[0m\r\nScript done on later\n");
   assert.equal(normalized, "hello");


### PR DESCRIPTION
Closes #109.

## Summary

- **Fix the dead recall guard** in `createMemPalaceBackend` (`src/core/session-memory.js`). The previous `includes("No results found")` check matched a string `mempalace` 3.3.3 never emits, so error stdout (`"No palace found at ..."` / `"Run: mempalace init ..."`) leaked into the prompt as recalled memory. Replaced with a row-count regex (`/^\s*\[\d+\]\s/m`) plus explicit rejection of the two known error strings.
- **Add real-CLI integration coverage** in `test/session.test.js`: two shim-based tests that lock the new guard against both empty-stdout shapes mempalace emits, and one opt-in test that exercises the real `mempalace mine`/`search` flow end-to-end. The real-CLI test skips cleanly when `mempalace` is not on `PATH` and `AGENTIFY_MEMPALACE_CMD` is unset, so CI stays fast.
- **Expand setup docs**: `docs/usage.md` § 6 now lists the actual install command (`pipx install mempalace`, Python 3.9+), notes the ~300 MB embedding-model download on first index, clarifies that `mempalace init` is not required (agentify lazy-creates the per-repo palace under `.agents/mempalace/palace/`), and pins the `MEMPALACE_PALACE_PATH` env-var contract so future refactors of `session-memory.js` do not strip it. `README.md` gains a new "Optional Accelerators" section so MemPalace is discoverable from the front page, not only from `agentify doctor`.

## Test plan

- [x] `node --test test/session.test.js` (mempalace **not** on PATH): 13 pass, 1 skipped (real-CLI test), 0 fail.
- [x] `PATH=/path/to/mempalace-venv/bin:$PATH node --test test/session.test.js`: 13 pass, 0 skipped, 1 pre-existing fail (`searches older sessions when the direct parent is not relevant` — pre-existing fragility: the test assumes mempalace is not on PATH; verified by stash-revert against base, fails without these changes too).
- [x] `node --test` full suite (mempalace not on PATH): 152 pass, 1 skipped, 2 pre-existing failures (`runExec refreshes ...`, `runCli exec refreshes ...`) — both pre-existing on the worktree base `71c7cd1`, verified by stash-revert; unrelated to mempalace and likely already fixed in commits between this PR's base and local `main`.
- [x] Manual repro of the original bug: with `mempalace` shimmed to emit `"No palace found at <path>"`, `loadAutomaticRunMemory` now returns a non-mempalace backend (was: returned `{backend: "mempalace", markdown: "...No palace found..."}` — corrupt recall).
- [x] `agentify doctor` detection of mempalace via `PATH` and `AGENTIFY_MEMPALACE_CMD` is unchanged (no edits to `src/core/toolchain.js`).

## Notes for reviewers

- The two pre-existing full-suite failures are not addressed here — they live in `test/main.test.js` around `runExec` and look unrelated to session-memory. Worth a separate issue if not already tracked.
- `MEMPALACE_PALACE_PATH` is honored by `mempalace/config.py` upstream but not surfaced in `mempalace --help`. The new doc note in § 6 documents this so the contract is not lost in future refactors.
- The new shim helper in `test/session.test.js` is intentionally small and inline rather than promoted to a shared fixture — adding broader test infrastructure was out of scope.
