### PR TITLE
fix: index query search with sqlite fts

### DIFF
--- a/src/core/db/connection.js
+++ b/src/core/db/connection.js
@@ -337,7 +337,9 @@ export function openIndexDatabase(root, options = {}) {
     .run("schema_version", toJson(DB_SCHEMA_VERSION));
   db.prepare("INSERT OR REPLACE INTO repo_meta (key, value_json) VALUES (?, ?)")
     .run("db_driver", toJson(implementation.name));
-  refreshSearchIndexIfNeeded(db);
+  if (!readOnly) {
+    refreshSearchIndexIfNeeded(db);
+  }
 
   return db;
 }

--- a/src/core/db/connection.js
+++ b/src/core/db/connection.js
@@ -4,10 +4,11 @@ import { createRequire } from "node:module";
 import os from "node:os";
 import process from "node:process";
 
+import { createSearchSchema, refreshSearchIndexIfNeeded } from "./search-store.js";
 import { toJson } from "./utils.js";
 
 const require = createRequire(import.meta.url);
-const DB_SCHEMA_VERSION = "3.0";
+const DB_SCHEMA_VERSION = "3.1";
 const SNAPSHOT_DIR_MODE = 0o700;
 const SNAPSHOT_FILE_MODE = 0o600;
 
@@ -330,11 +331,13 @@ export function openIndexDatabase(root, options = {}) {
     CREATE INDEX IF NOT EXISTS idx_semantic_edges_from_file_path ON semantic_symbol_edges(from_file_path);
     CREATE INDEX IF NOT EXISTS idx_semantic_edges_to_file_path ON semantic_symbol_edges(to_file_path);
   `);
+  createSearchSchema(db);
 
   db.prepare("INSERT OR REPLACE INTO repo_meta (key, value_json) VALUES (?, ?)")
     .run("schema_version", toJson(DB_SCHEMA_VERSION));
   db.prepare("INSERT OR REPLACE INTO repo_meta (key, value_json) VALUES (?, ?)")
     .run("db_driver", toJson(implementation.name));
+  refreshSearchIndexIfNeeded(db);
 
   return db;
 }

--- a/src/core/db/search-store.js
+++ b/src/core/db/search-store.js
@@ -1,0 +1,142 @@
+import { toJson } from "./utils.js";
+
+const SEARCH_INDEX_VERSION = "1.0";
+const STRUCTURAL_OWNER = "structural";
+
+function likePattern(term) {
+  const normalized = String(term || "").trim().toLowerCase();
+  return `%${normalized.replace(/[\\%_]/g, "\\$&")}%`;
+}
+
+export function createSearchSchema(db) {
+  db.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS query_search_fts USING fts5(
+      entity_type UNINDEXED,
+      owner_id UNINDEXED,
+      entity_id UNINDEXED,
+      search_text,
+      tokenize='trigram'
+    );
+  `);
+}
+
+export function refreshSearchIndexIfNeeded(db) {
+  const version = db.prepare("SELECT value_json FROM repo_meta WHERE key = ?")
+    .get("search_index_version")?.value_json;
+  if (version === toJson(SEARCH_INDEX_VERSION)) {
+    return;
+  }
+
+  rebuildSearchIndex(db);
+}
+
+export function rebuildSearchIndex(db) {
+  db.prepare("DELETE FROM query_search_fts").run();
+  rebuildStructuralSearchIndex(db);
+  rebuildSemanticSearchIndex(db);
+  setSearchIndexVersion(db);
+}
+
+export function setSearchIndexVersion(db) {
+  db.prepare("INSERT OR REPLACE INTO repo_meta (key, value_json) VALUES (?, ?)")
+    .run("search_index_version", toJson(SEARCH_INDEX_VERSION));
+}
+
+export function clearStructuralSearchIndex(db) {
+  db.prepare("DELETE FROM query_search_fts WHERE owner_id = ?").run(STRUCTURAL_OWNER);
+}
+
+export function rebuildStructuralSearchIndex(db) {
+  clearStructuralSearchIndex(db);
+  db.exec(`
+    INSERT INTO query_search_fts (entity_type, owner_id, entity_id, search_text)
+    SELECT 'module', '${STRUCTURAL_OWNER}', id, lower(id || ' ' || name || ' ' || root_path)
+    FROM modules;
+
+    INSERT INTO query_search_fts (entity_type, owner_id, entity_id, search_text)
+    SELECT 'file', '${STRUCTURAL_OWNER}', path, lower(path)
+    FROM files;
+
+    INSERT INTO query_search_fts (entity_type, owner_id, entity_id, search_text)
+    SELECT 'symbol', '${STRUCTURAL_OWNER}', CAST(symbol_id AS TEXT), lower(name || ' ' || file_path)
+    FROM symbols;
+  `);
+}
+
+export function clearSemanticProjectSearchIndex(db, projectId) {
+  db.prepare(`
+    DELETE FROM query_search_fts
+    WHERE entity_type IN ('semantic_project', 'semantic_surface', 'semantic_symbol')
+      AND owner_id = ?
+  `).run(projectId);
+}
+
+export function rebuildSemanticProjectSearchIndex(db, projectId) {
+  clearSemanticProjectSearchIndex(db, projectId);
+  db.prepare(`
+    INSERT INTO query_search_fts (entity_type, owner_id, entity_id, search_text)
+    SELECT
+      'semantic_project',
+      project_id,
+      project_id,
+      lower(project_id || ' ' || coalesce(config_path, '') || ' ' || project_root)
+    FROM semantic_projects
+    WHERE project_id = ?
+  `).run(projectId);
+  db.prepare(`
+    INSERT INTO query_search_fts (entity_type, owner_id, entity_id, search_text)
+    SELECT
+      'semantic_surface',
+      project_id,
+      surface_id,
+      lower(file_path || ' ' || kind || ' ' || role || ' ' || surface_key || ' ' || display_name)
+    FROM semantic_surfaces
+    WHERE project_id = ?
+  `).run(projectId);
+  db.prepare(`
+    INSERT INTO query_search_fts (entity_type, owner_id, entity_id, search_text)
+    SELECT
+      'semantic_symbol',
+      project_id,
+      symbol_id,
+      lower(name || ' ' || file_path || ' ' || coalesce(export_name, ''))
+    FROM semantic_symbols
+    WHERE project_id = ?
+  `).run(projectId);
+}
+
+export function rebuildSemanticSearchIndex(db) {
+  db.prepare(`
+    DELETE FROM query_search_fts
+    WHERE entity_type IN ('semantic_project', 'semantic_surface', 'semantic_symbol')
+  `).run();
+  db.exec(`
+    INSERT INTO query_search_fts (entity_type, owner_id, entity_id, search_text)
+    SELECT
+      'semantic_project',
+      project_id,
+      project_id,
+      lower(project_id || ' ' || coalesce(config_path, '') || ' ' || project_root)
+    FROM semantic_projects;
+
+    INSERT INTO query_search_fts (entity_type, owner_id, entity_id, search_text)
+    SELECT
+      'semantic_surface',
+      project_id,
+      surface_id,
+      lower(file_path || ' ' || kind || ' ' || role || ' ' || surface_key || ' ' || display_name)
+    FROM semantic_surfaces;
+
+    INSERT INTO query_search_fts (entity_type, owner_id, entity_id, search_text)
+    SELECT
+      'semantic_symbol',
+      project_id,
+      symbol_id,
+      lower(name || ' ' || file_path || ' ' || coalesce(export_name, ''))
+    FROM semantic_symbols;
+  `);
+}
+
+export function searchLikePattern(term) {
+  return likePattern(term);
+}

--- a/src/core/db/semantic-store.js
+++ b/src/core/db/semantic-store.js
@@ -1,6 +1,12 @@
 import { fromJson, normalizeRows, toJson } from "./utils.js";
+import {
+  clearSemanticProjectSearchIndex,
+  rebuildSemanticProjectSearchIndex,
+  searchLikePattern,
+} from "./search-store.js";
 
 export function clearSemanticProjectState(db, projectId) {
+  clearSemanticProjectSearchIndex(db, projectId);
   db.prepare("DELETE FROM semantic_symbol_edges WHERE project_id = ?").run(projectId);
   db.prepare("DELETE FROM semantic_surfaces WHERE project_id = ?").run(projectId);
   db.prepare("DELETE FROM semantic_symbols WHERE project_id = ?").run(projectId);
@@ -188,6 +194,8 @@ export function replaceSemanticProjectSnapshot(db, snapshot) {
       edgeInfo.metadata_json || null
     );
   }
+
+  rebuildSemanticProjectSearchIndex(db, snapshot.project.project_id);
 }
 
 export function listSemanticProjects(db) {
@@ -364,37 +372,35 @@ export function loadSemanticPlannerFacts(db) {
 }
 
 export function searchSemanticIndex(db, term, limit = 20) {
-  const normalized = `%${String(term || "").trim().toLowerCase()}%`;
+  const pattern = searchLikePattern(term);
   return {
     semantic_projects: normalizeRows(db.prepare(`
       SELECT project_id, config_path, project_root, status, file_count, symbol_count, surface_count, edge_count
-      FROM semantic_projects
-      WHERE lower(coalesce(config_path, '')) LIKE ?
-        OR lower(project_root) LIKE ?
-        OR lower(project_id) LIKE ?
+      FROM query_search_fts search
+      JOIN semantic_projects ON semantic_projects.project_id = search.entity_id
+      WHERE search.entity_type = 'semantic_project'
+        AND search.search_text LIKE ? ESCAPE '\\'
       ORDER BY coalesce(config_path, project_root), project_id
       LIMIT ?
-    `).all(normalized, normalized, normalized, limit)),
+    `).all(pattern, limit)),
     semantic_surfaces: normalizeRows(db.prepare(`
       SELECT surface_id, project_id, file_path, kind, role, surface_key, display_name
-      FROM semantic_surfaces
-      WHERE lower(file_path) LIKE ?
-        OR lower(kind) LIKE ?
-        OR lower(role) LIKE ?
-        OR lower(surface_key) LIKE ?
-        OR lower(display_name) LIKE ?
+      FROM query_search_fts search
+      JOIN semantic_surfaces ON semantic_surfaces.surface_id = search.entity_id
+      WHERE search.entity_type = 'semantic_surface'
+        AND search.search_text LIKE ? ESCAPE '\\'
       ORDER BY file_path, kind, role
       LIMIT ?
-    `).all(normalized, normalized, normalized, normalized, normalized, limit)),
+    `).all(pattern, limit)),
     semantic_symbols: normalizeRows(db.prepare(`
       SELECT symbol_id, project_id, file_path, name, kind, export_name, is_exported
-      FROM semantic_symbols
-      WHERE lower(name) LIKE ?
-        OR lower(file_path) LIKE ?
-        OR lower(coalesce(export_name, '')) LIKE ?
+      FROM query_search_fts search
+      JOIN semantic_symbols ON semantic_symbols.symbol_id = search.entity_id
+      WHERE search.entity_type = 'semantic_symbol'
+        AND search.search_text LIKE ? ESCAPE '\\'
       ORDER BY file_path, start_line
       LIMIT ?
-    `).all(normalized, normalized, normalized, limit)),
+    `).all(pattern, limit)),
   };
 }
 

--- a/src/core/db/structural-store.js
+++ b/src/core/db/structural-store.js
@@ -1,7 +1,13 @@
 import { fromJson, normalizeRows, toJson } from "./utils.js";
 import { setRepoMeta } from "./metadata-store.js";
+import {
+  clearStructuralSearchIndex,
+  rebuildStructuralSearchIndex,
+  searchLikePattern,
+} from "./search-store.js";
 
 export function clearIndexedState(db) {
+  clearStructuralSearchIndex(db);
   db.exec(`
     DELETE FROM commands;
     DELETE FROM tests;
@@ -219,6 +225,8 @@ export function writeRepositoryIndex(db, snapshot, { headCommit, provider }) {
     snapshot.symbols.length,
     snapshot.imports.length
   );
+
+  rebuildStructuralSearchIndex(db);
 }
 
 export function loadFiles(db, moduleId = null) {
@@ -315,28 +323,34 @@ export function loadModuleDependencies(db, moduleId) {
 }
 
 export function searchIndex(db, term, limit = 20) {
-  const normalized = `%${String(term || "").trim().toLowerCase()}%`;
+  const pattern = searchLikePattern(term);
   return {
     modules: normalizeRows(db.prepare(`
       SELECT id, name, root_path, stack
-      FROM modules
-      WHERE lower(id) LIKE ? OR lower(name) LIKE ? OR lower(root_path) LIKE ?
+      FROM query_search_fts search
+      JOIN modules ON modules.id = search.entity_id
+      WHERE search.entity_type = 'module'
+        AND search.search_text LIKE ? ESCAPE '\\'
       ORDER BY root_path
       LIMIT ?
-    `).all(normalized, normalized, normalized, limit)),
+    `).all(pattern, limit)),
     files: normalizeRows(db.prepare(`
       SELECT path, module_id, language, is_test, is_config
-      FROM files
-      WHERE lower(path) LIKE ?
+      FROM query_search_fts search
+      JOIN files ON files.path = search.entity_id
+      WHERE search.entity_type = 'file'
+        AND search.search_text LIKE ? ESCAPE '\\'
       ORDER BY path
       LIMIT ?
-    `).all(normalized, limit)),
+    `).all(pattern, limit)),
     symbols: normalizeRows(db.prepare(`
       SELECT name, kind, file_path, module_id, exported
-      FROM symbols
-      WHERE lower(name) LIKE ? OR lower(file_path) LIKE ?
+      FROM query_search_fts search
+      JOIN symbols ON symbols.symbol_id = CAST(search.entity_id AS INTEGER)
+      WHERE search.entity_type = 'symbol'
+        AND search.search_text LIKE ? ESCAPE '\\'
       ORDER BY file_path, start_line
       LIMIT ?
-    `).all(normalized, normalized, limit)),
+    `).all(pattern, limit)),
   };
 }

--- a/src/core/db/structural-store.js
+++ b/src/core/db/structural-store.js
@@ -3,7 +3,6 @@ import { setRepoMeta } from "./metadata-store.js";
 import {
   clearStructuralSearchIndex,
   rebuildStructuralSearchIndex,
-  searchLikePattern,
 } from "./search-store.js";
 
 export function clearIndexedState(db) {
@@ -323,14 +322,14 @@ export function loadModuleDependencies(db, moduleId) {
 }
 
 export function searchIndex(db, term, limit = 20) {
-  const pattern = searchLikePattern(term);
+  const pattern = `%${String(term || "").trim().toLowerCase()}%`;
   return {
     modules: normalizeRows(db.prepare(`
       SELECT id, name, root_path, stack
       FROM query_search_fts search
       JOIN modules ON modules.id = search.entity_id
       WHERE search.entity_type = 'module'
-        AND search.search_text LIKE ? ESCAPE '\\'
+        AND search.search_text LIKE ?
       ORDER BY root_path
       LIMIT ?
     `).all(pattern, limit)),
@@ -339,7 +338,7 @@ export function searchIndex(db, term, limit = 20) {
       FROM query_search_fts search
       JOIN files ON files.path = search.entity_id
       WHERE search.entity_type = 'file'
-        AND search.search_text LIKE ? ESCAPE '\\'
+        AND search.search_text LIKE ?
       ORDER BY path
       LIMIT ?
     `).all(pattern, limit)),
@@ -348,7 +347,7 @@ export function searchIndex(db, term, limit = 20) {
       FROM query_search_fts search
       JOIN symbols ON symbols.symbol_id = CAST(search.entity_id AS INTEGER)
       WHERE search.entity_type = 'symbol'
-        AND search.search_text LIKE ? ESCAPE '\\'
+        AND search.search_text LIKE ?
       ORDER BY file_path, start_line
       LIMIT ?
     `).all(pattern, limit)),

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -28,6 +28,12 @@ function octalMode(stats) {
   return (stats.mode & 0o777).toString(8);
 }
 
+function explainDetails(db, sql, ...params) {
+  return db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(...params)
+    .map((row) => String(row.detail || ""))
+    .join("\n");
+}
+
 test("openIndexDatabase read-only snapshots use user-only permissions", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-db-readonly-"));
   await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
@@ -140,6 +146,19 @@ test("structural store writes and searches repository index data", async () => {
     assert.equal(loadFiles(db, "app").length, 2);
     assert.equal(loadSymbols(db, "app")[0].name, "startApp");
     assert.equal(searchIndex(db, "start").symbols[0].name, "startApp");
+    assert.equal(searchIndex(db, "APP").symbols[0].name, "startApp");
+
+    const plan = explainDetails(db, `
+      SELECT name, kind, file_path, module_id, exported
+      FROM query_search_fts search
+      JOIN symbols ON symbols.symbol_id = CAST(search.entity_id AS INTEGER)
+      WHERE search.entity_type = 'symbol'
+        AND search.search_text LIKE ? ESCAPE '\\'
+      ORDER BY file_path, start_line
+      LIMIT ?
+    `, "%start%", 20);
+    assert.match(plan, /VIRTUAL TABLE/i);
+    assert.doesNotMatch(plan, /SCAN symbols/i);
   } finally {
     closeIndexDatabase(db);
   }
@@ -247,6 +266,18 @@ test("semantic store replaces snapshots and loads focused semantic facts", async
     assert.equal(loadSemanticProjectFactsByFile(db)[0].surface.displayName, "Dashboard");
     assert.equal(loadSemanticFileContext(db, "src/app/dashboard/page.tsx").exports[0].export_name, "default");
     assert.equal(searchSemanticIndex(db, "dashboard").semantic_surfaces[0].surface_key, "/dashboard");
+
+    const plan = explainDetails(db, `
+      SELECT surface_id, project_id, file_path, kind, role, surface_key, display_name
+      FROM query_search_fts search
+      JOIN semantic_surfaces ON semantic_surfaces.surface_id = search.entity_id
+      WHERE search.entity_type = 'semantic_surface'
+        AND search.search_text LIKE ? ESCAPE '\\'
+      ORDER BY file_path, kind, role
+      LIMIT ?
+    `, "%dashboard%", 20);
+    assert.match(plan, /VIRTUAL TABLE/i);
+    assert.doesNotMatch(plan, /SCAN semantic_surfaces/i);
   } finally {
     closeIndexDatabase(db);
   }


### PR DESCRIPTION
## Summary
- add a SQLite FTS5 trigram search index for structural and semantic query search entities
- keep the FTS index populated from existing structural and semantic write paths, with backfill for older index databases
- route `query search` lookups through the search index instead of leading-wildcard scans over primary tables

Fixes #21

## Verification
- `env -u AGENTIFY_MEMPALACE_CMD pnpm test -- test/db.test.js test/query.test.js test/semantic.test.js`
- `env -u AGENTIFY_MEMPALACE_CMD pnpm test`

Note: this shell has `AGENTIFY_MEMPALACE_CMD` set to a non-fixture path, which breaks the MemPalace fake-binary test if left in the environment. The full suite passes with that variable unset.