### PR TITLE
test: cover interactive session transcript fallback

### DIFF
--- a/test/exec.test.js
+++ b/test/exec.test.js
@@ -300,3 +300,58 @@ test("runExec records interactive provider output into a raw PTY log and normali
     assert.match(rawLog, /interactive transcript/);
   }
 });
+
+test("runExec writes a fallback transcript when PTY capture is unavailable", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-exec-interactive-fallback-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex", dryRun: false, tokenReport: false });
+  const session = await forkSession(root, config, { name: "interactive-fallback" });
+  const command = [process.execPath, "--input-type=module", "-e", ""];
+  const originalPath = process.env.PATH;
+  process.env.PATH = "";
+
+  try {
+    const result = await runExec(
+      root,
+      config,
+      command,
+      {
+        captureOutputMode: "pty",
+        skipRefresh: true,
+        sessionRecord: {
+          sessionId: session.sessionId,
+          provider: "codex",
+          prompt: "Continue the interactive fallback session.",
+          task: "Verify interactive fallback transcript persistence.",
+          command,
+          memoryContext: {
+            sourceSessionId: null,
+            transcriptRelativePath: null,
+            excerpt: "",
+            markdown: "## Automatic Session Memory\nNo prior session transcript was available.\n",
+          },
+          captureMode: "interactive-pty",
+        },
+      }
+    );
+
+    const transcript = await fs.readFile(path.join(session.sessionDir, "transcript.md"), "utf8");
+    const launches = await fs.readFile(path.join(session.sessionDir, "launches.jsonl"), "utf8");
+    const launch = JSON.parse(launches.trim().split(/\r?\n/).at(-1));
+
+    assert.equal(result.phase, "complete");
+    assert.equal(result.exitCode, 0);
+    assert.match(transcript, /full assistant transcript was not captured/);
+    assert.match(transcript, /Capture mode used: interactive-fallback/);
+    assert.equal(launch.capture_mode, "interactive-fallback");
+    assert.equal(launch.raw_interactive_log_path, null);
+    await assert.rejects(
+      () => fs.access(path.join(session.sessionDir, "interactive.log")),
+      /ENOENT/
+    );
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});


### PR DESCRIPTION
## Summary
- Adds regression coverage for interactive session runs when PTY transcript capture is unavailable.
- Verifies Agentify still persists a fallback transcript and launch metadata with `interactive-fallback` capture mode.

Closes #37

## Tests
- `node --test test/exec.test.js --test-name-pattern="session memory|interactive provider|fallback transcript"`
- `env -u AGENTIFY_MEMPALACE_CMD npm test`

Note: plain `npm test` initially failed because this shell had `AGENTIFY_MEMPALACE_CMD` pointed at a real MemPalace path, which bypassed the suite's fake MemPalace shim. Unsetting that env var made the suite use its intended local shim and pass.