### PR TITLE
fix: honor configured hook installation

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -31,7 +31,6 @@ const DEFAULT_CONFIG = {
   hooks: {
     preCommit: true,
     postMerge: true,
-    autoRefresh: false,
   },
   cache: {
     enabled: true,
@@ -141,6 +140,15 @@ function applyNestedFlags(config, flags) {
   return result;
 }
 
+function normalizeConfig(config) {
+  const normalized = { ...config };
+  if (normalized.hooks && typeof normalized.hooks === "object" && !Array.isArray(normalized.hooks)) {
+    const { autoRefresh: _autoRefresh, ...hooks } = normalized.hooks;
+    normalized.hooks = hooks;
+  }
+  return normalized;
+}
+
 export async function loadConfig(root, flags = {}) {
   let fileConfig = {};
   const configPath = path.join(root, ".agentify.yaml");
@@ -154,7 +162,7 @@ export async function loadConfig(root, flags = {}) {
   }
 
   const merged = deepMerge(DEFAULT_CONFIG, fileConfig);
-  return applyNestedFlags(merged, flags);
+  return normalizeConfig(applyNestedFlags(merged, flags));
 }
 
 export async function writeDefaultConfig(root, config, { dryRun = false } = {}) {
@@ -184,7 +192,7 @@ export async function writeDefaultConfig(root, config, { dryRun = false } = {}) 
     topKeyFilesPerModule: config.topKeyFilesPerModule,
     budgets: config.budgets,
     toolchain: config.toolchain,
-    hooks: config.hooks,
+    hooks: normalizeConfig(config).hooks,
     cache: config.cache,
     cleanup: config.cleanup,
     session: config.session,
@@ -215,7 +223,7 @@ export async function syncConfigFile(root, config, { dryRun = false } = {}) {
     }
   }
 
-  const merged = deepMerge(DEFAULT_CONFIG, fileConfig);
+  const merged = normalizeConfig(deepMerge(DEFAULT_CONFIG, fileConfig));
   if (!existing && config?.provider) {
     merged.provider = config.provider;
   }

--- a/src/core/hooks.js
+++ b/src/core/hooks.js
@@ -16,9 +16,13 @@ agentify scan --json >/dev/null 2>&1 || true
 `;
 
 const HOOK_BODIES = [
-  ["pre-commit", PRE_COMMIT_BODY],
-  ["post-merge", POST_MERGE_BODY],
+  { name: "pre-commit", configKey: "preCommit", body: PRE_COMMIT_BODY },
+  { name: "post-merge", configKey: "postMerge", body: POST_MERGE_BODY },
 ];
+
+function isHookEnabled(settings, configKey) {
+  return settings?.[configKey] !== false;
+}
 
 function renderHookScript(body) {
   return `#!/bin/sh\n${body.trimEnd()}\n`;
@@ -70,16 +74,37 @@ function composeHookContent(existing, body) {
   return `${remaining}\n\n${body.trimEnd()}\n`;
 }
 
-export async function installHooks(root) {
+async function removeManagedHookBlock(hookPath) {
+  const content = await safeRead(hookPath);
+  if (!content || !content.includes(AGENTIFY_MARKER)) return false;
+
+  const { remaining } = stripAgentifyBlock(content);
+  if (remaining && remaining !== "#!/bin/sh") {
+    await writeText(hookPath, `${remaining}\n`);
+  } else {
+    await fs.unlink(hookPath).catch(() => {});
+  }
+  return true;
+}
+
+export async function installHooks(root, settings = {}) {
   const hooksDir = path.join(root, ".git", "hooks");
   if (!(await exists(hooksDir))) {
     throw new Error(".git/hooks directory not found — is this a git repository?");
   }
 
   const installed = [];
+  const removed = [];
 
-  for (const [name, body] of HOOK_BODIES) {
+  for (const { name, configKey, body } of HOOK_BODIES) {
     const hookPath = path.join(hooksDir, name);
+    if (!isHookEnabled(settings, configKey)) {
+      if (await removeManagedHookBlock(hookPath)) {
+        removed.push(name);
+      }
+      continue;
+    }
+
     const existing = await safeRead(hookPath);
     const next = composeHookContent(existing, body);
 
@@ -92,7 +117,7 @@ export async function installHooks(root) {
     installed.push(name);
   }
 
-  return installed;
+  return { installed, removed };
 }
 
 export async function removeHooks(root) {
@@ -100,7 +125,7 @@ export async function removeHooks(root) {
   if (!(await exists(hooksDir))) return [];
 
   const removed = [];
-  for (const [name] of HOOK_BODIES) {
+  for (const { name } of HOOK_BODIES) {
     const hookPath = path.join(hooksDir, name);
     const content = await safeRead(hookPath);
     if (!content || !content.includes(AGENTIFY_MARKER)) continue;
@@ -130,7 +155,7 @@ export async function statusHooks(root) {
   };
 }
 
-export async function syncManagedHooks(root, { dryRun = false } = {}) {
+export async function syncManagedHooks(root, { dryRun = false, settings = {} } = {}) {
   const hooksDir = path.join(root, ".git", "hooks");
   if (!(await exists(hooksDir))) {
     return {
@@ -142,9 +167,39 @@ export async function syncManagedHooks(root, { dryRun = false } = {}) {
 
   const results = [];
 
-  for (const [name, body] of HOOK_BODIES) {
+  for (const { name, configKey, body } of HOOK_BODIES) {
     const hookPath = path.join(hooksDir, name);
     const existing = await safeRead(hookPath);
+
+    if (!isHookEnabled(settings, configKey)) {
+      if (!existing) {
+        results.push({ name, path: hookPath, managed: false, status: "skipped_disabled" });
+        continue;
+      }
+
+      const { hadMarker, remaining } = stripAgentifyBlock(existing);
+      if (!hadMarker) {
+        results.push({ name, path: hookPath, managed: false, status: "skipped_disabled_unmanaged" });
+        continue;
+      }
+
+      if (!dryRun) {
+        if (remaining && remaining !== "#!/bin/sh") {
+          await writeText(hookPath, `${remaining}\n`);
+        } else {
+          await fs.unlink(hookPath).catch(() => {});
+        }
+      }
+
+      results.push({
+        name,
+        path: hookPath,
+        managed: true,
+        status: dryRun ? "would_remove_disabled" : "removed_disabled",
+      });
+      continue;
+    }
+
     if (!existing) {
       results.push({ name, path: hookPath, managed: false, status: "skipped_missing" });
       continue;
@@ -175,7 +230,9 @@ export async function syncManagedHooks(root, { dryRun = false } = {}) {
     });
   }
 
-  const changed = results.some((item) => item.status === "updated" || item.status === "would_update");
+  const changed = results.some((item) =>
+    ["updated", "would_update", "removed_disabled", "would_remove_disabled"].includes(item.status)
+  );
   return {
     git_repository: true,
     results,

--- a/src/core/hooks.js
+++ b/src/core/hooks.js
@@ -81,6 +81,7 @@ async function removeManagedHookBlock(hookPath) {
   const { remaining } = stripAgentifyBlock(content);
   if (remaining && remaining !== "#!/bin/sh") {
     await writeText(hookPath, `${remaining}\n`);
+    await fs.chmod(hookPath, 0o755);
   } else {
     await fs.unlink(hookPath).catch(() => {});
   }
@@ -133,6 +134,7 @@ export async function removeHooks(root) {
     const { remaining } = stripAgentifyBlock(content);
     if (remaining && remaining !== "#!/bin/sh") {
       await writeText(hookPath, `${remaining}\n`);
+      await fs.chmod(hookPath, 0o755);
     } else {
       await fs.unlink(hookPath).catch(() => {});
     }
@@ -186,6 +188,7 @@ export async function syncManagedHooks(root, { dryRun = false, settings = {} } =
       if (!dryRun) {
         if (remaining && remaining !== "#!/bin/sh") {
           await writeText(hookPath, `${remaining}\n`);
+          await fs.chmod(hookPath, 0o755);
         } else {
           await fs.unlink(hookPath).catch(() => {});
         }

--- a/src/core/hooks.js
+++ b/src/core/hooks.js
@@ -36,6 +36,22 @@ async function safeRead(filePath) {
   }
 }
 
+async function readFileMode(filePath) {
+  try {
+    return (await fs.stat(filePath)).mode & 0o777;
+  } catch {
+    return null;
+  }
+}
+
+async function writeTextPreservingMode(filePath, text) {
+  const mode = await readFileMode(filePath);
+  await writeText(filePath, text);
+  if (mode !== null) {
+    await fs.chmod(filePath, mode);
+  }
+}
+
 function stripAgentifyBlock(content) {
   const lines = String(content || "").split(/\r?\n/);
   const filtered = [];
@@ -80,8 +96,7 @@ async function removeManagedHookBlock(hookPath) {
 
   const { remaining } = stripAgentifyBlock(content);
   if (remaining && remaining !== "#!/bin/sh") {
-    await writeText(hookPath, `${remaining}\n`);
-    await fs.chmod(hookPath, 0o755);
+    await writeTextPreservingMode(hookPath, `${remaining}\n`);
   } else {
     await fs.unlink(hookPath).catch(() => {});
   }
@@ -187,8 +202,7 @@ export async function syncManagedHooks(root, { dryRun = false, settings = {} } =
 
       if (!dryRun) {
         if (remaining && remaining !== "#!/bin/sh") {
-          await writeText(hookPath, `${remaining}\n`);
-          await fs.chmod(hookPath, 0o755);
+          await writeTextPreservingMode(hookPath, `${remaining}\n`);
         } else {
           await fs.unlink(hookPath).catch(() => {});
         }

--- a/src/core/repo-sync.js
+++ b/src/core/repo-sync.js
@@ -68,7 +68,7 @@ export async function runRepoSync(root, config, options = {}) {
     maintenance_provider: maintenanceConfig.provider,
     config: await syncConfigFile(root, config, { dryRun: config.dryRun }),
     baseline: await syncBaselineArtifacts(root, config),
-    hooks: await syncManagedHooks(root, { dryRun: config.dryRun }),
+    hooks: await syncManagedHooks(root, { dryRun: config.dryRun, settings: config.hooks }),
     skills: await syncProjectBuiltinSkills(root, {
       provider: skillProviderSelection,
       dryRun: config.dryRun,

--- a/src/main.js
+++ b/src/main.js
@@ -731,11 +731,15 @@ export async function runCli(argv) {
 
       case "hooks": {
         if (subcommand === "install") {
-          const installed = await installHooks(root);
+          const { installed, removed } = await installHooks(root, config.hooks);
           if (installed.length > 0) {
             success(`Installed hooks: ${installed.join(", ")}`);
-          } else {
-            log("All hooks already installed.");
+          }
+          if (removed.length > 0) {
+            success(`Removed disabled hooks: ${removed.join(", ")}`);
+          }
+          if (installed.length === 0 && removed.length === 0) {
+            log("Enabled hooks already installed.");
           }
         } else if (subcommand === "remove") {
           const removed = await removeHooks(root);

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { loadConfig, persistProviderPreference } from "../src/core/config.js";
+import { loadConfig, persistProviderPreference, syncConfigFile } from "../src/core/config.js";
 
 test("persistProviderPreference creates and updates .agentify.yaml", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-config-"));
@@ -49,4 +49,21 @@ test("loadConfig applies planner execution budget overrides", async () => {
   assert.equal(config.planner.maxAdditionalReadsBeforeEdit, 1);
   assert.equal(config.planner.maxWidenings, 0);
   assert.equal(config.planner.editAfterSelectedContextUnlessBlocked, false);
+});
+
+test("hook config drops deprecated autoRefresh setting", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-config-hooks-"));
+  await fs.writeFile(
+    path.join(root, ".agentify.yaml"),
+    "hooks:\n  preCommit: false\n  postMerge: true\n  autoRefresh: true\n",
+    "utf8",
+  );
+
+  const config = await loadConfig(root);
+  assert.deepEqual(config.hooks, { preCommit: false, postMerge: true });
+
+  await syncConfigFile(root, config);
+  const synced = await fs.readFile(path.join(root, ".agentify.yaml"), "utf8");
+  assert.doesNotMatch(synced, /autoRefresh/);
+  assert.match(synced, /preCommit: false/);
 });

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -10,7 +10,8 @@ test("installHooks writes a valid post-merge refresh command", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-hooks-"));
   await fs.mkdir(path.join(root, ".git", "hooks"), { recursive: true });
 
-  await installHooks(root);
+  const result = await installHooks(root);
+  assert.deepEqual(result, { installed: ["pre-commit", "post-merge"], removed: [] });
 
   const postMerge = await fs.readFile(path.join(root, ".git", "hooks", "post-merge"), "utf8");
   assert.match(postMerge, /agentify scan --json >\/dev\/null 2>&1 \|\| true/);
@@ -35,10 +36,29 @@ test("installHooks upgrades a legacy managed pre-commit body in place", async ()
   const legacy = "#!/bin/sh\n# @agentify pre-commit hook\n# Validates freshness and safety before commit\nagentify check\n";
   await fs.writeFile(path.join(hooksDir, "pre-commit"), legacy);
 
-  const installed = await installHooks(root);
+  const { installed } = await installHooks(root);
 
   assert.ok(installed.includes("pre-commit"), "pre-commit should be reported as updated");
   const next = await fs.readFile(path.join(hooksDir, "pre-commit"), "utf8");
   assert.match(next, /agentify check --hook/);
   assert.doesNotMatch(next, /^agentify check\s*$/m);
+});
+
+test("installHooks skips disabled hooks and removes managed disabled hooks", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-hooks-"));
+  const hooksDir = path.join(root, ".git", "hooks");
+  await fs.mkdir(hooksDir, { recursive: true });
+  await fs.writeFile(
+    path.join(hooksDir, "post-merge"),
+    "#!/bin/sh\ncustom merge step\n\n# @agentify post-merge hook\nagentify scan\n",
+    "utf8",
+  );
+
+  const result = await installHooks(root, { preCommit: true, postMerge: false });
+
+  assert.deepEqual(result, { installed: ["pre-commit"], removed: ["post-merge"] });
+  const preCommit = await fs.readFile(path.join(hooksDir, "pre-commit"), "utf8");
+  const postMerge = await fs.readFile(path.join(hooksDir, "post-merge"), "utf8");
+  assert.match(preCommit, /agentify check --hook/);
+  assert.equal(postMerge, "#!/bin/sh\ncustom merge step\n");
 });

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -6,12 +6,12 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
-import { installHooks } from "../src/core/hooks.js";
+import { installHooks, syncManagedHooks } from "../src/core/hooks.js";
 
 const execFileAsync = promisify(execFile);
 
-function isExecutable(mode) {
-  return (mode & 0o111) !== 0;
+function fileMode(mode) {
+  return mode & 0o777;
 }
 
 test("installHooks writes a valid post-merge refresh command", async () => {
@@ -88,7 +88,7 @@ test("installHooks skips disabled hooks and removes managed disabled hooks", asy
     "#!/bin/sh\ncustom merge step\n\n# @agentify post-merge hook\nagentify scan\n",
     "utf8",
   );
-  await fs.chmod(path.join(hooksDir, "post-merge"), 0o755);
+  await fs.chmod(path.join(hooksDir, "post-merge"), 0o700);
 
   const result = await installHooks(root, { preCommit: true, postMerge: false });
 
@@ -97,5 +97,24 @@ test("installHooks skips disabled hooks and removes managed disabled hooks", asy
   const postMerge = await fs.readFile(path.join(hooksDir, "post-merge"), "utf8");
   assert.match(preCommit, /agentify check --hook/);
   assert.equal(postMerge, "#!/bin/sh\ncustom merge step\n");
-  assert.equal(isExecutable((await fs.stat(path.join(hooksDir, "post-merge"))).mode), true);
+  assert.equal(fileMode((await fs.stat(path.join(hooksDir, "post-merge"))).mode), 0o700);
+});
+
+test("syncManagedHooks preserves mode when pruning disabled managed hook content", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-hooks-"));
+  const hooksDir = path.join(root, ".git", "hooks");
+  const hookPath = path.join(hooksDir, "pre-commit");
+  await fs.mkdir(hooksDir, { recursive: true });
+  await fs.writeFile(
+    hookPath,
+    "#!/bin/sh\ncustom pre-commit step\n\n# @agentify pre-commit hook\nagentify check\n",
+    "utf8",
+  );
+  await fs.chmod(hookPath, 0o710);
+
+  const result = await syncManagedHooks(root, { settings: { preCommit: false, postMerge: true } });
+
+  assert.equal(result.results.find((item) => item.name === "pre-commit")?.status, "removed_disabled");
+  assert.equal(await fs.readFile(hookPath, "utf8"), "#!/bin/sh\ncustom pre-commit step\n");
+  assert.equal(fileMode((await fs.stat(hookPath)).mode), 0o710);
 });

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -6,6 +6,10 @@ import path from "node:path";
 
 import { installHooks } from "../src/core/hooks.js";
 
+function isExecutable(mode) {
+  return (mode & 0o111) !== 0;
+}
+
 test("installHooks writes a valid post-merge refresh command", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-hooks-"));
   await fs.mkdir(path.join(root, ".git", "hooks"), { recursive: true });
@@ -53,6 +57,7 @@ test("installHooks skips disabled hooks and removes managed disabled hooks", asy
     "#!/bin/sh\ncustom merge step\n\n# @agentify post-merge hook\nagentify scan\n",
     "utf8",
   );
+  await fs.chmod(path.join(hooksDir, "post-merge"), 0o755);
 
   const result = await installHooks(root, { preCommit: true, postMerge: false });
 
@@ -61,4 +66,5 @@ test("installHooks skips disabled hooks and removes managed disabled hooks", asy
   const postMerge = await fs.readFile(path.join(hooksDir, "post-merge"), "utf8");
   assert.match(preCommit, /agentify check --hook/);
   assert.equal(postMerge, "#!/bin/sh\ncustom merge step\n");
+  assert.equal(isExecutable((await fs.stat(path.join(hooksDir, "post-merge"))).mode), true);
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -238,6 +238,32 @@ test("runCli supports skill install all for codex project scope", async () => {
   }
 });
 
+test("runCli hooks install honors hook settings from .agentify.yaml", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-hooks-config-"));
+  await fs.mkdir(path.join(root, ".git", "hooks"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, ".agentify.yaml"),
+    "hooks:\n  preCommit: true\n  postMerge: false\n",
+    "utf8",
+  );
+
+  const output = [];
+  const originalLog = console.log;
+  console.log = (...args) => {
+    output.push(args.join(" "));
+  };
+
+  try {
+    await runCli(["hooks", "install", "--root", root]);
+  } finally {
+    console.log = originalLog;
+  }
+
+  const preCommit = await fs.readFile(path.join(root, ".git", "hooks", "pre-commit"), "utf8");
+  assert.match(preCommit, /agentify check --hook/);
+  await assert.rejects(() => fs.access(path.join(root, ".git", "hooks", "post-merge")), { code: "ENOENT" });
+});
+
 test("runCli memory compress reports placeholder status", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-memory-compress-"));
   const output = [];


### PR DESCRIPTION
## Summary
- Wire `.agentify.yaml` `hooks.preCommit` and `hooks.postMerge` into `agentify hooks install` and managed hook sync.
- Remove the deprecated inert `hooks.autoRefresh` config surface when loading/syncing config.
- Add coverage for configured hook installation and disabled managed hook cleanup.

Closes #46

## Tests
- `node --test test/hooks.test.js test/config.test.js test/main.test.js`
- `env -u AGENTIFY_MEMPALACE_CMD pnpm test`