### PR TITLE
feat: add session handoff bundle command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ For longer workstreams, use sessions:
 ```bash
 agentify sess run --provider codex --name "checkout-retries" "map the current checkout flow"
 agentify sess resume --session <session-id> "finish the implementation"
+agentify handoff --session <session-id> "handoff to the next agent"
 ```
 
 ## Caveman Mode
@@ -111,6 +112,7 @@ Supported levels are `lite`, `full`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-f
 | Search indexed repo context | `agentify query search --term auth` |
 | Run a bounded task | `agentify run "your task"` |
 | Start durable multi-run work | `agentify sess run --name "<stream>" "your task"` |
+| Write a cross-agent handoff bundle | `agentify handoff --session <id> "next task"` |
 | Install built-in skills into the repo | `agentify skill install all --provider codex --scope project` |
 | Update Agentify-owned repo files after upgrading the CLI | `agentify sync` |
 

--- a/docs/DETAILED_README.md
+++ b/docs/DETAILED_README.md
@@ -176,9 +176,10 @@ tests:
 | `agentify sess resume` | Resumes a previous session by id and relaunches the provider with that bootstrap context. | Use when you want to continue a prior thread without manually rebuilding context. | `agentify sess resume --session sess_20260331_ab12cd "continue"` |
 | `agentify sess fork` | Forks an existing session into a new branch of work. | Use when you want to preserve the old session but try a different implementation or direction. | `agentify sess fork --from sess_20260331_ab12cd --name "payments-alt" "try alternate design"` |
 | `agentify sess list` | Lists known sessions for the repo. | Use when you need to find an id to resume or audit previous work threads. | `agentify sess list` |
+| `agentify handoff` | Writes deterministic Markdown and JSON handoff artifacts for a session. | Use before switching agents or worktrees so the next agent gets ranked context, touched symbols, tests, TODO/risk lines, and recent-session overlap hints. | `agentify handoff --session sess_20260331_ab12cd "next task"` |
 | `agentify issue-killer` | Launches opted-in GitHub issues into supervised tmux panes, each with its own Worktrunk worktree and Codex or Claude prompt running with provider permission checks bypassed. | Use when you want several labelled or explicit issues handled in parallel without giving agents arbitrary access to the whole issue backlog. | `agentify issue-killer --label agentify-ready --agent-provider codex --limit 5` |
 
-Session memory is automatic for `sess *` commands. Session runs write durable artifacts such as `transcript.md`, `memory-context.md`, and `launches.jsonl` under `.agents/session/<id>/`, and `sess resume` / `sess fork` automatically inject recent transcript excerpts into the next prompt without requiring a separate memory command.
+Session memory is automatic for `sess *` commands. Session runs write durable artifacts such as `transcript.md`, `memory-context.md`, and `launches.jsonl` under `.agents/session/<id>/`, and `sess resume` / `sess fork` automatically inject recent transcript excerpts into the next prompt without requiring a separate memory command. Handoff bundles live beside those artifacts as `handoff.md` and `handoff.json`.
 
 Normal `run` is intentionally lightweight. It does not persist durable session memory artifacts under `.agents/session/`; if you need reusable memory across multiple launches, use `sess *`.
 
@@ -228,6 +229,7 @@ agentify sess run [--provider <name>] [--name <label>] [--from <parent-id>] "tas
 agentify sess list
 agentify sess resume --session <id> "task"
 agentify sess fork --from <id> [--provider <name>] [--name <label>] "task"
+agentify handoff --session <id> "next task"
 ```
 
 Use sessions when the work is multi-step, the prompt context is too expensive to rebuild every time, or you want a durable audit trail under `.agents/session/`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -265,7 +265,10 @@ Template runs are interactive by default across providers.
 agentify sess run --provider codex --name "payments-v2" "implement initial module"
 agentify sess resume --session <session-id> "continue from the last checkpoint"
 agentify sess fork --from <session-id> --name "payments-alt" "try an alternate design"
+agentify handoff --session <session-id> "handoff to the next agent"
 ```
+
+`agentify handoff` writes `.agents/session/<id>/handoff.md` and `handoff.json` with ranked context, touched symbols, recommended tests, unresolved TODO/risk lines, and overlap hints from recent session handoffs.
 
 ### Launch opted-in issues in parallel
 

--- a/src/core/handoff.js
+++ b/src/core/handoff.js
@@ -1,0 +1,388 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { buildExecutionPlan } from "./planner.js";
+import { closeIndexDatabase, openIndexDatabase } from "./db/connection.js";
+import { loadSymbols } from "./db/structural-store.js";
+import { ensureDir, exists, readJson, relative, writeJson, writeText } from "./fs.js";
+import { getChangedFiles, getChangedFilesSince, getHeadCommit } from "./git.js";
+import { getSessionArtifactPaths } from "./session-memory.js";
+import { listSessions, resumeSession } from "./session.js";
+
+const MAX_CONTEXT_FILES = 8;
+const MAX_CONTEXT_SYMBOLS = 12;
+const MAX_TOUCHED_SYMBOLS_PER_FILE = 12;
+const MAX_RISKS = 12;
+const RECENT_SESSION_LIMIT = 8;
+
+function normalizePath(value) {
+  return String(value || "").split(path.sep).join("/").replace(/^\.\//, "");
+}
+
+function uniqueSorted(items) {
+  return Array.from(new Set(items.filter(Boolean))).sort((left, right) => left.localeCompare(right));
+}
+
+function byPathThenLine(left, right) {
+  return left.file_path.localeCompare(right.file_path) || left.start_line - right.start_line || left.name.localeCompare(right.name);
+}
+
+function normalizeChangedEntry(entry) {
+  return {
+    status: entry.status || "?",
+    path: normalizePath(entry.path),
+    orig_path: entry.origPath ? normalizePath(entry.origPath) : null,
+  };
+}
+
+async function collectTouchedFiles(root, manifest) {
+  const byPath = new Map();
+  const add = (entry, source) => {
+    const normalized = normalizeChangedEntry(entry);
+    if (!normalized.path) {
+      return;
+    }
+    const previous = byPath.get(normalized.path);
+    const previousSources = Array.isArray(previous?.source)
+      ? previous.source
+      : previous?.source
+        ? [previous.source]
+        : [];
+    byPath.set(normalized.path, {
+      ...normalized,
+      source: previous ? uniqueSorted([...previousSources, source]) : source,
+    });
+  };
+
+  if (manifest.head_commit_at_creation && manifest.head_commit_at_creation !== "nogit") {
+    for (const entry of await getChangedFilesSince(root, manifest.head_commit_at_creation)) {
+      add(entry, "session-base-diff");
+    }
+  }
+
+  for (const entry of await getChangedFiles(root)) {
+    add(entry, "working-tree");
+  }
+
+  return Array.from(byPath.values()).sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function summarizePlan(plan) {
+  if (!plan) {
+    return {
+      confidence: 0,
+      modules: [],
+      files: [],
+      symbols: [],
+    };
+  }
+
+  return {
+    confidence: plan.confidence,
+    modules: plan.selected_modules.map((item) => ({
+      id: item.id,
+      root_path: item.root_path,
+      score: item.score,
+      reasons: (item.reasons || []).map((reason) => reason.reason).slice(0, 3),
+    })),
+    files: plan.selected_files.slice(0, MAX_CONTEXT_FILES).map((item) => ({
+      path: item.path,
+      module_id: item.module_id,
+      score: item.score,
+      reasons: (item.reasons || []).map((reason) => reason.reason).slice(0, 3),
+    })),
+    symbols: plan.selected_symbols.slice(0, MAX_CONTEXT_SYMBOLS).map((item) => ({
+      name: item.name,
+      kind: item.kind,
+      file_path: item.file_path,
+      start_line: item.start_line,
+      end_line: item.end_line,
+      score: item.score,
+      source: item.source || "structural",
+    })),
+  };
+}
+
+function summarizeTests(plan) {
+  if (!plan) {
+    return { files: [], commands: [] };
+  }
+  return {
+    files: plan.related_tests.map((item) => ({
+      file_path: item.file_path,
+      related_path: item.related_path || null,
+      framework: item.framework || null,
+    })),
+    commands: plan.verification_commands.map((item) => ({
+      command: item.command,
+      args: item.args || [],
+      command_type: item.command_type || null,
+      module_id: item.module_id || null,
+    })),
+  };
+}
+
+async function loadTouchedSymbolNeighborhood(root, touchedFiles) {
+  if (touchedFiles.length === 0 || !(await exists(path.join(root, ".agents", "index.db")))) {
+    return [];
+  }
+
+  const touched = new Set(touchedFiles.map((item) => item.path));
+  const db = openIndexDatabase(root, { readOnly: true });
+  try {
+    const symbolsByFile = new Map();
+    for (const symbolInfo of loadSymbols(db).filter((item) => touched.has(item.file_path)).sort(byPathThenLine)) {
+      if (!symbolsByFile.has(symbolInfo.file_path)) {
+        symbolsByFile.set(symbolInfo.file_path, []);
+      }
+      symbolsByFile.get(symbolInfo.file_path).push({
+        name: symbolInfo.name,
+        kind: symbolInfo.kind,
+        module_id: symbolInfo.module_id || null,
+        exported: Boolean(symbolInfo.exported),
+        start_line: symbolInfo.start_line,
+        end_line: symbolInfo.end_line,
+      });
+    }
+
+    return Array.from(symbolsByFile.entries())
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([filePath, symbols]) => ({
+        file_path: filePath,
+        symbols: symbols.slice(0, MAX_TOUCHED_SYMBOLS_PER_FILE),
+        omitted_symbols: Math.max(0, symbols.length - MAX_TOUCHED_SYMBOLS_PER_FILE),
+      }));
+  } finally {
+    closeIndexDatabase(db);
+  }
+}
+
+async function scanRisks(root, filePaths) {
+  const risks = [];
+  const paths = uniqueSorted(filePaths).slice(0, 32);
+  const riskPattern = /\b(TODO|FIXME|XXX|HACK|BUG|RISK)\b[:\s-]*(.*)$/i;
+
+  for (const filePath of paths) {
+    const absolutePath = path.join(root, filePath);
+    let content = "";
+    try {
+      content = await fs.readFile(absolutePath, "utf8");
+    } catch {
+      continue;
+    }
+    const lines = content.split(/\r?\n/);
+    for (let index = 0; index < lines.length; index += 1) {
+      const match = lines[index].match(riskPattern);
+      if (!match) {
+        continue;
+      }
+      risks.push({
+        file_path: filePath,
+        line: index + 1,
+        tag: match[1].toUpperCase(),
+        text: match[2].trim().slice(0, 180) || lines[index].trim().slice(0, 180),
+      });
+      if (risks.length >= MAX_RISKS) {
+        return risks;
+      }
+    }
+  }
+
+  return risks;
+}
+
+function extractTouchedPathsFromBundle(bundle) {
+  const touched = Array.isArray(bundle?.touched_files) ? bundle.touched_files : [];
+  return uniqueSorted(touched.map((item) => typeof item === "string" ? item : item?.path));
+}
+
+async function loadSessionTouchedPaths(root, sessionId) {
+  const paths = getSessionArtifactPaths(root, sessionId);
+  if (await exists(paths.handoffJsonPath)) {
+    try {
+      return extractTouchedPathsFromBundle(await readJson(paths.handoffJsonPath));
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+async function collectConflictHints(root, sessionId, touchedFiles) {
+  const touchedPaths = new Set(touchedFiles.map((item) => item.path));
+  if (touchedPaths.size === 0) {
+    return [];
+  }
+
+  const hints = [];
+  const sessions = (await listSessions(root))
+    .filter((session) => session.session_id !== sessionId)
+    .slice(0, RECENT_SESSION_LIMIT);
+
+  for (const session of sessions) {
+    const otherTouchedPaths = await loadSessionTouchedPaths(root, session.session_id);
+    const overlap = otherTouchedPaths.filter((filePath) => touchedPaths.has(filePath));
+    if (overlap.length === 0) {
+      continue;
+    }
+
+    hints.push({
+      session_id: session.session_id,
+      created_at: session.created_at || null,
+      name: session.name || null,
+      severity: overlap.length >= 3 ? "high" : "medium",
+      overlap_files: overlap,
+      handoff_path: `.agents/session/${session.session_id}/handoff.json`,
+    });
+  }
+
+  return hints;
+}
+
+function renderCommand(commandInfo) {
+  return [commandInfo.command, ...(commandInfo.args || [])].join(" ").trim();
+}
+
+function buildNextActions(bundle) {
+  const actions = [];
+  actions.push(`Continue: ${bundle.task}`);
+  if (bundle.conflict_hints.length > 0) {
+    actions.push("Review conflict hints before editing overlapping files.");
+  }
+  if (bundle.top_ranked_context.files.length > 0) {
+    actions.push(`Start with ${bundle.top_ranked_context.files.slice(0, 3).map((item) => item.path).join(", ")}.`);
+  }
+  if (bundle.unresolved_risks.length > 0) {
+    actions.push(`Resolve or explicitly defer ${bundle.unresolved_risks.length} TODO/risk item(s).`);
+  }
+  if (bundle.recommended_tests.commands.length > 0) {
+    actions.push(`Run ${renderCommand(bundle.recommended_tests.commands[0])}.`);
+  } else if (bundle.recommended_tests.files.length > 0) {
+    actions.push(`Run tests covering ${bundle.recommended_tests.files.slice(0, 3).map((item) => item.file_path).join(", ")}.`);
+  }
+  return actions;
+}
+
+function renderHandoffMarkdown(bundle) {
+  const contextFiles = bundle.top_ranked_context.files.length > 0
+    ? bundle.top_ranked_context.files.map((item) => `- ${item.path}${item.reasons.length > 0 ? ` (${item.reasons.join("; ")})` : ""}`).join("\n")
+    : "- none";
+  const touched = bundle.touched_files.length > 0
+    ? bundle.touched_files.map((item) => `- ${item.path} [${item.status}; ${Array.isArray(item.source) ? item.source.join(", ") : item.source}]`).join("\n")
+    : "- none";
+  const symbols = bundle.touched_symbol_neighborhood.length > 0
+    ? bundle.touched_symbol_neighborhood.flatMap((fileInfo) => [
+      `- ${fileInfo.file_path}`,
+      ...fileInfo.symbols.map((symbol) => `  - ${symbol.name} (${symbol.kind}) lines ${symbol.start_line}-${symbol.end_line}`),
+    ]).join("\n")
+    : "- none";
+  const tests = bundle.recommended_tests.commands.length > 0
+    ? bundle.recommended_tests.commands.map((item) => `- ${renderCommand(item)}`).join("\n")
+    : bundle.recommended_tests.files.map((item) => `- ${item.file_path}`).join("\n") || "- none";
+  const risks = bundle.unresolved_risks.length > 0
+    ? bundle.unresolved_risks.map((item) => `- ${item.file_path}:${item.line} ${item.tag} ${item.text}`.trim()).join("\n")
+    : "- none";
+  const conflicts = bundle.conflict_hints.length > 0
+    ? bundle.conflict_hints.map((item) => `- ${item.severity}: ${item.session_id} overlaps ${item.overlap_files.join(", ")}`).join("\n")
+    : "- none";
+
+  return `# Agentify Handoff
+
+## Session
+- ID: ${bundle.session_id}
+- Parent: ${bundle.parent_id || "none"}
+- Provider: ${bundle.provider}
+- Task: ${bundle.task}
+- HEAD: ${bundle.current_head}
+
+## Next Actions
+${bundle.next_actions.map((item) => `- ${item}`).join("\n")}
+
+## Top-Ranked Context
+- Confidence: ${bundle.top_ranked_context.confidence}
+${contextFiles}
+
+## Touched Files
+${touched}
+
+## Touched Symbol Neighborhood
+${symbols}
+
+## Recommended Tests
+${tests}
+
+## Unresolved Risks and TODOs
+${risks}
+
+## Conflict Hints
+${conflicts}
+`;
+}
+
+export async function buildHandoffBundle(root, config, sessionId, task = "") {
+  const session = await resumeSession(root, sessionId);
+  const manifest = session.manifest;
+  const resolvedTask = String(task || "").trim()
+    || manifest.name
+    || session.context?.run_history?.at?.(-1)?.task
+    || "Continue this session from the latest repository state.";
+  const touchedFiles = await collectTouchedFiles(root, manifest);
+  const currentHead = await getHeadCommit(root);
+  let plan = null;
+  const planWarnings = [];
+
+  try {
+    plan = await buildExecutionPlan(root, config, resolvedTask);
+  } catch (error) {
+    planWarnings.push(`Planner context unavailable: ${error.message}`);
+  }
+
+  const selectedRiskPaths = plan?.selected_files?.map((item) => item.path) || [];
+  const touchedSymbolNeighborhood = await loadTouchedSymbolNeighborhood(root, touchedFiles);
+  const bundle = {
+    schema_version: "1.0",
+    bundle_type: "agentify-handoff",
+    session_id: manifest.session_id,
+    parent_id: manifest.parent_id || null,
+    provider: manifest.provider || manifest.tool || config.provider || "local",
+    task: resolvedTask,
+    session_created_at: manifest.created_at || null,
+    base_head: manifest.head_commit_at_creation || "unknown",
+    current_head: currentHead,
+    artifact_refs: {
+      markdown: `.agents/session/${sessionId}/handoff.md`,
+      json: `.agents/session/${sessionId}/handoff.json`,
+      manifest: `.agents/session/${sessionId}/session-manifest.json`,
+      context: `.agents/session/${sessionId}/context.json`,
+      checklist: `.agents/session/${sessionId}/checklist.json`,
+      transcript: `.agents/session/${sessionId}/transcript.md`,
+    },
+    top_ranked_context: summarizePlan(plan),
+    touched_files: touchedFiles,
+    touched_symbol_neighborhood: touchedSymbolNeighborhood,
+    recommended_tests: summarizeTests(plan),
+    unresolved_risks: [
+      ...planWarnings.map((message) => ({ file_path: null, line: null, tag: "RISK", text: message })),
+      ...await scanRisks(root, [...touchedFiles.map((item) => item.path), ...selectedRiskPaths]),
+    ].slice(0, MAX_RISKS),
+    conflict_hints: await collectConflictHints(root, sessionId, touchedFiles),
+    next_actions: [],
+  };
+  bundle.next_actions = buildNextActions(bundle);
+  return bundle;
+}
+
+export async function writeHandoffBundle(root, config, sessionId, task = "") {
+  const paths = getSessionArtifactPaths(root, sessionId);
+  const bundle = await buildHandoffBundle(root, config, sessionId, task);
+  await ensureDir(paths.sessionDir);
+  await writeJson(paths.handoffJsonPath, bundle);
+  await writeText(paths.handoffMarkdownPath, renderHandoffMarkdown(bundle));
+  return {
+    bundle,
+    jsonPath: paths.handoffJsonPath,
+    markdownPath: paths.handoffMarkdownPath,
+    relativeJsonPath: relative(root, paths.handoffJsonPath),
+    relativeMarkdownPath: relative(root, paths.handoffMarkdownPath),
+  };
+}

--- a/src/core/session-memory.js
+++ b/src/core/session-memory.js
@@ -734,6 +734,8 @@ export function getSessionArtifactPaths(root, sessionId) {
     sessionDir,
     transcriptPath: path.join(sessionDir, "transcript.md"),
     memoryContextPath: path.join(sessionDir, "memory-context.md"),
+    handoffJsonPath: path.join(sessionDir, "handoff.json"),
+    handoffMarkdownPath: path.join(sessionDir, "handoff.md"),
     launchesPath: path.join(sessionDir, "launches.jsonl"),
     turnsPath: path.join(sessionDir, "turns.jsonl"),
     rawInteractiveLogPath: path.join(sessionDir, "interactive.log"),

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -131,6 +131,8 @@ function fitContext(manifest, index, checklist, options, config) {
   const memoryArtifacts = getSessionArtifactPaths(options.root || "", manifest.session_id);
   const transcriptRef = options.root ? `.agents/session/${manifest.session_id}/transcript.md` : memoryArtifacts.transcriptPath;
   const memoryContextRef = options.root ? `.agents/session/${manifest.session_id}/memory-context.md` : memoryArtifacts.memoryContextPath;
+  const handoffJsonRef = options.root ? `.agents/session/${manifest.session_id}/handoff.json` : memoryArtifacts.handoffJsonPath;
+  const handoffMarkdownRef = options.root ? `.agents/session/${manifest.session_id}/handoff.md` : memoryArtifacts.handoffMarkdownPath;
   const launchesRef = options.root ? `.agents/session/${manifest.session_id}/launches.jsonl` : memoryArtifacts.launchesPath;
   const rawInteractiveLogRef = options.root ? `.agents/session/${manifest.session_id}/interactive.log` : memoryArtifacts.rawInteractiveLogPath;
   const turnsRef = options.root ? `.agents/session/${manifest.session_id}/turns.jsonl` : memoryArtifacts.turnsPath;
@@ -146,6 +148,7 @@ function fitContext(manifest, index, checklist, options, config) {
   for (const attempt of attempts) {
     const previewChecklist = normalizeChecklist(checklist, attempt.checklistLimit, attempt.checklistTextBytes);
     const runHistory = clampRunHistory(options.runHistory || [], attempt.runHistoryLimit, attempt.runSummaryBytes);
+    const includeHandoffRefs = attempt !== attempts[attempts.length - 1];
     const candidate = {
       schema_version: "1.0",
       session_id: manifest.session_id,
@@ -168,6 +171,10 @@ function fitContext(manifest, index, checklist, options, config) {
         checklist: `.agents/session/${manifest.session_id}/checklist.json`,
         transcript: transcriptRef,
         memory_context: memoryContextRef,
+        ...(includeHandoffRefs ? {
+          handoff_json: handoffJsonRef,
+          handoff_markdown: handoffMarkdownRef,
+        } : {}),
         launches: launchesRef,
         raw_interactive_log: rawInteractiveLogRef,
         turns: turnsRef,
@@ -317,6 +324,8 @@ export async function forkSession(root, config, options = {}) {
       `.agents/session/${sessionId}/checklist.json`,
       `.agents/session/${sessionId}/launches.jsonl`,
       `.agents/session/${sessionId}/turns.jsonl`,
+      `.agents/session/${sessionId}/handoff.json`,
+      `.agents/session/${sessionId}/handoff.md`,
       `.agents/session/${sessionId}/bootstrap.md`,
       `.agents/session/${sessionId}/transcript.md`,
       `.agents/session/${sessionId}/memory-context.md`,
@@ -333,11 +342,13 @@ export async function forkSession(root, config, options = {}) {
         "checklist.json",
         "launches.jsonl",
         "turns.jsonl",
+        "handoff.json",
       ],
       optional_markdown_artifacts: [
         "bootstrap.md",
         "transcript.md",
         "memory-context.md",
+        "handoff.md",
         "interactive.log",
       ],
     },

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import { applyCavemanPreamble, resolveCavemanLevel } from "./core/caveman.js";
 import { loadConfig, persistProviderPreference, writeDefaultConfig } from "./core/config.js";
 import { ensureBaselineArtifacts, runDoc, runScan, runUpdate, runValidate } from "./core/commands.js";
 import { runExec } from "./core/exec.js";
+import { writeHandoffBundle } from "./core/handoff.js";
 import { installHooks, removeHooks, statusHooks } from "./core/hooks.js";
 import { queryOwner, queryDeps, queryChanged, querySearch } from "./core/query.js";
 import { buildExecutionPlan } from "./core/planner.js";
@@ -259,6 +260,7 @@ function printHelp() {
     `    ${c("query")}           ${d("Query the repository index (owner, deps, changed)")}`,
     `    ${c("skill")}           ${d("Manage built-in agent skills")}`,
     `    ${c("sess")}            ${d("Manage provider-backed sessions")}`,
+    `    ${c("handoff")}         ${d("Write a cross-agent handoff bundle for a session")}`,
     `    ${c("memory")}          ${d("Manage agent memory helpers")}`,
     `    ${c("issue-killer")}    ${d("Launch labelled GitHub issues into supervised tmux worktrees")}`,
     `    ${c("hooks")}           ${d("Install/remove git hooks")}`,
@@ -309,6 +311,7 @@ function printHelp() {
     `    ${d("$")} agentify memory compress AGENTIFY.md`,
     `    ${d("$")} agentify sess run --provider codex --name "payments-v2" "add tests"`,
     `    ${d("$")} agentify sess run --provider codex --interactive --name "payments-v2" "continue in Codex TUI"`,
+    `    ${d("$")} agentify handoff --session sess_20260101000000_abcdef "continue payments-v2"`,
     `    ${d("$")} agentify issue-killer --label agentify-ready --agent-provider codex --limit 5`,
     `    ${d("$")} agentify exec -- codex exec "fix auth bug"`,
     ``,
@@ -520,6 +523,39 @@ export async function runCli(argv) {
       case "issue-killer":
         await runIssueKiller(root, config, args);
         return;
+
+      case "handoff": {
+        let sessionId = args.session ? validateSessionId(String(args.session), "--session id") : null;
+        let promptStartIndex = 1;
+        if (!sessionId && args._[1]) {
+          sessionId = validateSessionId(String(args._[1]), "session id");
+          promptStartIndex = 2;
+        }
+        if (!sessionId) {
+          const sessions = await listSessions(root);
+          if (sessions.length === 0) {
+            throw new Error("handoff requires --session <id> when no sessions exist");
+          }
+          sessionId = validateSessionId(String(sessions[0].session_id), "session id");
+        }
+
+        const task = getPromptFromArgs(args, promptStartIndex);
+        const result = await writeHandoffBundle(root, config, sessionId, task);
+        if (config.json) {
+          console.log(JSON.stringify({
+            command: "handoff",
+            session_id: sessionId,
+            markdown_path: result.relativeMarkdownPath,
+            json_path: result.relativeJsonPath,
+            bundle: result.bundle,
+          }, null, 2));
+        } else {
+          success(`Handoff written for ${sessionId}`);
+          log(`Markdown: ${dim(result.relativeMarkdownPath)}`);
+          log(`JSON: ${dim(result.relativeJsonPath)}`);
+        }
+        return;
+      }
 
       case "query": {
         let result;

--- a/test/handoff.test.js
+++ b/test/handoff.test.js
@@ -1,0 +1,206 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { loadConfig } from "../src/core/config.js";
+import { closeIndexDatabase, inTransaction, openIndexDatabase } from "../src/core/db/connection.js";
+import { writeRepositoryIndex } from "../src/core/db/structural-store.js";
+import { writeHandoffBundle } from "../src/core/handoff.js";
+import { forkSession } from "../src/core/session.js";
+import { getSessionArtifactPaths } from "../src/core/session-memory.js";
+import { runCli } from "../src/main.js";
+
+const execFileAsync = promisify(execFile);
+
+async function initGitRepo(root) {
+  await execFileAsync("git", ["init"], { cwd: root });
+  await execFileAsync("git", ["config", "user.name", "Agentify Tests"], { cwd: root });
+  await execFileAsync("git", ["config", "user.email", "agentify-tests@example.com"], { cwd: root });
+  await execFileAsync("git", ["add", "."], { cwd: root });
+  await execFileAsync("git", ["commit", "-m", "initial"], { cwd: root });
+}
+
+async function setupHandoffRepo() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-handoff-"));
+  await fs.mkdir(path.join(root, "src", "core"), { recursive: true });
+  await fs.mkdir(path.join(root, "test"), { recursive: true });
+  await fs.writeFile(path.join(root, ".gitignore"), ".agents/\n", "utf8");
+  await fs.writeFile(path.join(root, "package.json"), JSON.stringify({
+    type: "module",
+    scripts: { test: "node --test" },
+  }, null, 2));
+  await fs.writeFile(path.join(root, "src", "core", "session.js"), [
+    "export function buildSessionPrompt(task) {",
+    "  return `Continue ${task}`;",
+    "}",
+    "",
+  ].join("\n"), "utf8");
+  await fs.writeFile(path.join(root, "test", "session.test.js"), [
+    "import test from 'node:test';",
+    "test('session prompt', () => {});",
+    "",
+  ].join("\n"), "utf8");
+  await initGitRepo(root);
+
+  const db = openIndexDatabase(root);
+  try {
+    inTransaction(db, () => {
+      writeRepositoryIndex(db, {
+        generated_at: "2026-01-01T00:00:00.000Z",
+        repo: {
+          name: "agentify-handoff-test",
+          root,
+          detected_stacks: [{ name: "js", confidence: 1 }],
+          default_stack: "js",
+          package_manager: "npm",
+        },
+        modules: [{
+          id: "core-session",
+          name: "core-session",
+          root_path: "src/core",
+          stack: "js",
+          package_name: null,
+          slug: "core-session",
+          doc_path: "docs/modules/core-session.md",
+          fingerprint: "fp-core-session",
+          entry_files: ["src/core/session.js"],
+          key_files: ["src/core/session.js"],
+        }],
+        files: [
+          {
+            path: "src/core/session.js",
+            module_id: "core-session",
+            language: "js",
+            size_bytes: 80,
+            fingerprint: "fp-session",
+            is_test: 0,
+            is_config: 0,
+            is_entrypoint: 1,
+            is_key_file: 1,
+          },
+          {
+            path: "test/session.test.js",
+            module_id: "core-session",
+            language: "js",
+            size_bytes: 60,
+            fingerprint: "fp-test",
+            is_test: 1,
+            is_config: 0,
+            is_entrypoint: 0,
+            is_key_file: 0,
+          },
+        ],
+        symbols: [{
+          module_id: "core-session",
+          file_path: "src/core/session.js",
+          name: "buildSessionPrompt",
+          kind: "function",
+          exported: 1,
+          start_line: 1,
+          end_line: 3,
+        }],
+        imports: [],
+        tests: [{
+          file_path: "test/session.test.js",
+          module_id: "core-session",
+          framework: "node:test",
+          related_path: "src/core/session.js",
+        }],
+        commands: [{
+          module_id: null,
+          command_type: "test",
+          command: "npm",
+          args: ["test"],
+        }],
+      }, {
+        headCommit: "indexed-head",
+        provider: "codex",
+      });
+    });
+  } finally {
+    closeIndexDatabase(db);
+  }
+
+  return root;
+}
+
+test("writeHandoffBundle creates deterministic JSON and markdown with conflict hints", async () => {
+  const root = await setupHandoffRepo();
+  const config = await loadConfig(root, { provider: "codex" });
+  const session = await forkSession(root, config, { name: "handoff buildSessionPrompt" });
+
+  await fs.appendFile(
+    path.join(root, "src", "core", "session.js"),
+    "// TODO: decide whether handoff should run after every provider launch\n",
+    "utf8",
+  );
+
+  const previousDir = path.join(root, ".agents", "session", "sess_previous");
+  await fs.mkdir(previousDir, { recursive: true });
+  await fs.writeFile(path.join(previousDir, "session-manifest.json"), JSON.stringify({
+    schema_version: "1.0",
+    session_id: "sess_previous",
+    created_at: "2026-01-01T00:00:00.000Z",
+    provider: "codex",
+    name: "previous session",
+    head_commit_at_creation: "previous-head",
+  }, null, 2));
+  await fs.writeFile(path.join(previousDir, "handoff.json"), JSON.stringify({
+    schema_version: "1.0",
+    touched_files: [{ path: "src/core/session.js", status: "M" }],
+  }, null, 2));
+
+  const first = await writeHandoffBundle(root, config, session.sessionId, "continue buildSessionPrompt handoff");
+  const second = await writeHandoffBundle(root, config, session.sessionId, "continue buildSessionPrompt handoff");
+
+  assert.deepEqual(second.bundle, first.bundle);
+  assert.equal(first.relativeJsonPath, `.agents/session/${session.sessionId}/handoff.json`);
+  assert.equal(first.relativeMarkdownPath, `.agents/session/${session.sessionId}/handoff.md`);
+  assert.ok(first.bundle.top_ranked_context.files.some((item) => item.path === "src/core/session.js"));
+  assert.ok(first.bundle.touched_files.some((item) => item.path === "src/core/session.js"));
+  assert.ok(first.bundle.touched_symbol_neighborhood.some((item) =>
+    item.file_path === "src/core/session.js"
+    && item.symbols.some((symbol) => symbol.name === "buildSessionPrompt")
+  ));
+  assert.ok(first.bundle.recommended_tests.files.some((item) => item.file_path === "test/session.test.js"));
+  assert.ok(first.bundle.recommended_tests.commands.some((item) => item.command === "npm" && item.args.includes("test")));
+  assert.ok(first.bundle.unresolved_risks.some((item) => item.tag === "TODO"));
+  assert.ok(first.bundle.conflict_hints.some((item) =>
+    item.session_id === "sess_previous"
+    && item.overlap_files.includes("src/core/session.js")
+  ));
+
+  const paths = getSessionArtifactPaths(root, session.sessionId);
+  await assert.doesNotReject(() => fs.access(paths.handoffJsonPath));
+  const markdown = await fs.readFile(paths.handoffMarkdownPath, "utf8");
+  assert.match(markdown, /# Agentify Handoff/);
+  assert.match(markdown, /Conflict Hints/);
+});
+
+test("runCli handoff writes the latest session bundle as JSON", async () => {
+  const root = await setupHandoffRepo();
+  const config = await loadConfig(root, { provider: "codex" });
+  const session = await forkSession(root, config, { name: "latest handoff" });
+  const output = [];
+  const originalLog = console.log;
+  console.log = (...args) => {
+    output.push(args.join(" "));
+  };
+
+  try {
+    await runCli(["handoff", "--root", root, "--json"]);
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(output.length, 1);
+  const payload = JSON.parse(output[0]);
+  assert.equal(payload.command, "handoff");
+  assert.equal(payload.session_id, session.sessionId);
+  assert.equal(payload.json_path, `.agents/session/${session.sessionId}/handoff.json`);
+  assert.equal(payload.markdown_path, `.agents/session/${session.sessionId}/handoff.md`);
+});


### PR DESCRIPTION
## Summary
- Add `agentify handoff` to write deterministic session handoff Markdown and JSON artifacts.
- Include ranked planner context, touched files and symbols, recommended tests, TODO/risk lines, and overlap hints from recent handoffs.
- Document the new workflow and cover deterministic output plus CLI behavior in tests.

Closes #11

## Tests
- `AGENTIFY_MEMPALACE_CMD= pnpm test`