### PR TITLE
fix: surface external provider failures

### DIFF
--- a/src/core/commands.js
+++ b/src/core/commands.js
@@ -933,23 +933,35 @@ async function _runDocInner(root, config, options, progress) {
       }
     }
 
+    const moduleProviderStatuses = generatedModules
+      .map((item) => item.result?.metadata?.provider_status)
+      .filter(Boolean);
+    const providerStatus = moduleProviderStatuses.length > 0
+      && moduleProviderStatuses.every((status) => status.status === "fallback" && status.mode === "deterministic-local")
+      ? {
+          status: "fallback",
+          provider: "local",
+          mode: "deterministic-local"
+        }
+      : provider.name === "local"
+        ? {
+            status: "fallback",
+            provider: provider.name,
+            mode: "deterministic-local"
+          }
+        : {
+            status: "success",
+            provider: provider.name,
+            mode: "provider-backed"
+          };
+
     const runReport = {
     run_id: `${Date.now()}`,
     started_at: now,
     finished_at: new Date().toISOString(),
     provider: provider.name,
     provider_model: provider.providerModel,
-    provider_status: provider.name === "local"
-      ? {
-          status: "fallback",
-          provider: provider.name,
-          mode: "deterministic-local"
-        }
-      : {
-          status: "success",
-          provider: provider.name,
-          mode: "provider-backed"
-        },
+    provider_status: providerStatus,
     token_usage: {
       input_tokens: inputTokens,
       output_tokens: outputTokens,

--- a/src/core/commands.js
+++ b/src/core/commands.js
@@ -939,6 +939,17 @@ async function _runDocInner(root, config, options, progress) {
     finished_at: new Date().toISOString(),
     provider: provider.name,
     provider_model: provider.providerModel,
+    provider_status: provider.name === "local"
+      ? {
+          status: "fallback",
+          provider: provider.name,
+          mode: "deterministic-local"
+        }
+      : {
+          status: "success",
+          provider: provider.name,
+          mode: "provider-backed"
+        },
     token_usage: {
       input_tokens: inputTokens,
       output_tokens: outputTokens,
@@ -1013,6 +1024,7 @@ async function _runDocInner(root, config, options, progress) {
       cached_modules: cachedModules,
       files_with_headers: filesWithHeaders,
       docs_written: docsWritten,
+      provider_status: runReport.provider_status,
       token_usage: runReport.token_usage,
       wrote: config.dryRun ? [] : ["AGENTIFY.md", "docs/repo-map.md", "docs/modules/*.md", ".agents/index.db", ".agents/runs/*.json"],
     };

--- a/src/core/provider.js
+++ b/src/core/provider.js
@@ -8,6 +8,30 @@ import { getProviderDefinition } from "./provider-registry.js";
 
 const DEFAULT_PROVIDER_TIMEOUT_MS = 120000;
 
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export class ProviderExecutionError extends Error {
+  constructor(provider, phase, cause) {
+    super(`provider "${provider}" failed during ${phase}: ${errorMessage(cause)}`, {
+      cause
+    });
+    this.name = "ProviderExecutionError";
+    this.code = "AGENTIFY_PROVIDER_EXECUTION_FAILED";
+    this.provider = provider;
+    this.phase = phase;
+    this.status = "error";
+  }
+}
+
+function asProviderExecutionError(provider, phase, error) {
+  if (error instanceof ProviderExecutionError) {
+    return error;
+  }
+  return new ProviderExecutionError(provider, phase, error);
+}
+
 export function summarizeModule(moduleInfo, files, semantic = null) {
   const examples = files.slice(0, 5).join(", ");
   const semanticLead = semantic?.surfaces?.length
@@ -164,6 +188,11 @@ function fallbackArtifacts(moduleInfo, context) {
       stack: moduleInfo.stack
     },
     summary,
+    provider_status: {
+      status: "fallback",
+      provider: "local",
+      mode: "deterministic-local"
+    },
     public_api: inferPublicApi(context.files, context.semantic),
     start_here: inferStartHere(context),
     dependencies: {
@@ -485,6 +514,11 @@ async function runOpenCodeExec({ root, prompt, model, timeoutMs }) {
 function buildMetadataFromCodex(moduleInfo, context, response) {
   return {
     schema_version: "1.0",
+    provider_status: {
+      status: "success",
+      provider: context.providerName || "external",
+      mode: "provider-backed"
+    },
     module: {
       id: moduleInfo.id,
       name: moduleInfo.name,
@@ -565,44 +599,37 @@ function createExternalProvider(config, options) {
           plan: sanitizeManagerPlan(result.output, new Set(repoContext.modules.map((item) => item.id))),
           tokenUsage: result.usage
         };
-      } catch {
-        return {
-          plan: {
-            repo_summary: "",
-            shared_conventions: [],
-            module_focus: []
-          },
-          tokenUsage: {
-            input_tokens: 0,
-            output_tokens: 0,
-            total_tokens: 0
-          }
-        };
+      } catch (error) {
+        throw asProviderExecutionError(options.name, "manager planning", error);
       }
     },
     async generateModuleArtifacts(moduleInfo, context) {
-      const prompt = buildModulePrompt(moduleInfo, context);
-      const result = await options.run({
-        root: context.root,
-        prompt,
-        schema: buildModuleSchema(),
-        model: config.model,
-        timeoutMs
-      });
-      const sanitized = sanitizeModuleResponse(result.output, moduleInfo, new Set(context.keyFiles));
-      const metadata = {
-        ...buildMetadataFromCodex(moduleInfo, context, sanitized),
-        summary: sanitized.summary,
-        public_api: sanitized.public_api,
-        start_here: sanitized.start_here,
-        side_effects: sanitized.side_effects
-      };
-      return {
-        markdown: renderModuleMarkdown(moduleInfo, metadata),
-        metadata,
-        headers: sanitized.header_summaries,
-        tokenUsage: result.usage
-      };
+      try {
+        const prompt = buildModulePrompt(moduleInfo, context);
+        const result = await options.run({
+          root: context.root,
+          prompt,
+          schema: buildModuleSchema(),
+          model: config.model,
+          timeoutMs
+        });
+        const sanitized = sanitizeModuleResponse(result.output, moduleInfo, new Set(context.keyFiles));
+        const metadata = {
+          ...buildMetadataFromCodex(moduleInfo, { ...context, providerName: options.name }, sanitized),
+          summary: sanitized.summary,
+          public_api: sanitized.public_api,
+          start_here: sanitized.start_here,
+          side_effects: sanitized.side_effects
+        };
+        return {
+          markdown: renderModuleMarkdown(moduleInfo, metadata),
+          metadata,
+          headers: sanitized.header_summaries,
+          tokenUsage: result.usage
+        };
+      } catch (error) {
+        throw asProviderExecutionError(options.name, "module artifact generation", error);
+      }
     }
   };
 }

--- a/test/provider.test.js
+++ b/test/provider.test.js
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { createProvider, parseCodexJsonl, runChild } from "../src/core/provider.js";
+import { createProvider, parseCodexJsonl, ProviderExecutionError, runChild } from "../src/core/provider.js";
 
 test("parseCodexJsonl extracts token usage from turn.completed", () => {
   const usage = parseCodexJsonl([
@@ -28,6 +28,86 @@ test("runChild times out stalled provider subprocesses", async () => {
     }),
     /timed out after 50ms/,
   );
+});
+
+test("external provider manager planning surfaces unavailable provider failures", async () => {
+  const provider = createProvider("codex");
+  const previousPath = process.env.PATH;
+  process.env.PATH = "";
+
+  try {
+    await assert.rejects(
+      () => provider.buildManagerPlan({
+        repoName: "agentify-fixture",
+        root: process.cwd(),
+        defaultStack: "ts",
+        stacks: [{ name: "ts", confidence: 1 }],
+        entrypoints: [],
+        modules: [{ id: "auth", rootPath: "src/auth" }],
+        sampleFiles: [],
+      }),
+      (error) => {
+        assert.equal(error instanceof ProviderExecutionError, true);
+        assert.equal(error.code, "AGENTIFY_PROVIDER_EXECUTION_FAILED");
+        assert.equal(error.provider, "codex");
+        assert.equal(error.phase, "manager planning");
+        assert.equal(error.status, "error");
+        assert.match(error.message, /spawn codex ENOENT/);
+        return true;
+      },
+    );
+  } finally {
+    if (previousPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = previousPath;
+    }
+  }
+});
+
+test("external provider module generation surfaces unavailable provider failures", async () => {
+  const provider = createProvider("codex");
+  const previousPath = process.env.PATH;
+  process.env.PATH = "";
+
+  try {
+    await assert.rejects(
+      () => provider.generateModuleArtifacts(
+        { id: "auth", name: "auth", rootPath: "src/auth", stack: "ts", slug: "auth" },
+        {
+          root: process.cwd(),
+          files: [{ path: "src/auth/index.ts", content: "export const login = () => true;" }],
+          semantic: null,
+          keyFiles: ["src/auth/index.ts"],
+          dependsOn: [],
+          usedBy: [],
+          now: "2026-04-06T00:00:00.000Z",
+          headCommit: "deadbeef",
+          managerPlan: {
+            repo_summary: "",
+            shared_conventions: [],
+            module_focus: []
+          },
+          managerFocus: ""
+        },
+      ),
+      (error) => {
+        assert.equal(error instanceof ProviderExecutionError, true);
+        assert.equal(error.code, "AGENTIFY_PROVIDER_EXECUTION_FAILED");
+        assert.equal(error.provider, "codex");
+        assert.equal(error.phase, "module artifact generation");
+        assert.equal(error.status, "error");
+        assert.match(error.message, /spawn codex ENOENT/);
+        return true;
+      },
+    );
+  } finally {
+    if (previousPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = previousPath;
+    }
+  }
 });
 
 test("gemini provider execution preserves the readiness credential home", async () => {

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -10,7 +10,7 @@ import { applyHeaderToSource, renderHeader } from "../src/core/headers.js";
 import { loadConfig } from "../src/core/config.js";
 import { runDoc, runScan, runUpdate } from "../src/core/commands.js";
 import { closeIndexDatabase, openIndexDatabase } from "../src/core/db/connection.js";
-import { getArtifact, upsertArtifact } from "../src/core/db/artifact-store.js";
+import { getArtifact, removeArtifact, upsertArtifact } from "../src/core/db/artifact-store.js";
 import { getRepoMeta } from "../src/core/db/metadata-store.js";
 import { validateRepo } from "../src/core/validate.js";
 
@@ -372,12 +372,22 @@ test("runDoc reuses cached module artifacts when bounded content is unchanged", 
 
   assert.equal(docResult?.cached_manager_plan, true);
   assert.equal(docResult?.cached_modules, 1);
+  assert.deepEqual(docResult?.provider_status, {
+    status: "fallback",
+    provider: "local",
+    mode: "deterministic-local"
+  });
 
   const runDir = path.join(root, ".agents", "runs");
   const runFiles = (await fs.readdir(runDir)).sort();
   const latestRun = JSON.parse(await fs.readFile(path.join(runDir, runFiles.at(-1)), "utf8"));
   assert.equal(latestRun.results.cached_manager_plan, true);
   assert.equal(latestRun.results.cached_modules, 1);
+  assert.deepEqual(latestRun.provider_status, {
+    status: "fallback",
+    provider: "local",
+    mode: "deterministic-local"
+  });
   const db = openIndexDatabase(root);
   try {
     const meta = getRepoMeta(db);
@@ -385,6 +395,11 @@ test("runDoc reuses cached module artifacts when bounded content is unchanged", 
     const moduleArtifact = getArtifact(db, "module-doc:auth");
     assert.equal(meta.module_count, 1);
     assert.ok(managerPlanArtifact);
+    assert.deepEqual(moduleArtifact?.payload?.metadata?.provider_status, {
+      status: "fallback",
+      provider: "local",
+      mode: "deterministic-local"
+    });
     assert.match(moduleArtifact?.payload?.metadata?.freshness?.content_fingerprint || "", /^[a-f0-9]{64}$/);
   } finally {
     closeIndexDatabase(db);
@@ -415,6 +430,15 @@ setInterval(() => {}, 1000);
       providerTimeoutMs: 50,
     });
     await runScan(root, config, { skipOutput: true });
+    const localConfig = await loadConfig(root, { provider: "local", dryRun: false, tokenReport: false });
+    await runDoc(root, localConfig, { skipOutput: true });
+    const db = openIndexDatabase(root);
+    try {
+      removeArtifact(db, "module-doc:auth");
+    } finally {
+      closeIndexDatabase(db);
+    }
+    await fs.unlink(path.join(root, "docs", "modules", "auth.md"));
     assert.equal(await fs.stat(path.join(root, "docs", "repo-map.md")).then(() => true), true);
 
     await assert.rejects(


### PR DESCRIPTION
## Summary
- fail external manager planning instead of returning an empty success-shaped plan
- wrap external provider manager/module failures in ProviderExecutionError with provider, phase, code, and status fields
- add provider_status metadata to doc results, run reports, and module artifacts so local fallback output is machine-readable

Closes #20

## Tests
- node --test test/provider.test.js
- node --test --test-name-pattern 'cached module artifacts|external module provider stalls' test/update.test.js\n- git diff --check\n\n## Note\n- npm test currently fails in test/session.test.js: loadAutomaticRunMemory uses MemPalace automatically when the CLI is available because mempalace-calls.log is not created; this reproduces when running test/session.test.js by itself and is outside this provider failure change.