### PR TITLE
docs: align CLI reference with live help

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,62 @@ Supported levels are `lite`, `full`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-f
 
 > **Note** — `agentify up` runs the repo's detected `package.json` test script in a **sanitized environment** by default. The host shell's environment is not forwarded to the test subprocess; configure `tests.env.passthrough` / `tests.env.extra` (or set `tests.env.inherit: true`) in `.agentify.yaml` if a test suite needs specific variables. See [docs/DETAILED_README.md](./docs/DETAILED_README.md#project-test-environment) for the allowlist and override schema.
 
+## CLI Reference
+
+### Commands
+
+| Command | Description |
+| --- | --- |
+| `init` | Create baseline Agentify artifacts |
+| `index` | Build the SQLite repository index |
+| `scan` | Alias for index |
+| `doc` | Generate docs, metadata, and key-file headers |
+| `up` | Run scan -> optional doc -> check -> test pipeline |
+| `sync` | Upgrade repo-owned Agentify files, then run refresh |
+| `check` | Validate freshness, schemas, and safety rules |
+| `plan` | Preview the planner-selected context for a task |
+| `run` | Run provider template command with auto-refresh |
+| `exec` | Advanced wrapper for custom agent commands |
+| `this` | Bootstrap this macOS repo for a provider-backed Agentify workflow |
+| `query` | Query the repository index (owner, deps, changed) |
+| `skill` | Manage built-in agent skills |
+| `sess` | Manage provider-backed sessions |
+| `memory` | Manage agent memory helpers |
+| `issue-killer` | Launch labelled GitHub issues into supervised tmux worktrees |
+| `hooks` | Install/remove git hooks |
+| `doctor` | Check toolchain health and capability tier |
+| `semantic` | Refresh semantic TS/JS project facts |
+| `clean` | Prune stale generated artifacts and dead Agentify folders |
+| `cache` | Manage the content cache |
+
+### Options
+
+| Option | Description |
+| --- | --- |
+| `--provider <local|codex|claude|gemini|opencode>` | Choose a provider. `skill install` also accepts comma lists and `all`. |
+| `--strict <true|false>` | Fail closed on validation issues |
+| `--languages <auto|ts|python|go|rust|dotnet|java|kotlin|swift>` | Override language detection |
+| `--dry-run` | Report planned changes without writing |
+| `--docs` | Generate docs during refresh/update flows (off by default) |
+| `--headers` | Apply `@agentify` headers to source files (off by default) |
+| `--provider-timeout-ms <ms>` | Fail provider doc calls after N milliseconds |
+| `--ghost` | Route outputs to `.current_session/` |
+| `--json` | Machine-readable JSON output only |
+| `--interactive`, `-i` | Force interactive mode (template providers default to interactive for `run`/`sess`) |
+| `--explain-plan` | Print planner output before executing `run` |
+| `--caveman[=level]` | Terse output for `run`/`sess` (`lite`, `full`, `ultra`, `wenyan*`) |
+| `--root <path>` | Target repo root (default: cwd) |
+| `--scope <project|user>` | Skill install scope (`skill` command) |
+| `--hook` | Hook-friendly check: skip changed-file body diffing (used by managed pre-commit) |
+
+### Exec Flags
+
+| Flag | Description |
+| --- | --- |
+| `--fail-on-stale` | Exit 80 if validation fails post-refresh |
+| `--timeout <seconds>` | Kill wrapped command after N seconds |
+| `--skip-refresh` | Skip post-command refresh |
+
 ## What Agentify Creates
 
 Depending on the command, Agentify can create or refresh:

--- a/docs/DETAILED_README.md
+++ b/docs/DETAILED_README.md
@@ -192,6 +192,7 @@ Normal `run` is intentionally lightweight. It does not persist durable session m
 | `agentify query search` | Searches the index for matching files, symbols, and semantic surfaces. | Use when you need a repo-aware search that goes beyond raw grep, especially after indexing and semantic refresh. | `agentify query search --term retry` |
 | `agentify skill list` | Lists built-in skills available for installation. | Use when you want to see what behavior bundles Agentify can install for a provider. | `agentify skill list` |
 | `agentify skill install` | Installs one built-in skill or all built-ins into project or user scope. | Use when you want repeatable agent behavior shared at the repo level or available globally for a provider. | `agentify skill install all --provider codex --scope project` |
+| `agentify memory compress` | Reserved helper for future agent memory compression workflows. | Use only when following a memory-compression skill flow; today it reports the placeholder follow-up. | `agentify memory compress AGENTIFY.md` |
 | `agentify hooks install` | Installs Agentify git hooks. | Use when you want automatic validation or refresh behavior tied to Git events. | `agentify hooks install` |
 | `agentify hooks status` | Shows whether Agentify hooks are installed. | Use when you are verifying local setup or debugging why hook-driven behavior is missing. | `agentify hooks status` |
 | `agentify hooks remove` | Removes Agentify git hooks. | Use when you want to disable Agentify-managed hook behavior cleanly. | `agentify hooks remove` |
@@ -317,12 +318,17 @@ In the second command, Agentify reuses `codex` for the same repo.
 | `--strict <true|false>` | Tighten validation behavior. Use this when you want failures to stop the workflow instead of being treated leniently. |
 | `--languages <auto|ts|python|go|rust|dotnet|java|kotlin|swift>` | Override language detection. Use this when auto-detection is wrong or too broad for the repo. |
 | `--dry-run` | Show what Agentify would do without writing changes. Use this before cleanup, installs, or config-affecting commands. |
+| `--docs` | Generate docs during refresh/update flows. It is off by default for `up` and `sync`. |
+| `--headers` | Apply `@agentify` headers to source files. It is off by default. |
+| `--provider-timeout-ms <ms>` | Fail provider doc calls after the given number of milliseconds. Use this to keep doc-generation subprocesses bounded. |
 | `--ghost` | Route outputs into `.current_session/`. Use this for ephemeral runs where you want isolated output artifacts. |
 | `--json` | Emit machine-readable JSON. Use this when scripting around Agentify or integrating it into tooling. |
 | `--interactive`, `-i` | Force interactive provider mode. Template providers already default to interactive mode for `run` and `sess`, but this is useful when you want to be explicit. |
 | `--explain-plan` | Print the planner result before `run` executes. Use this when you want to inspect Agentify's chosen context first. |
+| `--caveman[=level]` | Request terse output for `run` and `sess`. Supported levels include `lite`, `full`, `ultra`, and `wenyan*` variants. |
 | `--root <path>` | Target a repo other than the current working directory. Use this in scripts or monorepo tooling. |
 | `--scope <project|user>` | Choose where skills are installed. Use `project` for repo-local behavior and `user` for account-level installs. |
+| `--hook` | Run hook-friendly `check` behavior by skipping changed-file body diffing. This is used by managed pre-commit hooks. |
 
 ### `exec`-Only Flags
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -19,6 +19,36 @@ async function initGitRepo(root) {
   await execFileAsync("git", ["commit", "-m", "initial"], { cwd: root });
 }
 
+async function captureHelpText() {
+  const chunks = [];
+  const originalWrite = process.stderr.write;
+  process.stderr.write = function write(chunk, encoding, callback) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk));
+    if (typeof encoding === "function") {
+      encoding();
+    } else if (typeof callback === "function") {
+      callback();
+    }
+    return true;
+  };
+
+  try {
+    await runCli(["--help"]);
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+
+  return chunks.join("").replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+function extractHelpSection(help, heading, nextHeading) {
+  const start = help.indexOf(heading);
+  assert.notEqual(start, -1, `missing help heading ${heading}`);
+  const end = nextHeading ? help.indexOf(nextHeading, start + heading.length) : help.length;
+  assert.notEqual(end, -1, `missing help heading ${nextHeading}`);
+  return help.slice(start + heading.length, end);
+}
+
 test("parseArgs normalizes dashed flags to camelCase", () => {
   const args = parseArgs([
     "doc",
@@ -32,6 +62,30 @@ test("parseArgs normalizes dashed flags to camelCase", () => {
   assert.equal(args.provider, "codex");
   assert.equal(args.moduleConcurrency, 6);
   assert.equal(args.maxFilesPerModule, 12);
+});
+
+test("README CLI reference includes every command and option from help", async () => {
+  const help = await captureHelpText();
+  const readme = await fs.readFile(new URL("../README.md", import.meta.url), "utf8");
+  const commandSection = extractHelpSection(help, "COMMANDS", "OPTIONS");
+  const optionSection = extractHelpSection(help, "OPTIONS", "EXEC FLAGS");
+  const execFlagSection = extractHelpSection(help, "EXEC FLAGS", "EXAMPLES");
+
+  const commands = [...commandSection.matchAll(/^\s{4}([a-z][a-z-]*)\s{2,}/gm)].map((match) => match[1]);
+  const flags = [...`${optionSection}\n${execFlagSection}`.matchAll(/(--[a-z][a-z-]*(?:\[\=level\])?)/g)]
+    .map((match) => match[1])
+    .filter((flag, index, all) => all.indexOf(flag) === index);
+
+  assert.ok(commands.length > 0, "expected commands in help");
+  assert.ok(flags.length > 0, "expected flags in help");
+
+  for (const command of commands) {
+    assert.match(readme, new RegExp(`\\| \`${command}\` \\|`), `README is missing command ${command}`);
+  }
+
+  for (const flag of flags) {
+    assert.match(readme, new RegExp(`\\| \`${flag.replace("[", "\\[").replace("]", "\\]")}`), `README is missing flag ${flag}`);
+  }
 });
 
 test("parseArgs supports short help and version flags", () => {


### PR DESCRIPTION
## Summary
- Add a public README CLI reference covering every command, option, and exec flag from `agentify --help`
- Fill remaining detailed guide drift for live-help flags and the memory helper command
- Add a regression test that compares README command/option coverage against live help output

Closes #23

## Verification
- `node --test test/main.test.js`
- `env -u AGENTIFY_MEMPALACE_CMD pnpm test`

Note: `pnpm test` without unsetting `AGENTIFY_MEMPALACE_CMD` failed in the pre-existing MemPalace fake CLI test because this pane had `AGENTIFY_MEMPALACE_CMD` set, which bypassed the test fake binary.