### PR TITLE
fix: preserve interactive session memory on PTY log loss

### DIFF
--- a/src/core/exec.js
+++ b/src/core/exec.js
@@ -178,23 +178,25 @@ function runWrappedCommand(argv, options) {
     child.on("error", reject);
     child.on("close", async (code) => {
       if (timer) clearTimeout(timer);
-      try {
-        let interactiveTranscript = "";
-        if (captureMode === "pty" && options.capturePath) {
+      let interactiveTranscript = "";
+      let interactiveCaptureError = "";
+      if (captureMode === "pty" && options.capturePath) {
+        try {
           const raw = await fs.readFile(options.capturePath, "utf8");
           interactiveTranscript = normalizeInteractiveCapture(raw);
+        } catch (error) {
+          interactiveCaptureError = `Unable to read PTY transcript log: ${error.message}`;
         }
-
-        resolve({
-          exitCode: code ?? 1,
-          stdout: captureMode === "pipe" ? stdoutCapture.toString() : "",
-          stderr: captureMode === "pipe" ? stderrCapture.toString() : "",
-          interactiveTranscript,
-          rawInteractiveLogPath: captureMode === "pty" ? options.capturePath : null,
-        });
-      } catch (error) {
-        reject(error);
       }
+
+      resolve({
+        exitCode: code ?? 1,
+        stdout: captureMode === "pipe" ? stdoutCapture.toString() : "",
+        stderr: captureMode === "pipe" ? stderrCapture.toString() : "",
+        interactiveTranscript,
+        interactiveCaptureError,
+        rawInteractiveLogPath: captureMode === "pty" && !interactiveCaptureError ? options.capturePath : null,
+      });
     });
   });
 }
@@ -250,6 +252,7 @@ export async function runExec(root, config, agentCommand, flags) {
       stdout: commandResult.stdout,
       stderr: commandResult.stderr,
       interactiveTranscript: commandResult.interactiveTranscript,
+      interactiveCaptureError: commandResult.interactiveCaptureError,
       rawInteractiveLogPath: commandResult.rawInteractiveLogPath,
     };
     if (preparedSessionMemory) {
@@ -281,6 +284,7 @@ export async function runExec(root, config, agentCommand, flags) {
       stdout: commandResult.stdout,
       stderr: commandResult.stderr,
       interactiveTranscript: commandResult.interactiveTranscript,
+      interactiveCaptureError: commandResult.interactiveCaptureError,
       rawInteractiveLogPath: commandResult.rawInteractiveLogPath,
     };
     if (preparedSessionMemory) {
@@ -304,6 +308,7 @@ export async function runExec(root, config, agentCommand, flags) {
       stdout: commandResult.stdout,
       stderr: `${commandResult.stderr}${commandResult.stderr ? "\n" : ""}${error.message}`,
       interactiveTranscript: commandResult.interactiveTranscript,
+      interactiveCaptureError: commandResult.interactiveCaptureError,
       rawInteractiveLogPath: commandResult.rawInteractiveLogPath,
     };
     if (preparedSessionMemory) {
@@ -332,6 +337,7 @@ export async function runExec(root, config, agentCommand, flags) {
     stdout: commandResult.stdout,
     stderr: commandResult.stderr,
     interactiveTranscript: commandResult.interactiveTranscript,
+    interactiveCaptureError: commandResult.interactiveCaptureError,
     rawInteractiveLogPath: commandResult.rawInteractiveLogPath,
   };
   if (preparedSessionMemory) {

--- a/src/core/session-memory.js
+++ b/src/core/session-memory.js
@@ -971,6 +971,7 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
       `Validation: ${validationSummary}`,
       `Capture mode used: ${sessionRecord.captureMode}`,
       outcome?.rawInteractiveLogPath ? `Raw interactive log: ${relative(root, outcome.rawInteractiveLogPath)}` : null,
+      outcome?.interactiveCaptureError ? `Interactive capture warning: ${outcome.interactiveCaptureError}` : null,
       `Ended: ${endedAt}`,
       ""
     ].filter(Boolean).join("\n");
@@ -1001,6 +1002,7 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
     validation: validationSummary,
     stdout: clipToBytes(outcome?.stdout || "", captureMaxBytes),
     stderr: clipToBytes(outcome?.stderr || "", captureMaxBytes),
+    interactive_capture_error: outcome?.interactiveCaptureError || null,
   };
   await fs.appendFile(prepared.paths.launchesPath, `${JSON.stringify(launchRecord)}\n`, "utf8");
 

--- a/test/exec.test.js
+++ b/test/exec.test.js
@@ -300,3 +300,50 @@ test("runExec records interactive provider output into a raw PTY log and normali
     assert.match(rawLog, /interactive transcript/);
   }
 });
+
+test("runExec finalizes session memory when the PTY recorder log is unavailable", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-exec-interactive-log-missing-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex", dryRun: false, tokenReport: false });
+  const session = await forkSession(root, config, { name: "codex-interactive-log-missing" });
+  const script = [
+    "import fs from 'node:fs/promises';",
+    `await fs.unlink(${JSON.stringify(path.join(session.sessionDir, "interactive.log"))});`,
+    "process.stdout.write('transcript hidden in removed pty log\\n');",
+  ].join("");
+  const result = await runExec(
+    root,
+    config,
+    ["node", "--input-type=module", "-e", script],
+    {
+      captureOutputMode: "pty",
+      sessionRecord: {
+        sessionId: session.sessionId,
+        provider: "codex",
+        prompt: "Continue the codex interactive session.",
+        task: "Verify PTY capture fallback finalization.",
+        command: ["node", "--input-type=module", "-e", script],
+        memoryContext: {
+          sourceSessionId: null,
+          transcriptRelativePath: null,
+          excerpt: "",
+          markdown: "## Automatic Session Memory\nNo prior session transcript was available.\n",
+        },
+        captureMode: "interactive-pty",
+      },
+    }
+  );
+
+  const transcript = await fs.readFile(path.join(session.sessionDir, "transcript.md"), "utf8");
+  const launches = await fs.readFile(path.join(session.sessionDir, "launches.jsonl"), "utf8");
+
+  assert.equal(result.phase, "complete");
+  assert.equal(result.exitCode, 0);
+  assert.match(transcript, /full assistant transcript was not captured/);
+  assert.match(transcript, /Interactive capture warning: Unable to read PTY transcript log:/);
+  assert.doesNotMatch(transcript, /Raw interactive log:/);
+  assert.match(launches, /"raw_interactive_log_path":null/);
+  assert.match(launches, /"interactive_capture_error":"Unable to read PTY transcript log:/);
+});


### PR DESCRIPTION
## Summary
- keep PTY-backed interactive session execution from failing if the raw recorder log disappears before normalization
- record an explicit interactive capture warning in transcript and launch metadata
- add regression coverage that session memory still finalizes when the PTY log is unavailable

## Tests
- npm test -- --test-name-pattern='runExec records interactive provider output|runExec finalizes session memory|runExec writes MemPalace|prepareSessionLaunch|getSessionCaptureSettings'
- env -u AGENTIFY_MEMPALACE_CMD npm test

Links #38