### PR TITLE
fix: bound project test output capture

### DIFF
--- a/docs/DETAILED_README.md
+++ b/docs/DETAILED_README.md
@@ -147,6 +147,7 @@ Configure overrides in `.agentify.yaml` under the `tests.env` key:
 
 ```yaml
 tests:
+  outputMaxKb: 48        # max stdout bytes and max stderr bytes captured in run reports
   env:
     inherit: false        # set to true to forward the entire host environment (legacy behavior, not recommended)
     passthrough: []       # list of additional env var names to forward from the host shell

--- a/src/core/capture-buffer.js
+++ b/src/core/capture-buffer.js
@@ -1,0 +1,47 @@
+export const DEFAULT_CAPTURE_MAX_KB = 48;
+
+export function normalizeCaptureMaxBytes(maxKb, fallbackKb = DEFAULT_CAPTURE_MAX_KB) {
+  const normalizedKb = Number.isFinite(Number(maxKb)) && Number(maxKb) > 0
+    ? Number(maxKb)
+    : fallbackKb;
+  return Math.floor(normalizedKb * 1024);
+}
+
+export function createBoundedCaptureBuffer(maxBytes) {
+  const limit = Number.isFinite(Number(maxBytes)) ? Math.max(0, Math.floor(Number(maxBytes))) : 0;
+  const chunks = [];
+  let capturedBytes = 0;
+  let seenBytes = 0;
+
+  return {
+    append(chunk) {
+      if (!chunk?.length) {
+        return;
+      }
+
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      seenBytes += buffer.length;
+
+      if (limit <= 0 || capturedBytes >= limit) {
+        return;
+      }
+
+      const remaining = limit - capturedBytes;
+      const slice = buffer.length <= remaining ? buffer : buffer.subarray(0, remaining);
+      chunks.push(Buffer.from(slice));
+      capturedBytes += slice.length;
+    },
+    toString() {
+      return capturedBytes > 0 ? Buffer.concat(chunks, capturedBytes).toString("utf8") : "";
+    },
+    get capturedBytes() {
+      return capturedBytes;
+    },
+    get seenBytes() {
+      return seenBytes;
+    },
+    get truncated() {
+      return seenBytes > capturedBytes;
+    },
+  };
+}

--- a/src/core/commands.js
+++ b/src/core/commands.js
@@ -158,6 +158,11 @@ function summarizeTestResult(testResult) {
     status: testResult.status,
     passed: testResult.passed,
     command: testResult.command,
+    stdout_truncated: Boolean(testResult.stdout_truncated),
+    stderr_truncated: Boolean(testResult.stderr_truncated),
+    stdout_bytes: testResult.stdout_bytes ?? 0,
+    stderr_bytes: testResult.stderr_bytes ?? 0,
+    output_max_bytes: testResult.output_max_bytes ?? null,
     exit_code: testResult.exit_code
   };
 }

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -78,6 +78,7 @@ const DEFAULT_CONFIG = {
     },
   },
   tests: {
+    outputMaxKb: 48,
     env: {
       inherit: false,
       passthrough: [],

--- a/src/core/exec.js
+++ b/src/core/exec.js
@@ -6,11 +6,11 @@ import { getChangedFiles, getHeadCommit } from "./git.js";
 import { runScan, runDoc } from "./commands.js";
 import { validateRepo } from "./validate.js";
 import { finalizeSessionMemoryRun, normalizeInteractiveCapture, prepareSessionMemoryRun } from "./session-memory.js";
+import { createBoundedCaptureBuffer, DEFAULT_CAPTURE_MAX_KB, normalizeCaptureMaxBytes } from "./capture-buffer.js";
 import * as ui from "./ui.js";
 
 const AGENTIFY_EXIT_VALIDATE_FAILED = 80;
 const AGENTIFY_EXIT_REFRESH_ERROR = 81;
-const DEFAULT_CAPTURE_MAX_KB = 48;
 
 function getSnapshotKey(file) {
   return `${file.status}:${file.path}`;
@@ -110,31 +110,7 @@ function buildScriptCommand(argv, capturePath) {
 }
 
 function getCaptureBufferMaxBytes(config) {
-  const maxKb = Number(config?.session?.captureMaxKb);
-  const normalizedKb = Number.isFinite(maxKb) && maxKb > 0 ? maxKb : DEFAULT_CAPTURE_MAX_KB;
-  return normalizedKb * 1024;
-}
-
-function createBoundedCaptureBuffer(maxBytes) {
-  const chunks = [];
-  let totalBytes = 0;
-
-  return {
-    append(chunk) {
-      if (maxBytes <= 0 || totalBytes >= maxBytes || !chunk?.length) {
-        return;
-      }
-
-      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      const remaining = maxBytes - totalBytes;
-      const slice = buffer.length <= remaining ? buffer : buffer.subarray(0, remaining);
-      chunks.push(Buffer.from(slice));
-      totalBytes += slice.length;
-    },
-    toString() {
-      return totalBytes > 0 ? Buffer.concat(chunks, totalBytes).toString("utf8") : "";
-    },
-  };
+  return normalizeCaptureMaxBytes(config?.session?.captureMaxKb, DEFAULT_CAPTURE_MAX_KB);
 }
 
 function runWrappedCommand(argv, options) {

--- a/src/core/project-tests.js
+++ b/src/core/project-tests.js
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
 
+import { createBoundedCaptureBuffer, DEFAULT_CAPTURE_MAX_KB, normalizeCaptureMaxBytes } from "./capture-buffer.js";
 import { exists, readJson } from "./fs.js";
 
 const DEFAULT_PASSTHROUGH_ENV = Object.freeze([
@@ -81,17 +82,21 @@ export function buildTestEnv(testsConfig = {}, sourceEnv = process.env) {
   return env;
 }
 
-async function runChildCommand(command, args, { cwd, env } = {}) {
-  const stdoutChunks = [];
-  const stderrChunks = [];
+function getTestOutputMaxBytes(testsConfig = {}) {
+  return normalizeCaptureMaxBytes(testsConfig.outputMaxKb, DEFAULT_CAPTURE_MAX_KB);
+}
+
+async function runChildCommand(command, args, { cwd, env, outputMaxBytes } = {}) {
+  const stdoutCapture = createBoundedCaptureBuffer(outputMaxBytes);
+  const stderrCapture = createBoundedCaptureBuffer(outputMaxBytes);
 
   const code = await new Promise((resolve, reject) => {
     const child = spawn(command, args, { cwd, env });
     child.stdout.on("data", (chunk) => {
-      stdoutChunks.push(String(chunk));
+      stdoutCapture.append(chunk);
     });
     child.stderr.on("data", (chunk) => {
-      stderrChunks.push(String(chunk));
+      stderrCapture.append(chunk);
     });
     child.on("error", reject);
     child.on("close", resolve);
@@ -99,8 +104,13 @@ async function runChildCommand(command, args, { cwd, env } = {}) {
 
   return {
     code: Number(code ?? 1),
-    stdout: stdoutChunks.join(""),
-    stderr: stderrChunks.join(""),
+    stdout: stdoutCapture.toString(),
+    stderr: stderrCapture.toString(),
+    stdoutTruncated: stdoutCapture.truncated,
+    stderrTruncated: stderrCapture.truncated,
+    stdoutBytes: stdoutCapture.seenBytes,
+    stderrBytes: stderrCapture.seenBytes,
+    outputMaxBytes,
   };
 }
 
@@ -142,6 +152,8 @@ export async function detectTestCommand(root) {
 }
 
 export async function runProjectTests(root, reporter, options = {}) {
+  const testsConfig = options.config?.tests || options.tests || {};
+  const outputMaxBytes = getTestOutputMaxBytes(testsConfig);
   const testCommand = await detectTestCommand(root);
   if (!testCommand) {
     const result = {
@@ -150,6 +162,11 @@ export async function runProjectTests(root, reporter, options = {}) {
       command: null,
       stdout: "",
       stderr: "",
+      stdout_truncated: false,
+      stderr_truncated: false,
+      stdout_bytes: 0,
+      stderr_bytes: 0,
+      output_max_bytes: outputMaxBytes,
       exit_code: null,
     };
     reporter.log("tests: skipped because no package.json test script was found");
@@ -157,14 +174,19 @@ export async function runProjectTests(root, reporter, options = {}) {
     return result;
   }
 
-  const testsConfig = options.config?.tests || options.tests || {};
   const env = buildTestEnv(testsConfig);
 
   reporter.log(`tests: running ${testCommand.command} ${testCommand.args.join(" ")}`);
   if (testsConfig.env?.inherit !== true) {
     reporter.log("tests: subprocess env is sanitized; configure tests.env.passthrough or tests.env.extra to expose vars");
   }
-  const outcome = await runChildCommand(testCommand.command, testCommand.args, { cwd: root, env });
+  const outcome = await runChildCommand(testCommand.command, testCommand.args, { cwd: root, env, outputMaxBytes });
+  if (outcome.stdoutTruncated) {
+    reporter.log(`tests: stdout truncated to ${outcome.outputMaxBytes} bytes from ${outcome.stdoutBytes} bytes; configure tests.outputMaxKb to adjust`);
+  }
+  if (outcome.stderrTruncated) {
+    reporter.log(`tests: stderr truncated to ${outcome.outputMaxBytes} bytes from ${outcome.stderrBytes} bytes; configure tests.outputMaxKb to adjust`);
+  }
   if (outcome.stdout) {
     reporter.appendSection("[tests stdout]", outcome.stdout);
   }
@@ -178,6 +200,11 @@ export async function runProjectTests(root, reporter, options = {}) {
     command: `${testCommand.command} ${testCommand.args.join(" ")}`,
     stdout: outcome.stdout,
     stderr: outcome.stderr,
+    stdout_truncated: outcome.stdoutTruncated,
+    stderr_truncated: outcome.stderrTruncated,
+    stdout_bytes: outcome.stdoutBytes,
+    stderr_bytes: outcome.stderrBytes,
+    output_max_bytes: outcome.outputMaxBytes,
     exit_code: outcome.code,
   };
   reporter.log(`tests: ${result.status}`);

--- a/src/core/run-report.js
+++ b/src/core/run-report.js
@@ -58,8 +58,18 @@ export function renderHtmlReport(summary) {
   const testStderr = summary.tests?.stderr || "";
   const testStdout = summary.tests?.stdout || "";
   const testCombined = [testStdout, testStderr].filter(Boolean).join("\n");
+  const testTruncationMessages = [];
+  if (summary.tests?.stdout_truncated) {
+    testTruncationMessages.push(`stdout captured ${summary.tests.output_max_bytes} of ${summary.tests.stdout_bytes} bytes`);
+  }
+  if (summary.tests?.stderr_truncated) {
+    testTruncationMessages.push(`stderr captured ${summary.tests.output_max_bytes} of ${summary.tests.stderr_bytes} bytes`);
+  }
+  const testOutputNotice = testTruncationMessages.length > 0
+    ? `<p class="muted mono-sm">test output was truncated: ${escapeHtml(testTruncationMessages.join("; "))}. Configure <code>tests.outputMaxKb</code> to adjust the limit.</p>`
+    : "";
   const testOutput = summary.tests
-    ? `<details class="term-details"><summary>test output · stdout/stderr</summary><pre class="term-body small">${escapeHtml(testCombined)}</pre></details>`
+    ? `${testOutputNotice}<details class="term-details"><summary>test output · stdout/stderr</summary><pre class="term-body small">${escapeHtml(testCombined)}</pre></details>`
     : `<p class="muted mono-sm">no test run was recorded.</p>`;
 
   const rerunUpdateCommand = sanitizeForJsString("agentify up --provider local");

--- a/test/project-tests.test.js
+++ b/test/project-tests.test.js
@@ -176,3 +176,37 @@ test("runProjectTests forwards a configured passthrough variable", async () => {
     }
   }
 });
+
+test("runProjectTests bounds captured stdout and stderr and reports truncation", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-test-output-bound-"));
+  const scriptPath = path.join(root, "emit-output.js");
+  const stdoutPayload = "a".repeat(1536);
+  const stderrPayload = "b".repeat(1536);
+
+  await fs.writeFile(scriptPath, `
+    process.stdout.write(${JSON.stringify(stdoutPayload)});
+    process.stderr.write(${JSON.stringify(stderrPayload)});
+  `);
+  await fs.writeFile(path.join(root, "package.json"), JSON.stringify({
+    name: "agentify-output-bound",
+    scripts: { test: "node emit-output.js" },
+  }, null, 2));
+
+  const reporter = createReporter();
+  const result = await runProjectTests(root, reporter, {
+    config: { tests: { outputMaxKb: 1 } },
+  });
+
+  assert.equal(result.status, "passed");
+  assert.equal(result.stdout_truncated, true);
+  assert.equal(result.stderr_truncated, true);
+  assert.equal(result.output_max_bytes, 1024);
+  assert.equal(Buffer.byteLength(result.stdout, "utf8"), 1024);
+  assert.equal(Buffer.byteLength(result.stderr, "utf8"), 1024);
+  assert.equal(reporter.tests.stdout_truncated, true);
+  assert.equal(reporter.tests.stderr_truncated, true);
+  assert.match(reporter.logs.join("\n"), /stdout truncated to 1024 bytes/);
+  assert.match(reporter.logs.join("\n"), /stderr truncated to 1024 bytes/);
+  assert.equal(Buffer.byteLength(reporter.sections.find((section) => section.title === "[tests stdout]").body, "utf8"), 1024);
+  assert.equal(Buffer.byteLength(reporter.sections.find((section) => section.title === "[tests stderr]").body, "utf8"), 1024);
+});

--- a/test/run-report.test.js
+++ b/test/run-report.test.js
@@ -59,3 +59,38 @@ test("createRunReporter persists output and HTML report", async (t) => {
   assert.match(html, /Total tokens/);
   assert.match(html, /&lt;script&gt;alert\('xss'\)&lt;\/script&gt;/);
 });
+
+test("createRunReporter shows test output truncation metadata in HTML", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-run-report-truncated-"));
+  const previousSilent = false;
+  setSilent(true);
+  t.after(() => {
+    setSilent(previousSilent);
+  });
+
+  const reporter = createRunReporter(root);
+  reporter.setCommand("up");
+  reporter.setValidation({ passed: true, failures: [] });
+  reporter.setTests({
+    status: "failed",
+    passed: false,
+    command: "npm test",
+    stdout: "a".repeat(16),
+    stderr: "b".repeat(16),
+    stdout_truncated: true,
+    stderr_truncated: true,
+    stdout_bytes: 1536,
+    stderr_bytes: 1536,
+    output_max_bytes: 1024,
+    exit_code: 1,
+  });
+
+  await reporter.finalize();
+
+  const html = await fs.readFile(path.join(root, "agentify-report.html"), "utf8");
+
+  assert.match(html, /test output was truncated/);
+  assert.match(html, /stdout captured 1024 of 1536 bytes/);
+  assert.match(html, /stderr captured 1024 of 1536 bytes/);
+  assert.match(html, /tests\.outputMaxKb/);
+});

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -296,15 +296,18 @@ test("runUpdate persists test metadata for passing and failing up and sync run r
       }
 
       const persistedRun = await readLatestRunReport(root, testCase.commandName);
-      const expectedTests = {
-        status: testCase.expectedStatus,
-        passed: testCase.expectedPassed,
-        command: "npm test",
-        exit_code: testCase.exitCode,
-      };
-
-      assert.deepEqual(finalOutput.tests, expectedTests);
-      assert.deepEqual(persistedRun.tests, expectedTests);
+      for (const tests of [finalOutput.tests, persistedRun.tests]) {
+        assert.equal(tests.status, testCase.expectedStatus);
+        assert.equal(tests.passed, testCase.expectedPassed);
+        assert.equal(tests.command, "npm test");
+        assert.equal(tests.stdout_truncated, false);
+        assert.equal(tests.stderr_truncated, false);
+        assert.equal(typeof tests.stdout_bytes, "number");
+        assert.equal(typeof tests.stderr_bytes, "number");
+        assert.equal(tests.output_max_bytes, 49152);
+        assert.equal(tests.exit_code, testCase.exitCode);
+      }
+      assert.deepEqual(finalOutput.tests, persistedRun.tests);
     }
   } finally {
     process.exitCode = previousExitCode;


### PR DESCRIPTION
## Summary
- Bound agentify up project-test stdout/stderr capture with a configurable tests.outputMaxKb limit.
- Report stdout/stderr truncation metadata in CLI logs, JSON test summaries, and HTML reports.
- Share the bounded capture buffer with exec capture and cover large-output regression behavior.

Closes #44

## Tests
- node --test test/project-tests.test.js
- node --test test/run-report.test.js
- node --test test/exec.test.js
- node --test test/update.test.js
- git diff --check

## Notes
- Full npm test currently has one unrelated failure in test/session.test.js: loadAutomaticRunMemory uses MemPalace automatically when the CLI is available. It fails because the expected mempalace-calls.log fixture file is not created in this environment.