### PR TITLE
fix: fail tests on package manifest discovery errors

### DIFF
--- a/src/core/commands.js
+++ b/src/core/commands.js
@@ -154,12 +154,16 @@ async function writeRunReport(root, report) {
 }
 
 function summarizeTestResult(testResult) {
-  return {
+  const summary = {
     status: testResult.status,
     passed: testResult.passed,
     command: testResult.command,
     exit_code: testResult.exit_code
   };
+  if (testResult.discovery_error) {
+    summary.discovery_error = testResult.discovery_error;
+  }
+  return summary;
 }
 
 function renderDefaultAgentignore() {

--- a/src/core/project-tests.js
+++ b/src/core/project-tests.js
@@ -104,45 +104,74 @@ async function runChildCommand(command, args, { cwd, env } = {}) {
   };
 }
 
+function formatPackageJsonDiscoveryError(packageJsonPath, error) {
+  const type = error instanceof SyntaxError
+    ? "package_json_parse_error"
+    : "package_json_read_error";
+  return {
+    type,
+    path: packageJsonPath,
+    message: error.message,
+  };
+}
+
 export async function detectTestCommand(root) {
   const packageJsonPath = path.join(root, "package.json");
   if (!(await exists(packageJsonPath))) {
     return null;
   }
+
+  let packageJson;
   try {
-    const packageJson = await readJson(packageJsonPath);
-    if (packageJson?.scripts?.test) {
-      const packageManager = typeof packageJson.packageManager === "string"
-        ? packageJson.packageManager.split("@")[0]
-        : null;
-      if (packageManager === "pnpm") {
-        return { command: "pnpm", args: ["test"] };
-      }
-      if (packageManager === "yarn") {
-        return { command: "yarn", args: ["test"] };
-      }
-      if (packageManager === "bun") {
-        return { command: "bun", args: ["test"] };
-      }
-      if (await exists(path.join(root, "pnpm-lock.yaml"))) {
-        return { command: "pnpm", args: ["test"] };
-      }
-      if (await exists(path.join(root, "yarn.lock"))) {
-        return { command: "yarn", args: ["test"] };
-      }
-      if (await exists(path.join(root, "bun.lockb")) || await exists(path.join(root, "bun.lock"))) {
-        return { command: "bun", args: ["test"] };
-      }
-      return { command: "npm", args: ["test"] };
+    packageJson = await readJson(packageJsonPath);
+  } catch (error) {
+    return { error: formatPackageJsonDiscoveryError(packageJsonPath, error) };
+  }
+
+  if (packageJson?.scripts?.test) {
+    const packageManager = typeof packageJson.packageManager === "string"
+      ? packageJson.packageManager.split("@")[0]
+      : null;
+    if (packageManager === "pnpm") {
+      return { command: "pnpm", args: ["test"] };
     }
-  } catch {
-    return null;
+    if (packageManager === "yarn") {
+      return { command: "yarn", args: ["test"] };
+    }
+    if (packageManager === "bun") {
+      return { command: "bun", args: ["test"] };
+    }
+    if (await exists(path.join(root, "pnpm-lock.yaml"))) {
+      return { command: "pnpm", args: ["test"] };
+    }
+    if (await exists(path.join(root, "yarn.lock"))) {
+      return { command: "yarn", args: ["test"] };
+    }
+    if (await exists(path.join(root, "bun.lockb")) || await exists(path.join(root, "bun.lock"))) {
+      return { command: "bun", args: ["test"] };
+    }
+    return { command: "npm", args: ["test"] };
   }
   return null;
 }
 
 export async function runProjectTests(root, reporter, options = {}) {
   const testCommand = await detectTestCommand(root);
+  if (testCommand?.error) {
+    const result = {
+      status: "failed",
+      passed: false,
+      command: null,
+      stdout: "",
+      stderr: `package.json test discovery failed: ${testCommand.error.message}`,
+      exit_code: null,
+      discovery_error: testCommand.error,
+    };
+    reporter.log(`tests: failed to discover package.json test script (${testCommand.error.type})`);
+    reporter.setTests(result);
+    return result;
+  }
+
   if (!testCommand) {
     const result = {
       status: "skipped",

--- a/test/project-tests.test.js
+++ b/test/project-tests.test.js
@@ -56,6 +56,18 @@ test("detectTestCommand falls back to lockfile detection", async () => {
   assert.deepEqual(result, { command: "yarn", args: ["test"] });
 });
 
+test("detectTestCommand returns a discovery error for malformed package.json", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-test-malformed-pkg-"));
+  const packageJsonPath = path.join(root, "package.json");
+  await fs.writeFile(packageJsonPath, "{ invalid json\n", "utf8");
+
+  const result = await detectTestCommand(root);
+
+  assert.equal(result.error.type, "package_json_parse_error");
+  assert.equal(result.error.path, packageJsonPath);
+  assert.match(result.error.message, /JSON|Expected property name|Unexpected token/);
+});
+
 test("buildTestEnv strips arbitrary host variables by default", () => {
   const sourceEnv = {
     PATH: "/usr/bin:/bin",
@@ -143,6 +155,23 @@ test("runProjectTests does not leak host secrets to the test subprocess by defau
       process.env.SENTINEL_SECRET = previous;
     }
   }
+});
+
+test("runProjectTests fails when package.json test discovery fails", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-test-discovery-failure-"));
+  await fs.writeFile(path.join(root, "package.json"), "{ invalid json\n", "utf8");
+
+  const reporter = createReporter();
+  const result = await runProjectTests(root, reporter);
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.passed, false);
+  assert.equal(result.command, null);
+  assert.equal(result.exit_code, null);
+  assert.equal(result.discovery_error.type, "package_json_parse_error");
+  assert.match(result.stderr, /package\.json test discovery failed:/);
+  assert.deepEqual(reporter.tests, result);
+  assert.deepEqual(reporter.logs, ["tests: failed to discover package.json test script (package_json_parse_error)"]);
 });
 
 test("runProjectTests forwards a configured passthrough variable", async () => {

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -271,6 +271,44 @@ test("passes", () => {
   assert.equal(payload.tests.status, "passed");
 });
 
+test("runUpdate reports malformed package.json as a failed test discovery", async () => {
+  const previousExitCode = process.exitCode;
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-update-malformed-pkg-"));
+  const packageJsonPath = path.join(root, "package.json");
+  await fs.writeFile(packageJsonPath, "{ invalid json\n", "utf8");
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, "src", "index.js"), "export const ok = true;\n", "utf8");
+
+  const config = await loadConfig(root, { provider: "local", dryRun: false, tokenReport: false, json: true });
+  config._suppressProgress = true;
+  const output = [];
+  const originalLog = console.log;
+
+  console.log = (...args) => {
+    output.push(args.join(" "));
+  };
+
+  try {
+    process.exitCode = undefined;
+    const finalOutput = await runUpdate(root, config);
+
+    assert.equal(output.length, 1);
+    const payload = JSON.parse(output[0]);
+    assert.equal(payload.validation.passed, true);
+    assert.equal(payload.tests.status, "failed");
+    assert.equal(payload.tests.passed, false);
+    assert.equal(payload.tests.command, null);
+    assert.equal(payload.tests.exit_code, null);
+    assert.deepEqual(payload, finalOutput);
+    assert.equal(payload.tests.discovery_error.type, "package_json_parse_error");
+    assert.equal(payload.tests.discovery_error.path, packageJsonPath);
+    assert.equal(process.exitCode, 1);
+  } finally {
+    console.log = originalLog;
+    process.exitCode = previousExitCode;
+  }
+});
+
 test("runUpdate persists test metadata for passing and failing up and sync run reports", async () => {
   const previousExitCode = process.exitCode;
   const cases = [


### PR DESCRIPTION
## Summary
- distinguish missing/no-test package manifests from package.json read or parse failures
- report manifest discovery failures as failed tests with structured discovery_error details
- cover malformed package.json in direct test discovery and agentify up JSON output

Fixes #78

## Tests
- pnpm install --frozen-lockfile
- git diff --check
- node --test test/project-tests.test.js test/update.test.js
- pnpm test *(fails: existing `test/session.test.js` MemPalace log fixture does not create `mempalace-calls.log` in this environment)*