### PR TITLE
fix: refresh docs from post-merge hook

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -320,7 +320,7 @@ This adds:
   validator still checks freshness and unsafe generated artifacts under
   `.agents/` and `docs/`, but it does not flag intentional source-file edits in
   the working tree, so ordinary commits are not blocked.
-- a `post-merge` hook that refreshes the scan
+- a `post-merge` hook that refreshes the scan and deterministic local docs
 
 ### 2. Install project-local skills for Codex
 

--- a/src/core/hooks.js
+++ b/src/core/hooks.js
@@ -11,8 +11,8 @@ agentify check --hook
 `;
 
 const POST_MERGE_BODY = `${AGENTIFY_MARKER} post-merge hook
-# Refreshes index and metadata after merge
-agentify scan --json >/dev/null 2>&1 || true
+# Refreshes index, docs, and metadata after merge
+agentify scan --json >/dev/null 2>&1 && agentify doc --provider local --json >/dev/null 2>&1 || true
 `;
 
 const HOOK_BODIES = [

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1,10 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 
 import { installHooks } from "../src/core/hooks.js";
+
+const execFileAsync = promisify(execFile);
 
 test("installHooks writes a valid post-merge refresh command", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-hooks-"));
@@ -13,8 +17,35 @@ test("installHooks writes a valid post-merge refresh command", async () => {
   await installHooks(root);
 
   const postMerge = await fs.readFile(path.join(root, ".git", "hooks", "post-merge"), "utf8");
-  assert.match(postMerge, /agentify scan --json >\/dev\/null 2>&1 \|\| true/);
+  assert.match(postMerge, /Refreshes index, docs, and metadata after merge/);
+  assert.match(postMerge, /agentify scan --json >\/dev\/null 2>&1 && agentify doc --provider local --json >\/dev\/null 2>&1 \|\| true/);
   assert.doesNotMatch(postMerge, /--skip-finalize/);
+});
+
+test("installed post-merge hook refreshes scan and local docs", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-hooks-run-"));
+  const hooksDir = path.join(root, ".git", "hooks");
+  const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-hooks-bin-"));
+  const logPath = path.join(root, "hook.log");
+  await fs.mkdir(hooksDir, { recursive: true });
+  await fs.writeFile(path.join(binDir, "agentify"), "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$AGENTIFY_HOOK_LOG\"\n", "utf8");
+  await fs.chmod(path.join(binDir, "agentify"), 0o755);
+
+  await installHooks(root);
+  await execFileAsync(path.join(hooksDir, "post-merge"), [], {
+    cwd: root,
+    env: {
+      ...process.env,
+      AGENTIFY_HOOK_LOG: logPath,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
+    },
+  });
+
+  const calls = (await fs.readFile(logPath, "utf8")).trim().split("\n");
+  assert.deepEqual(calls, [
+    "scan --json",
+    "doc --provider local --json",
+  ]);
 });
 
 test("installHooks writes a hook-friendly pre-commit body", async () => {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -410,7 +410,7 @@ test("runCli sync upgrades repo-owned Agentify assets and emits sync json", asyn
   assert.match(gitignoreText, /# >>> agentify generated artifacts/);
   assert.match(gitignoreText, /^\.agents\/$/m);
   assert.match(skillText, /Interview the user relentlessly/);
-  assert.match(hookText, /agentify scan --json >\/dev\/null 2>&1 \|\| true/);
+  assert.match(hookText, /agentify scan --json >\/dev\/null 2>&1 && agentify doc --provider local --json >\/dev\/null 2>&1 \|\| true/);
   await assert.doesNotReject(() => fs.access(path.join(root, ".agentignore")));
   await assert.doesNotReject(() => fs.access(path.join(root, ".guardrails")));
 });


### PR DESCRIPTION
## Summary
- update the managed post-merge hook to run scan followed by deterministic local doc generation
- cover the installed hook behavior with a fake agentify binary and update sync expectations
- clarify hook behavior in usage docs

Closes #45

## Tests
- node --test test/hooks.test.js test/main.test.js
- env -u AGENTIFY_MEMPALACE_CMD pnpm exec node --test --test-concurrency=1

Note: plain `pnpm test` failed in this shell because `AGENTIFY_MEMPALACE_CMD` points at a non-invokable host path, causing the MemPalace auto-detection test to bypass its fake PATH binary. The env-clean serial run passed: 194 passing, 1 skipped.