### PR TITLE
fix: assign src root TS files to fallback module

### DIFF
--- a/src/core/indexer.js
+++ b/src/core/indexer.js
@@ -197,14 +197,14 @@ async function detectTypeScriptModules(root, config, relFiles) {
   }
 
   if (modules.length > 0) {
-    return modules.sort((left, right) => left.rootPath.localeCompare(right.rootPath));
+    return withTypeScriptSourceFallbackModule(modules, relFiles);
   }
 
   const fallbackModules = await detectModules(root, config, "ts");
-  return fallbackModules.map((moduleInfo) => ({
+  return withTypeScriptSourceFallbackModule(fallbackModules.map((moduleInfo) => ({
     ...moduleInfo,
     packageName: null,
-  }));
+  })), relFiles);
 }
 
 function findOwningModule(filePath, modules) {
@@ -215,6 +215,49 @@ function findOwningModule(filePath, modules) {
     }
   }
   return null;
+}
+
+function withTypeScriptSourceFallbackModule(modules, relFiles) {
+  const sortedModules = modules.slice().sort((left, right) => left.rootPath.localeCompare(right.rootPath));
+  const hasSrcModule = sortedModules.some((moduleInfo) => moduleInfo.rootPath === "src");
+  if (hasSrcModule) {
+    return sortedModules;
+  }
+
+  const hasUnownedSrcSource = relFiles.some((filePath) => (
+    filePath.startsWith("src/")
+    && TS_EXTENSIONS.has(path.extname(filePath).toLowerCase())
+    && !findOwningModule(filePath, sortedModules)
+  ));
+
+  if (!hasUnownedSrcSource) {
+    return sortedModules;
+  }
+
+  const fallbackId = uniqueModuleId("src", sortedModules);
+  return [
+    ...sortedModules,
+    {
+      id: fallbackId,
+      name: fallbackId,
+      rootPath: "src",
+      stack: "ts",
+      packageName: null,
+    },
+  ].sort((left, right) => left.rootPath.localeCompare(right.rootPath));
+}
+
+function uniqueModuleId(baseId, modules) {
+  const ids = new Set(modules.map((moduleInfo) => moduleInfo.id));
+  if (!ids.has(baseId)) {
+    return baseId;
+  }
+
+  let suffix = 2;
+  while (ids.has(`${baseId}-${suffix}`)) {
+    suffix += 1;
+  }
+  return `${baseId}-${suffix}`;
 }
 
 function detectPackageManager(rootFiles, rootPackageJson) {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1,12 +1,24 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 
 import { runScan } from "../src/core/commands.js";
 import { loadConfig } from "../src/core/config.js";
-import { querySearch } from "../src/core/query.js";
+import { queryChanged, queryOwner, querySearch } from "../src/core/query.js";
+
+const execFileAsync = promisify(execFile);
+
+async function initGitRepo(root) {
+  await execFileAsync("git", ["init"], { cwd: root });
+  await execFileAsync("git", ["config", "user.name", "Agentify Tests"], { cwd: root });
+  await execFileAsync("git", ["config", "user.email", "agentify-tests@example.com"], { cwd: root });
+  await execFileAsync("git", ["add", "."], { cwd: root });
+  await execFileAsync("git", ["commit", "-m", "initial"], { cwd: root });
+}
 
 test("querySearch reads an existing index when the database is read-only", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-query-readonly-"));
@@ -33,4 +45,44 @@ test("querySearch reads an existing index when the database is read-only", async
     await fs.chmod(dbDir, 0o755);
     await fs.chmod(dbPath, 0o644);
   }
+});
+
+test("query owner and changed files use src fallback module for root TS app files", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-query-ts-src-root-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, "src", "components"), { recursive: true });
+  await fs.mkdir(path.join(root, "src", "pages"), { recursive: true });
+  await fs.writeFile(path.join(root, "src", "App.tsx"), "export function App() { return null; }\n", "utf8");
+  await fs.writeFile(path.join(root, "src", "main.tsx"), "import { App } from './App';\nexport { App };\n", "utf8");
+  await fs.writeFile(path.join(root, "src", "components", "Button.tsx"), "export function Button() { return null; }\n", "utf8");
+  await fs.writeFile(path.join(root, "src", "pages", "Home.tsx"), "export function Home() { return null; }\n", "utf8");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "local", dryRun: false });
+  await runScan(root, config);
+
+  const appOwner = await queryOwner(root, "src/App.tsx");
+  const mainOwner = await queryOwner(root, "src/main.tsx");
+  const componentOwner = await queryOwner(root, "src/components/Button.tsx");
+
+  assert.equal(appOwner.module_id, "src");
+  assert.equal(appOwner.module_root, "src");
+  assert.equal(mainOwner.module_id, "src");
+  assert.equal(componentOwner.module_id, "components");
+  assert.equal(componentOwner.module_root, "src/components");
+
+  const { stdout: baseCommit } = await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: root });
+  await fs.appendFile(path.join(root, "src", "App.tsx"), "export const changed = true;\n", "utf8");
+  await execFileAsync("git", ["add", "src/App.tsx"], { cwd: root });
+  await execFileAsync("git", ["commit", "-m", "change app entry"], { cwd: root });
+  const changed = await queryChanged(root, baseCommit.trim());
+
+  assert.deepEqual(changed.affected_modules, [{
+    module_id: "src",
+    module_name: "src",
+    changed_files: [{
+      status: "M",
+      path: "src/App.tsx",
+    }],
+  }]);
 });


### PR DESCRIPTION
## Summary
- add a deterministic `src` fallback module when TS/JS source files under `src/` are not covered by detected `src/*` modules
- keep nested folder modules as the more specific owners via existing longest-root matching
- add regression coverage for owner and changed-file queries on `src/App.tsx` and `src/main.tsx` style repos

Fixes #63

## Verification
- `node --test test/query.test.js test/indexer.test.js test/detect.test.js`
- `env -u AGENTIFY_MEMPALACE_CMD pnpm test`