### PR TITLE
feat: add execution telemetry to run reports

### DIFF
--- a/src/core/exec.js
+++ b/src/core/exec.js
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { getChangedFiles, getHeadCommit } from "./git.js";
 import { runScan, runDoc } from "./commands.js";
+import { createRunReporter } from "./run-report.js";
 import { validateRepo } from "./validate.js";
 import { finalizeSessionMemoryRun, normalizeInteractiveCapture, prepareSessionMemoryRun } from "./session-memory.js";
 import * as ui from "./ui.js";
@@ -137,6 +138,89 @@ function createBoundedCaptureBuffer(maxBytes) {
   };
 }
 
+function normalizeCommandForDisplay(argv) {
+  if (!Array.isArray(argv) || argv.length === 0) {
+    return "";
+  }
+
+  return argv.map((part) => {
+    const text = String(part);
+    if (!/[\s"'\\]/.test(text)) {
+      return text;
+    }
+    return `"${text.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"")}"`;
+  }).join(" ");
+}
+
+function summarizeProviderCommand(argv) {
+  const parts = Array.isArray(argv) ? argv.map(String) : [];
+  return {
+    executable: parts[0] || null,
+    argv: parts,
+    argc: parts.length,
+    display: normalizeCommandForDisplay(parts),
+  };
+}
+
+function summarizeChangedFiles(files) {
+  return files.map((file) => ({
+    status: file.status,
+    path: file.path,
+    ...(file.origPath ? { orig_path: file.origPath } : {}),
+  }));
+}
+
+function buildExecutionTelemetry({
+  runId,
+  startedAt,
+  finishedAt,
+  durationMs,
+  result,
+  config,
+  agentCommand,
+  commandResult,
+  agentChanges,
+  headChanged,
+  flags,
+}) {
+  const changedFiles = summarizeChangedFiles(agentChanges || []);
+  const captureMode = commandResult?.captureMode || flags.captureOutputMode || (flags.captureOutput ? "pipe" : "inherit");
+  const transcript = commandResult?.interactiveTranscript || result.interactiveTranscript || "";
+  const rawLogPath = commandResult?.rawInteractiveLogPath || result.rawInteractiveLogPath || null;
+
+  return {
+    run_id: runId,
+    started_at: startedAt.toISOString(),
+    finished_at: finishedAt.toISOString(),
+    duration_ms: durationMs,
+    phase: result.phase,
+    exit_code: result.exitCode,
+    skipped_refresh: Boolean(result.skippedRefresh),
+    provider: config.provider || null,
+    provider_model: config.providerModel || config.provider_model || null,
+    provider_command: summarizeProviderCommand(agentCommand),
+    capture: {
+      mode: flags.sessionRecord?.captureMode || captureMode,
+      output_mode: captureMode,
+      transcript_available: transcript.length > 0,
+      transcript_bytes: Buffer.byteLength(transcript, "utf8"),
+      raw_log_available: Boolean(rawLogPath),
+      raw_log_path: rawLogPath,
+    },
+    changed_files_count: changedFiles.length,
+    changed_paths: changedFiles.map((file) => file.path),
+    changed_files: changedFiles,
+    head_changed: Boolean(headChanged),
+    session: flags.sessionRecord
+      ? {
+          session_id: flags.sessionRecord.sessionId || null,
+          provider: flags.sessionRecord.provider || null,
+          capture_mode: flags.sessionRecord.captureMode || null,
+        }
+      : null,
+  };
+}
+
 function runWrappedCommand(argv, options) {
   return new Promise((resolve, reject) => {
     const captureMode = options.captureOutputMode || "inherit";
@@ -191,6 +275,7 @@ function runWrappedCommand(argv, options) {
           stderr: captureMode === "pipe" ? stderrCapture.toString() : "",
           interactiveTranscript,
           rawInteractiveLogPath: captureMode === "pty" ? options.capturePath : null,
+          captureMode,
         });
       } catch (error) {
         reject(error);
@@ -200,6 +285,14 @@ function runWrappedCommand(argv, options) {
 }
 
 export async function runExec(root, config, agentCommand, flags) {
+  const commandName = flags.commandName || "exec";
+  const runId = `${Date.now()}-${commandName.replace(/[^a-z0-9_.-]+/gi, "-")}`;
+  const startedAt = new Date();
+  const startMs = Date.now();
+  const progress = flags.reporter || createRunReporter(root);
+  progress.setCommand(commandName);
+  progress.log(`${commandName}: starting provider command`);
+
   const preHeadCommit = await getHeadCommit(root);
   const preFiles = await getChangedFiles(root);
   const preFileDigests = await captureDirtyFileDigests(root, preFiles);
@@ -235,11 +328,63 @@ export async function runExec(root, config, agentCommand, flags) {
           stderr: error.message,
         }, config);
       }
+      const finishedAt = new Date();
+      const result = {
+        phase: "spawn-error",
+        exitCode: 1,
+        stderr: error.message,
+        stdout: "",
+        interactiveTranscript: "",
+        rawInteractiveLogPath: null,
+      };
+      const executionTelemetry = buildExecutionTelemetry({
+        runId,
+        startedAt,
+        finishedAt,
+        durationMs: Date.now() - startMs,
+        result,
+        config,
+        agentCommand,
+        commandResult: null,
+        agentChanges: [],
+        headChanged: false,
+        flags,
+      });
+      progress.setCommand(commandName);
+      progress.setExecution(executionTelemetry);
+      await progress.finalize();
       throw error;
     }
   }
   let exitCode = commandResult.exitCode || 0;
   const commandFailed = exitCode !== 0;
+
+  const postHeadCommit = await getHeadCommit(root);
+  const postFiles = await getChangedFiles(root);
+  const postFileDigests = await captureDirtyFileDigests(root, postFiles);
+  const agentChanges = diffSnapshots(preFiles, postFiles, preFileDigests, postFileDigests);
+  const headChanged = postHeadCommit !== preHeadCommit;
+
+  async function finalizeResult(result) {
+    const finishedAt = new Date();
+    result.executionTelemetry = buildExecutionTelemetry({
+      runId,
+      startedAt,
+      finishedAt,
+      durationMs: Date.now() - startMs,
+      result,
+      config,
+      agentCommand,
+      commandResult,
+      agentChanges,
+      headChanged,
+      flags,
+    });
+    progress.setCommand(commandName);
+    progress.setExecution(result.executionTelemetry);
+    await progress.finalize();
+    return result;
+  }
 
   if (flags.skipRefresh) {
     process.exitCode = exitCode;
@@ -255,14 +400,8 @@ export async function runExec(root, config, agentCommand, flags) {
     if (preparedSessionMemory) {
       await finalizeSessionMemoryRun(root, flags.sessionRecord, preparedSessionMemory, result, config);
     }
-    return result;
+    return finalizeResult(result);
   }
-
-  const postHeadCommit = await getHeadCommit(root);
-  const postFiles = await getChangedFiles(root);
-  const postFileDigests = await captureDirtyFileDigests(root, postFiles);
-  const agentChanges = diffSnapshots(preFiles, postFiles, preFileDigests, postFileDigests);
-  const headChanged = postHeadCommit !== preHeadCommit;
   if (agentChanges.length === 0 && !headChanged) {
     const validation = await validateRepo(root, config);
     if (!validation.passed && flags.failOnStale && !commandFailed) {
@@ -286,12 +425,13 @@ export async function runExec(root, config, agentCommand, flags) {
     if (preparedSessionMemory) {
       await finalizeSessionMemoryRun(root, flags.sessionRecord, preparedSessionMemory, result, config);
     }
-    return result;
+    progress.setValidation(validation);
+    return finalizeResult(result);
   }
 
   try {
-    await runScan(root, config, { skipFinalize: true });
-    await runDoc(root, config, { skipFinalize: true });
+    await runScan(root, config, { reporter: progress, skipFinalize: true });
+    await runDoc(root, config, { reporter: progress, skipFinalize: true });
   } catch (error) {
     ui.error(`refresh error: ${error.message}`);
     if (flags.failOnStale && !commandFailed) {
@@ -309,10 +449,11 @@ export async function runExec(root, config, agentCommand, flags) {
     if (preparedSessionMemory) {
       await finalizeSessionMemoryRun(root, flags.sessionRecord, preparedSessionMemory, result, config);
     }
-    return result;
+    return finalizeResult(result);
   }
 
   const validation = await validateRepo(root, config);
+  progress.setValidation(validation);
 
   if (!validation.passed) {
     if (flags.failOnStale && !commandFailed) {
@@ -337,5 +478,5 @@ export async function runExec(root, config, agentCommand, flags) {
   if (preparedSessionMemory) {
     await finalizeSessionMemoryRun(root, flags.sessionRecord, preparedSessionMemory, result, config);
   }
-  return result;
+  return finalizeResult(result);
 }

--- a/src/core/exec.js
+++ b/src/core/exec.js
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { getChangedFiles, getHeadCommit } from "./git.js";
+import { getChangedFiles, getChangedFilesSince, getHeadCommit } from "./git.js";
 import { runScan, runDoc } from "./commands.js";
 import { createRunReporter } from "./run-report.js";
 import { validateRepo } from "./validate.js";
@@ -88,6 +88,22 @@ function diffSnapshots(preFiles, postFiles, preDigests = new Map(), postDigests 
     }
   }
 
+  return changes;
+}
+
+function combineChanges(...groups) {
+  const seen = new Set();
+  const changes = [];
+  for (const group of groups) {
+    for (const file of group || []) {
+      const key = getSnapshotKey(file);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      changes.push(file);
+    }
+  }
   return changes;
 }
 
@@ -362,8 +378,14 @@ export async function runExec(root, config, agentCommand, flags) {
   const postHeadCommit = await getHeadCommit(root);
   const postFiles = await getChangedFiles(root);
   const postFileDigests = await captureDirtyFileDigests(root, postFiles);
-  const agentChanges = diffSnapshots(preFiles, postFiles, preFileDigests, postFileDigests);
   const headChanged = postHeadCommit !== preHeadCommit;
+  const committedChanges = headChanged && preHeadCommit !== "nogit"
+    ? await getChangedFilesSince(root, preHeadCommit)
+    : [];
+  const agentChanges = combineChanges(
+    diffSnapshots(preFiles, postFiles, preFileDigests, postFileDigests),
+    committedChanges,
+  );
 
   async function finalizeResult(result) {
     const finishedAt = new Date();

--- a/src/core/run-report.js
+++ b/src/core/run-report.js
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import { writeText } from "./fs.js";
+import { writeJson, writeText } from "./fs.js";
 import * as ui from "./ui.js";
 
 function escapeHtml(value) {
@@ -15,11 +15,117 @@ function sanitizeForJsString(value) {
   return String(value).replaceAll("\\", "\\\\").replaceAll("`", "\\`").replaceAll("${", "\\${");
 }
 
+function normalizeExecutionTelemetry(value) {
+  if (!value) {
+    return null;
+  }
+
+  const changedFiles = Array.isArray(value.changed_files) ? value.changed_files : [];
+  const changedPaths = Array.isArray(value.changed_paths)
+    ? value.changed_paths
+    : changedFiles.map((file) => file?.path).filter(Boolean);
+
+  return {
+    run_id: value.run_id || `${Date.now()}-execution`,
+    started_at: value.started_at || null,
+    finished_at: value.finished_at || null,
+    duration_ms: Number.isFinite(Number(value.duration_ms)) ? Number(value.duration_ms) : null,
+    phase: value.phase || "unknown",
+    exit_code: Number.isFinite(Number(value.exit_code)) ? Number(value.exit_code) : null,
+    skipped_refresh: Boolean(value.skipped_refresh),
+    provider: value.provider || null,
+    provider_model: value.provider_model || null,
+    provider_command: value.provider_command || null,
+    capture: value.capture || {
+      mode: "inherit",
+      transcript_available: false,
+      raw_log_available: false,
+      raw_log_path: null,
+    },
+    changed_files_count: Number.isFinite(Number(value.changed_files_count))
+      ? Number(value.changed_files_count)
+      : changedPaths.length,
+    changed_paths: changedPaths,
+    changed_files: changedFiles,
+    head_changed: Boolean(value.head_changed),
+    session: value.session || null,
+  };
+}
+
+function renderExecutionOutputBlock(execution) {
+  if (!execution) {
+    return "";
+  }
+
+  const changedPaths = execution.changed_paths?.length
+    ? execution.changed_paths.join(", ")
+    : "none";
+  const command = execution.provider_command?.display || execution.provider_command?.executable || "unknown";
+  const capture = execution.capture || {};
+
+  return [
+    "[agentify] execution telemetry",
+    `[agentify] execution: phase=${execution.phase} exit=${execution.exit_code ?? "unknown"} duration_ms=${execution.duration_ms ?? "unknown"}`,
+    `[agentify] execution: provider=${execution.provider || "unknown"} command=${command}`,
+    `[agentify] execution: capture=${capture.mode || "inherit"} transcript=${capture.transcript_available ? "yes" : "no"} raw_log=${capture.raw_log_available ? "yes" : "no"}`,
+    `[agentify] execution: changed_files=${execution.changed_files_count} head_changed=${execution.head_changed ? "yes" : "no"}`,
+    `[agentify] execution: changed_paths=${changedPaths}`,
+  ].join("\n");
+}
+
 export function renderHtmlReport(summary) {
   const artifactsRaw = summary.artifacts || [];
   const artifacts = artifactsRaw.length > 0
     ? artifactsRaw.map((item) => `<li><code>${escapeHtml(item)}</code></li>`).join("")
     : `<li class="empty">no generated artifacts recorded.</li>`;
+  const execution = normalizeExecutionTelemetry(summary.execution);
+  const executionChangedPaths = execution?.changed_paths?.length
+    ? execution.changed_paths.map((item) => `<li><code>${escapeHtml(item)}</code></li>`).join("")
+    : `<li class="empty">no changed paths recorded.</li>`;
+  const executionCommand = execution?.provider_command?.display || execution?.provider_command?.executable || "unknown";
+  const executionCapture = execution?.capture || {};
+  const executionSection = execution
+    ? `
+      <div class="metrics" style="grid-template-columns: repeat(4, minmax(0, 1fr));">
+        <div class="metric">
+          <span class="metric-label">phase</span>
+          <span class="metric-value">${escapeHtml(execution.phase)}</span>
+        </div>
+        <div class="metric">
+          <span class="metric-label">duration ms</span>
+          <span class="metric-value">${escapeHtml(execution.duration_ms ?? "n/a")}</span>
+        </div>
+        <div class="metric">
+          <span class="metric-label">changed files</span>
+          <span class="metric-value">${escapeHtml(execution.changed_files_count)}</span>
+        </div>
+        <div class="metric">
+          <span class="metric-label">transcript</span>
+          <span class="metric-value">${executionCapture.transcript_available ? "yes" : "no"}</span>
+        </div>
+      </div>
+
+      <div class="token-wrap" style="margin-top: 16px;">
+        <div class="token-scroll">
+          <table class="tokens">
+            <tbody>
+              <tr><th scope="row">provider</th><td><code>${escapeHtml(execution.provider || "unknown")}</code></td></tr>
+              <tr><th scope="row">command</th><td><code>${escapeHtml(executionCommand)}</code></td></tr>
+              <tr><th scope="row">capture mode</th><td><code>${escapeHtml(executionCapture.mode || "inherit")}</code></td></tr>
+              <tr><th scope="row">raw interactive log</th><td><code>${escapeHtml(executionCapture.raw_log_available ? executionCapture.raw_log_path || "available" : "not available")}</code></td></tr>
+              <tr><th scope="row">head changed</th><td><code>${escapeHtml(execution.head_changed ? "yes" : "no")}</code></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <ul class="artifact-list" style="margin-top: 16px;">${executionChangedPaths}</ul>
+
+      <details class="term-details" style="margin-top: 16px;">
+        <summary>raw execution telemetry · JSON</summary>
+        <pre class="term-body small">${escapeHtml(JSON.stringify(execution, null, 2))}</pre>
+      </details>`
+    : `<p class="muted mono-sm">no execution telemetry was recorded for this report.</p>`;
 
   const tokenUsage = summary.doc?.token_usage || {
     input_tokens: 0,
@@ -82,6 +188,9 @@ export function renderHtmlReport(summary) {
   const measuredModules = (tokenUsage.by_module || []).length;
 
   const commandDisplay = summary.command || "unknown";
+  const executionPhase = execution?.phase || "not-run";
+  const executionChangedCount = execution?.changed_files_count ?? 0;
+  const executionTranscriptText = execution?.capture?.transcript_available ? "yes" : "no";
 
   const healthHeadline = validationStatus === "passed" && testStatus === "passed"
     ? "repository checks completed successfully."
@@ -765,6 +874,7 @@ export function renderHtmlReport(summary) {
 <span class="dim">→</span> validation  <span class="${validationTone === "passed" ? "ok" : validationTone === "failed" ? "r" : "w"}">${escapeHtml(validationStatus)}</span>   <span class="c">#</span> ${escapeHtml(validationCount)} failure${validationCount === 1 ? "" : "s"} recorded
 <span class="dim">→</span> tests       <span class="${testTone === "passed" ? "ok" : testTone === "failed" ? "r" : "w"}">${escapeHtml(testStatus)}</span>   <span class="c">#</span> <span class="s">${escapeHtml(summary.tests?.command || "not-run")}</span>
 <span class="dim">→</span> modules     <span class="m">${escapeHtml(moduleCount)}</span>        <span class="c">#</span> ${escapeHtml(docsWritten)} docs · ${escapeHtml(headersRefreshed)} headers
+<span class="dim">→</span> execution   <span class="m">${escapeHtml(executionPhase)}</span> <span class="c">#</span> changed: ${escapeHtml(executionChangedCount)} · transcript: ${escapeHtml(executionTranscriptText)}
 <span class="dim">→</span> tokens      <span class="m">${escapeHtml(totalTokens)}</span>        <span class="c">#</span> in: ${escapeHtml(inputTokens)} · out: ${escapeHtml(outputTokens)} · modules: ${escapeHtml(measuredModules)}
 <span class="dim">→</span> artifacts   <span class="m">${escapeHtml(artifactCount)}</span>        <span class="c">#</span> files produced this run
 
@@ -774,6 +884,8 @@ export function renderHtmlReport(summary) {
       <div class="chip-row" aria-label="quick status">
         <span class="chip ${escapeHtml(validationTone)}"><span class="label">validation</span><span class="glyph" aria-hidden="true">${validationGlyph}</span><strong>${escapeHtml(validationStatus)}</strong></span>
         <span class="chip ${escapeHtml(testTone)}"><span class="label">tests</span><span class="glyph" aria-hidden="true">${testGlyph}</span><strong>${escapeHtml(testStatus)}</strong></span>
+        <span class="chip"><span class="label">phase</span><strong>${escapeHtml(executionPhase)}</strong></span>
+        <span class="chip"><span class="label">changed</span><strong>${escapeHtml(executionChangedCount)}</strong></span>
         <span class="chip"><span class="label">tokens</span><strong>${escapeHtml(totalTokens)}</strong></span>
         <span class="chip"><span class="label">artifacts</span><strong>${escapeHtml(artifactCount)}</strong></span>
       </div>
@@ -817,10 +929,20 @@ export function renderHtmlReport(summary) {
       </div>
     </section>
 
+    <!-- ===== EXECUTION ===== -->
+    <section id="execution" aria-labelledby="execution-title">
+      <header class="section-head">
+        <span class="section-mark"><span class="caret">▶</span><span class="num">02</span><span class="slash">/</span>execution</span>
+        <h2 id="execution-title">execution telemetry</h2>
+        <p class="dek">provider command behavior, capture availability, and changed-file scope for benchmarking this run.</p>
+      </header>
+      ${executionSection}
+    </section>
+
     <!-- ===== HEALTH ===== -->
     <section id="health" aria-labelledby="health-title">
       <header class="section-head">
-        <span class="section-mark"><span class="caret">▶</span><span class="num">02</span><span class="slash">/</span>health</span>
+        <span class="section-mark"><span class="caret">▶</span><span class="num">03</span><span class="slash">/</span>health</span>
         <h2 id="health-title">validation &amp; tests</h2>
         <p class="dek">trust or reject the run from this block alone — unsafe writes, freshness drift, and test status sit side by side.</p>
       </header>
@@ -853,7 +975,7 @@ export function renderHtmlReport(summary) {
     <!-- ===== TOKENS ===== -->
     <section id="tokens" aria-labelledby="tokens-title">
       <header class="section-head">
-        <span class="section-mark"><span class="caret">▶</span><span class="num">03</span><span class="slash">/</span>tokens</span>
+        <span class="section-mark"><span class="caret">▶</span><span class="num">04</span><span class="slash">/</span>tokens</span>
         <h2 id="tokens-title">model usage</h2>
         <p class="dek">totals first, per-module breakdown second — enough to audit cost and activity without opening raw JSON.</p>
       </header>
@@ -902,7 +1024,7 @@ export function renderHtmlReport(summary) {
     <!-- ===== ARTIFACTS ===== -->
     <section id="artifacts" aria-labelledby="artifacts-title">
       <header class="section-head">
-        <span class="section-mark"><span class="caret">▶</span><span class="num">04</span><span class="slash">/</span>artifacts</span>
+        <span class="section-mark"><span class="caret">▶</span><span class="num">05</span><span class="slash">/</span>artifacts</span>
         <h2 id="artifacts-title">generated files</h2>
         <p class="dek">every path agentify recorded for this run. useful as a handoff checklist.</p>
       </header>
@@ -912,7 +1034,7 @@ export function renderHtmlReport(summary) {
     <!-- ===== RAW ===== -->
     <section id="raw" aria-labelledby="raw-title">
       <header class="section-head">
-        <span class="section-mark"><span class="caret">▶</span><span class="num">05</span><span class="slash">/</span>raw</span>
+        <span class="section-mark"><span class="caret">▶</span><span class="num">06</span><span class="slash">/</span>raw</span>
         <h2 id="raw-title">machine summary</h2>
         <p class="dek">the complete structured payload — preserved for debugging, diffing, or downstream tooling.</p>
       </header>
@@ -961,6 +1083,7 @@ export function createRunReporter(root) {
     doc: null,
     validation: null,
     tests: null,
+    execution: null,
   };
 
   function record(text) {
@@ -1008,15 +1131,29 @@ export function createRunReporter(root) {
     setTests(result) {
       summary.tests = result;
     },
+    setExecution(result) {
+      summary.execution = normalizeExecutionTelemetry(result);
+      if (summary.execution) {
+        const telemetryPath = `.agents/runs/${summary.execution.run_id}-execution-telemetry.json`;
+        summary.artifacts = Array.from(new Set([...summary.artifacts, telemetryPath]));
+        record(renderExecutionOutputBlock(summary.execution));
+      }
+    },
     async finalize() {
       const outputPath = path.join(root, "output.txt");
       const htmlPath = path.join(root, "agentify-report.html");
+      let telemetryJsonPath = null;
+      if (summary.execution) {
+        telemetryJsonPath = path.join(root, ".agents", "runs", `${summary.execution.run_id}-execution-telemetry.json`);
+        await writeJson(telemetryJsonPath, summary.execution);
+      }
       await writeText(outputPath, events.join(""));
       await writeText(htmlPath, renderHtmlReport(summary));
 
       ui.box("Run Complete", [
         ui.label("Artifacts", String(summary.artifacts.length)),
         ui.label("Modules", String(summary.doc?.modules_processed ?? 0)),
+        ui.label("Execution", summary.execution?.phase || "not run"),
         ui.label(
           "Validation",
           summary.validation
@@ -1027,7 +1164,7 @@ export function createRunReporter(root) {
         ui.label("Report", ui.dim(htmlPath)),
       ]);
 
-      return { outputPath, htmlPath };
+      return { outputPath, htmlPath, telemetryJsonPath };
     },
   };
 }

--- a/src/main.js
+++ b/src/main.js
@@ -223,6 +223,7 @@ export async function prepareSessionLaunch(root, config, args, sessionResult, ta
     runExecFlags: getExecFlags(args, {
       captureOutputMode: captureSettings.captureOutputMode,
       sessionRecord,
+      commandName: `sess ${args._?.[1] || "run"}`,
     }),
   };
 }
@@ -504,7 +505,7 @@ export async function runCli(argv) {
             providerOptions,
           );
 
-        await runExec(root, config, agentCommand, getExecFlags(args));
+        await runExec(root, config, agentCommand, getExecFlags(args, { commandName: "run" }));
         return;
       }
 
@@ -513,7 +514,7 @@ export async function runCli(argv) {
         if (agentCommand.length === 0) {
           throw new Error("exec requires a command after --: agentify exec [flags] -- <command...>");
         }
-        await runExec(root, config, agentCommand, getExecFlags(args));
+        await runExec(root, config, agentCommand, getExecFlags(args, { commandName: "exec" }));
         return;
       }
 

--- a/test/exec.test.js
+++ b/test/exec.test.js
@@ -120,6 +120,34 @@ test("runExec refreshes when the wrapped command edits an already-dirty tracked 
   assert.deepEqual(telemetry.changed_paths, ["src/index.js"]);
 });
 
+test("runExec includes committed edits in execution telemetry", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-exec-committed-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, "src", "index.js"), "export const version = 1;\n", "utf8");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "local", dryRun: false, tokenReport: false });
+  await runScan(root, config);
+  await runDoc(root, config);
+
+  const script = [
+    "import fs from 'node:fs/promises';",
+    "import { execFile } from 'node:child_process';",
+    "import { promisify } from 'node:util';",
+    "const execFileAsync = promisify(execFile);",
+    "await fs.appendFile('src/index.js', 'export const committed = true;\\n', 'utf8');",
+    "await execFileAsync('git', ['add', 'src/index.js']);",
+    "await execFileAsync('git', ['commit', '-m', 'update source']);",
+  ].join("");
+
+  const result = await runExec(root, config, ["node", "--input-type=module", "-e", script], {});
+
+  assert.equal(result.executionTelemetry.head_changed, true);
+  assert.equal(result.executionTelemetry.changed_files_count, 1);
+  assert.deepEqual(result.executionTelemetry.changed_paths, ["src/index.js"]);
+});
+
 test("runExec refreshes and validates after a failing command mutates tracked files", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-exec-failed-refresh-"));
   await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");

--- a/test/exec.test.js
+++ b/test/exec.test.js
@@ -106,6 +106,18 @@ test("runExec refreshes when the wrapped command edits an already-dirty tracked 
   assert.equal(result.skippedRefresh, undefined);
   assert.equal(afterDocMtime > beforeDocMtime, true);
   assert.equal(result.validation?.failures.some((failure) => failure.category === "code-body-changed"), true);
+  assert.equal(result.executionTelemetry.phase, "complete");
+  assert.equal(result.executionTelemetry.provider, "local");
+  assert.equal(result.executionTelemetry.changed_files_count, 1);
+  assert.deepEqual(result.executionTelemetry.changed_paths, ["src/index.js"]);
+
+  const output = await fs.readFile(path.join(root, "output.txt"), "utf8");
+  const html = await fs.readFile(path.join(root, "agentify-report.html"), "utf8");
+  const telemetryPath = path.join(root, ".agents", "runs", `${result.executionTelemetry.run_id}-execution-telemetry.json`);
+  const telemetry = JSON.parse(await fs.readFile(telemetryPath, "utf8"));
+  assert.match(output, /execution: changed_files=1/);
+  assert.match(html, /execution telemetry/);
+  assert.deepEqual(telemetry.changed_paths, ["src/index.js"]);
 });
 
 test("runExec refreshes and validates after a failing command mutates tracked files", async () => {

--- a/test/run-report.test.js
+++ b/test/run-report.test.js
@@ -46,16 +46,56 @@ test("createRunReporter persists output and HTML report", async (t) => {
     stderr: "",
     exit_code: 0,
   });
+  reporter.setExecution({
+    run_id: "test-execution",
+    started_at: "2026-01-01T00:00:00.000Z",
+    finished_at: "2026-01-01T00:00:01.250Z",
+    duration_ms: 1250,
+    phase: "complete",
+    exit_code: 0,
+    skipped_refresh: false,
+    provider: "codex",
+    provider_command: {
+      executable: "codex",
+      argv: ["codex", "run"],
+      argc: 2,
+      display: "codex run",
+    },
+    capture: {
+      mode: "interactive-pty",
+      output_mode: "pty",
+      transcript_available: true,
+      transcript_bytes: 512,
+      raw_log_available: true,
+      raw_log_path: ".current_session/session/interactive.log",
+    },
+    changed_files_count: 2,
+    changed_paths: ["src/core/exec.js", "src/core/run-report.js"],
+    changed_files: [
+      { status: "M", path: "src/core/exec.js" },
+      { status: "M", path: "src/core/run-report.js" },
+    ],
+    head_changed: false,
+  });
   reporter.log("tests: passed");
 
   await reporter.finalize();
 
   const output = await fs.readFile(path.join(root, "output.txt"), "utf8");
   const html = await fs.readFile(path.join(root, "agentify-report.html"), "utf8");
+  const telemetry = JSON.parse(
+    await fs.readFile(path.join(root, ".agents", "runs", "test-execution-execution-telemetry.json"), "utf8")
+  );
 
   assert.match(output, /\[agentify\] tests: passed/);
+  assert.match(output, /execution: phase=complete exit=0 duration_ms=1250/);
   assert.match(html, /All configured test cases passed\./);
+  assert.match(html, /execution telemetry/);
+  assert.match(html, /src\/core\/exec\.js/);
   assert.match(html, /Copy rerun tests command/);
   assert.match(html, /Total tokens/);
   assert.match(html, /&lt;script&gt;alert\('xss'\)&lt;\/script&gt;/);
+  assert.equal(telemetry.phase, "complete");
+  assert.equal(telemetry.capture.transcript_available, true);
+  assert.deepEqual(telemetry.changed_paths, ["src/core/exec.js", "src/core/run-report.js"]);
 });


### PR DESCRIPTION
## Summary
- Persist runExec execution telemetry into the run reporter summary
- Render execution phase, capture availability, duration, and changed-file scope in agentify-report.html and output.txt
- Emit structured execution telemetry JSON under .agents/runs for future comparisons

Closes #55

## Tests
- npm test -- test/run-report.test.js test/exec.test.js
- env -u AGENTIFY_MEMPALACE_CMD npm test

Note: plain npm test fails in this pane when AGENTIFY_MEMPALACE_CMD points at a non-existent local MemPalace binary; unsetting that stale override lets the existing fake MemPalace tests use PATH and the suite passes.