### PR TITLE
feat: add multi-language semantic adapters

### DIFF
--- a/docs/DETAILED_README.md
+++ b/docs/DETAILED_README.md
@@ -338,15 +338,16 @@ In the second command, Agentify reuses `codex` for the same repo.
 - `run` and `sess *` require an external provider CLI: `codex`, `claude`, `gemini`, or `opencode`.
 - `agentify this` supports provider-backed bootstrap on macOS and requires Homebrew for package installation.
 
-## Semantic TypeScript/JavaScript Indexing
+## Semantic Indexing
 
-Semantic indexing is optional, but it is one of the highest-value features for TypeScript and JavaScript repositories.
+Semantic indexing is optional, but it is one of the highest-value features for richer planner and query context. Agentify indexes TypeScript/JavaScript with the TS compiler-backed worker, and also stores normalized semantic facts for Python, Go, Java, and .NET repositories.
 
 Enable it in `.agentify.yaml`:
 
 ```yaml
 provider: codex
 semantic:
+  enabled: true
   tsjs:
     enabled: true
     workerConcurrency: 2
@@ -365,16 +366,16 @@ agentify check
 
 Why use it:
 
-- richer planner context for TS/JS repos
+- richer planner context for TS/JS, Python, Go, Java, and .NET repos
 - semantic surfaces in `query search`
 - better repo-map output
 - deterministic semantic headers during doc generation
 
-Use it when the repository is TypeScript- or JavaScript-heavy and raw dependency scanning is not enough.
+Use it when raw dependency scanning is not enough and planner/query results should include symbols, public surfaces, and import edges.
 
 How to verify it is active:
 
-- `agentify doctor` shows a `Semantic TS/JS` section when semantic indexing is enabled and the repo has been indexed.
+- `agentify doctor` shows a `Semantic` section when semantic indexing is enabled and the repo has been indexed.
 - `agentify query search --term <term>` starts returning semantic surfaces in addition to structural matches.
 - `docs/repo-map.md` and module docs become richer after refreshes.
 

--- a/docs/QNA.md
+++ b/docs/QNA.md
@@ -260,9 +260,9 @@ Agentify's `--caveman` prompt modifier tells agents to suspend caveman for those
 
 The biggest practical gaps today are mostly around **depth, visibility, and feedback loops**:
 
-1. **Semantic coverage is TS/JS-first**
-   - Deep semantic graphing is strongest for TypeScript/JavaScript projects.
-   - Python/Go/Java/C# repositories get structural indexing, but not equivalent semantic richness yet.
+1. **Semantic coverage is still deepest for TS/JS**
+   - TypeScript/JavaScript uses a compiler-backed semantic worker.
+   - Python, Go, Java, and .NET now have normalized semantic adapters for projects, symbols, public surfaces, and import edges, but do not yet have full LSP-depth call graph parity.
 
 2. **Semantic internals are not obvious to new users**
    - Users can run `scan/plan/query`, but often do not understand which tables/facts are driving ranking decisions.
@@ -288,8 +288,8 @@ The biggest practical gaps today are mostly around **depth, visibility, and feed
 
 High-impact features to add next:
 
-1. **Multi-language semantic adapters**
-   - Add analyzers for Python, Go, Java, and .NET with normalized symbol/edge tables.
+1. **Deeper multi-language semantic adapters**
+   - Expand Python, Go, Java, and .NET adapters beyond normalized symbol/import facts toward richer call/type graph extraction.
    - Goal: same query/planner quality profile regardless of language stack.
 
 2. **Explainable planning mode**

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -358,19 +358,20 @@ agentify up --provider local
 
 `up` is not a sticky-provider command, so this does not switch the repo away from Codex.
 
-### 5. Enable semantic TS/JS indexing for TypeScript and JavaScript repos
+### 5. Enable semantic indexing
 
-For TS/JS-heavy repos, turn this on in `.agentify.yaml`:
+For TS/JS, Python, Go, Java, and .NET repos that need richer planner and query context, turn this on in `.agentify.yaml`:
 
 ```yaml
 provider: codex
 semantic:
+  enabled: true
   tsjs:
     enabled: true
     workerConcurrency: 2
 ```
 
-This improves semantic surfaces, deterministic headers, and repo-map quality for TS/JS projects.
+This improves semantic surfaces, deterministic headers, and repo-map quality. The TS/JS adapter uses the compiler-backed worker; Python, Go, Java, and .NET adapters store normalized project, symbol, surface, and edge facts.
 
 After enabling it:
 

--- a/src/core/commands.js
+++ b/src/core/commands.js
@@ -25,7 +25,7 @@ import {
 } from "./db/structural-store.js";
 import { loadSemanticModuleContext } from "./db/semantic-store.js";
 import { buildRepositoryIndex } from "./indexer.js";
-import { applySemanticHeaders, runSemanticRefresh, writeSemanticRepoMap } from "./semantic.js";
+import { applySemanticHeaders, isSemanticEnabled, runSemanticRefresh, writeSemanticRepoMap } from "./semantic.js";
 import * as ui from "./ui.js";
 
 export { detectTestCommand } from "./project-tests.js";
@@ -650,10 +650,10 @@ async function _runDocInner(root, config, options, progress) {
     }
   }
 
-  const semanticEnabled = Boolean(config.semantic?.tsjs?.enabled);
+  const semanticEnabled = isSemanticEnabled(config);
   if (semanticEnabled && !config.dryRun) {
-    progress.log("doc: refreshing semantic TS/JS facts");
-    progress.percent("doc", 5, "refreshing semantic TS/JS facts");
+    progress.log("doc: refreshing semantic facts");
+    progress.percent("doc", 5, "refreshing semantic facts");
     await runSemanticRefresh(root, config, {
       artifactRoot,
       silent: true,

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -69,12 +69,25 @@ const DEFAULT_CONFIG = {
     editAfterSelectedContextUnlessBlocked: true,
   },
   semantic: {
+    enabled: false,
     tsjs: {
       enabled: false,
       workerConcurrency: 1,
       timeoutMs: 45000,
       memoryMb: 1536,
       analyzerVersion: "semantic-tsjs-v1",
+    },
+    python: {
+      analyzerVersion: "semantic-python-v1",
+    },
+    go: {
+      analyzerVersion: "semantic-go-v1",
+    },
+    java: {
+      analyzerVersion: "semantic-java-v1",
+    },
+    dotnet: {
+      analyzerVersion: "semantic-dotnet-v1",
     },
   },
   tests: {

--- a/src/core/planner.js
+++ b/src/core/planner.js
@@ -14,6 +14,7 @@ import {
 import { loadSemanticModuleDependencies, loadSemanticPlannerFacts } from "./db/semantic-store.js";
 import { getChangedFiles } from "./git.js";
 import { stripLeadingAgentifyHeader } from "./headers.js";
+import { isSemanticEnabled } from "./semantic.js";
 
 function bytes(value) {
   return Buffer.byteLength(String(value || ""), "utf8");
@@ -342,7 +343,8 @@ export async function buildExecutionPlan(root, config, task, options = {}) {
       alias: null,
       source: "structural",
     }));
-    const semanticSymbols = config.semantic?.tsjs?.enabled
+    const semanticEnabled = isSemanticEnabled(config);
+    const semanticSymbols = semanticEnabled
       ? loadSemanticPlannerFacts(db).map((symbolInfo) => ({
           symbol_id: symbolInfo.semantic_id,
           module_id: symbolInfo.module_id || null,
@@ -386,7 +388,7 @@ export async function buildExecutionPlan(root, config, task, options = {}) {
           .filter((symbolInfo) => symbolInfo.module_id === moduleInfo.id)
           .reduce((sum, symbolInfo) => sum + Math.min(symbolInfo.score, 50), 0);
         const structuralDep = loadModuleDependencies(db, moduleInfo.id);
-        const semanticDep = config.semantic?.tsjs?.enabled
+        const semanticDep = semanticEnabled
           ? loadSemanticModuleDependencies(db, moduleInfo.id)
           : { dependsOn: [], usedBy: [] };
         const dep = {

--- a/src/core/semantic.js
+++ b/src/core/semantic.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import ts from "typescript";
 
+import { buildRepositoryIndex } from "./indexer.js";
 import { closeIndexDatabase, inTransaction, openIndexDatabase } from "./db/connection.js";
 import { getRepoMeta } from "./db/metadata-store.js";
 import { loadFiles, loadModules } from "./db/structural-store.js";
@@ -27,8 +28,16 @@ function sha1(value) {
   return crypto.createHash("sha1").update(value).digest("hex");
 }
 
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
 function normalizeRepoPath(filePath) {
   return String(filePath || "").split(path.sep).join("/");
+}
+
+function pathHash(...parts) {
+  return sha1(parts.join(":"));
 }
 
 function isTsJsFile(filePath) {
@@ -59,6 +68,10 @@ function shouldTreatAsOwned(filePath) {
 function isSupportPath(filePath) {
   return /(^|\/)(__tests__|__mocks__|fixtures?|examples?|stories)\//i.test(filePath)
     || /\.(test|spec|stories)\.[^.]+$/i.test(filePath);
+}
+
+function domainForFile(filePath) {
+  return isSupportPath(filePath) ? "support" : "runtime";
 }
 
 function isTestOwnedPath(filePath) {
@@ -195,7 +208,292 @@ async function computeFingerprint(root, filePaths) {
   return crypto.createHash("sha256").update(entries.sort().join("\n")).digest("hex");
 }
 
-export async function discoverSemanticProjects(root) {
+function normalizeSourceFiles(files, language) {
+  return files
+    .filter((fileInfo) => fileInfo.language === language)
+    .map((fileInfo) => normalizeRepoPath(fileInfo.path))
+    .filter(shouldTreatAsOwned)
+    .sort();
+}
+
+function findFirstConfig(repoFiles, candidates) {
+  return candidates.find((candidate) => repoFiles.includes(candidate)) || null;
+}
+
+function semanticAdapterConfig(config, adapterId) {
+  return config.semantic?.[adapterId] || {};
+}
+
+export function isSemanticEnabled(config) {
+  return Boolean(
+    config.semantic?.enabled
+      || config.semantic?.tsjs?.enabled
+      || GENERIC_SEMANTIC_ADAPTERS.some((adapter) => semanticAdapterConfig(config, adapter.id).enabled)
+  );
+}
+
+function isSemanticAdapterEnabled(config, adapterId) {
+  if (adapterId === "tsjs") {
+    return Boolean(config.semantic?.enabled || config.semantic?.tsjs?.enabled);
+  }
+  const adapterConfig = semanticAdapterConfig(config, adapterId);
+  return Boolean(
+    adapterConfig.enabled
+      || (config.semantic?.enabled && adapterConfig.enabled !== false)
+  );
+}
+
+function genericAnalyzerVersion(config, adapterId) {
+  return semanticAdapterConfig(config, adapterId).analyzerVersion || `semantic-${adapterId}-v1`;
+}
+
+function groupGenericProjects(root, repoIndex, adapter, config) {
+  const repoFiles = repoIndex.files.map((fileInfo) => normalizeRepoPath(fileInfo.path)).sort();
+  const filePaths = normalizeSourceFiles(repoIndex.files, adapter.language)
+    .filter((filePath) => adapter.includeTests || !adapter.isTestFile?.(filePath));
+  if (filePaths.length === 0) {
+    return [];
+  }
+
+  const configPath = adapter.configPath(root, repoFiles, ".");
+  const groups = [{
+    id: `${adapter.id}:root`,
+    configPath,
+    projectRoot: ".",
+    inferred: configPath ? false : true,
+    filePaths,
+  }];
+
+  const analyzerVersion = genericAnalyzerVersion(config, adapter.id);
+  return groups.map((project) => ({
+    ...project,
+    adapterId: adapter.id,
+    analyzerVersion,
+    schemaVersion: `semantic-${adapter.id}-1`,
+  }));
+}
+
+function symbolIdentity(projectId, filePath, name, kind, startLine, endLine) {
+  return `sym_${pathHash(projectId, filePath, name, kind, String(startLine), String(endLine))}`;
+}
+
+function semanticSymbolFromStructural(project, symbolInfo) {
+  const filePath = normalizeRepoPath(symbolInfo.file_path);
+  const startLine = symbolInfo.start_line || 1;
+  const endLine = symbolInfo.end_line || startLine;
+  const exported = symbolInfo.exported ? 1 : 0;
+  return {
+    symbol_id: symbolIdentity(project.id, filePath, symbolInfo.name, symbolInfo.kind, startLine, endLine),
+    project_id: project.id,
+    file_path: filePath,
+    name: symbolInfo.name,
+    display_name: symbolInfo.name,
+    kind: symbolInfo.kind || "symbol",
+    export_name: exported ? symbolInfo.name : null,
+    start_line: startLine,
+    end_line: endLine,
+    is_exported: exported,
+    is_default: 0,
+    domain: domainForFile(filePath),
+  };
+}
+
+function createGenericSurface(project, symbolInfo) {
+  return {
+    surface_id: `surface_${pathHash(project.id, symbolInfo.file_path, symbolInfo.symbol_id, "public-api")}`,
+    project_id: project.id,
+    file_path: symbolInfo.file_path,
+    symbol_id: symbolInfo.symbol_id,
+    kind: "public-api",
+    role: symbolInfo.kind || "symbol",
+    surface_key: symbolInfo.export_name || symbolInfo.name,
+    display_name: symbolInfo.display_name || symbolInfo.name,
+    domain: symbolInfo.domain,
+    is_header_target: symbolInfo.domain === "support" ? 0 : 1,
+  };
+}
+
+function externalPackageForImport(adapterId, specifier) {
+  const cleaned = String(specifier || "").trim().replace(/^["']|["']$/g, "");
+  if (!cleaned) {
+    return null;
+  }
+  if (adapterId === "python") {
+    const withoutRelativePrefix = cleaned.replace(/^\.+/, "");
+    return withoutRelativePrefix.split(".").filter(Boolean)[0] || null;
+  }
+  if (adapterId === "go") {
+    return cleaned;
+  }
+  if (adapterId === "java" || adapterId === "dotnet") {
+    const parts = cleaned.split(".").filter(Boolean);
+    return parts.length > 1 ? parts.slice(0, -1).join(".") : cleaned;
+  }
+  return cleaned.split(/[/.]/).filter(Boolean)[0] || null;
+}
+
+function createSemanticEdge(project, adapterId, importInfo, symbolByFile) {
+  const fromFilePath = normalizeRepoPath(importInfo.from_path);
+  const toFilePath = importInfo.to_path ? normalizeRepoPath(importInfo.to_path) : null;
+  const fromSymbolId = symbolByFile.get(fromFilePath)?.symbol_id || null;
+  const toSymbolId = toFilePath ? symbolByFile.get(toFilePath)?.symbol_id || null : null;
+  const externalPackage = toFilePath ? null : externalPackageForImport(adapterId, importInfo.specifier);
+  if (!toFilePath && !externalPackage) {
+    return null;
+  }
+  return {
+    project_id: project.id,
+    from_symbol_id: fromSymbolId,
+    to_symbol_id: toSymbolId,
+    from_file_path: fromFilePath,
+    to_file_path: toFilePath,
+    to_external_package: externalPackage,
+    edge_kind: importInfo.kind || "imports",
+    edge_domain: "runtime",
+    confidence: toFilePath ? 0.85 : 0.65,
+    source: `${adapterId}-semantic-adapter`,
+    metadata_json: JSON.stringify({ specifier: importInfo.specifier }),
+  };
+}
+
+function buildGenericSnapshot(repoIndex, project, adapter) {
+  const projectFiles = new Set(project.filePaths.map(normalizeRepoPath));
+  const structuralSymbols = repoIndex.symbols
+    .filter((symbolInfo) => projectFiles.has(normalizeRepoPath(symbolInfo.file_path)));
+  const symbols = structuralSymbols.map((symbolInfo) => semanticSymbolFromStructural(project, symbolInfo));
+  const symbolByFile = new Map();
+  for (const symbolInfo of symbols) {
+    if (!symbolByFile.has(symbolInfo.file_path) || symbolInfo.is_exported) {
+      symbolByFile.set(symbolInfo.file_path, symbolInfo);
+    }
+  }
+
+  const surfaces = symbols
+    .filter((symbolInfo) => symbolInfo.is_exported && symbolInfo.domain !== "support")
+    .map((symbolInfo) => createGenericSurface(project, symbolInfo));
+
+  const externalPackages = new Map();
+  const edgeDedup = new Set();
+  const symbolEdges = [];
+  for (const importInfo of repoIndex.imports) {
+    const fromFilePath = normalizeRepoPath(importInfo.from_path);
+    if (!projectFiles.has(fromFilePath)) {
+      continue;
+    }
+    const edge = createSemanticEdge(project, adapter.id, importInfo, symbolByFile);
+    if (!edge) {
+      continue;
+    }
+    const dedupeKey = JSON.stringify([
+      edge.from_file_path,
+      edge.to_file_path,
+      edge.to_external_package,
+      edge.edge_kind,
+      edge.metadata_json,
+    ]);
+    if (edgeDedup.has(dedupeKey)) {
+      continue;
+    }
+    edgeDedup.add(dedupeKey);
+    symbolEdges.push(edge);
+    if (edge.to_external_package) {
+      externalPackages.set(edge.to_external_package, (externalPackages.get(edge.to_external_package) || 0) + 1);
+    }
+  }
+
+  const contentEntries = project.filePaths.map((filePath) => {
+    const fileInfo = repoIndex.files.find((item) => normalizeRepoPath(item.path) === filePath);
+    return `${filePath}:${fileInfo?.fingerprint || ""}`;
+  });
+  const publicEntries = [
+    ...symbols.filter((symbol) => symbol.is_exported).map((symbol) => `export:${symbol.file_path}:${symbol.export_name}:${symbol.kind}`),
+    ...surfaces.map((surface) => `surface:${surface.kind}:${surface.surface_key}:${surface.role}:${surface.file_path}`),
+  ];
+
+  return {
+    project: {
+      project_id: project.id,
+      config_path: project.configPath || null,
+      project_root: project.projectRoot || ".",
+      inferred: project.inferred ? 1 : 0,
+      analyzer_version: project.analyzerVersion,
+      schema_version: project.schemaVersion,
+      status: "ready",
+      coverage_ratio: 1,
+      file_count: project.filePaths.length,
+      symbol_count: symbols.length,
+      surface_count: surfaces.length,
+      edge_count: symbolEdges.length,
+      content_fingerprint: sha256(contentEntries.sort().join("\n")),
+      public_fingerprint: sha256(publicEntries.sort().join("\n")),
+      refreshed_at: new Date().toISOString(),
+      last_error: null,
+    },
+    files: project.filePaths.map((filePath) => ({
+      project_id: project.id,
+      file_path: filePath,
+      domain: domainForFile(filePath),
+      is_header_target: surfaces.some((surface) => surface.file_path === filePath) ? 1 : 0,
+    })),
+    externalPackages: Array.from(externalPackages.entries()).sort(([left], [right]) => left.localeCompare(right)).map(([packageName, usageCount]) => ({
+      project_id: project.id,
+      package_name: packageName,
+      usage_count: usageCount,
+    })),
+    symbols,
+    surfaces,
+    symbolEdges,
+  };
+}
+
+const GENERIC_SEMANTIC_ADAPTERS = [
+  {
+    id: "python",
+    stack: "python",
+    language: "python",
+    configPath(_root, repoFiles) {
+      return findFirstConfig(repoFiles, ["pyproject.toml", "setup.py", "requirements.txt"]);
+    },
+  },
+  {
+    id: "go",
+    stack: "go",
+    language: "go",
+    isTestFile: (filePath) => filePath.endsWith("_test.go"),
+    configPath(_root, repoFiles) {
+      return findFirstConfig(repoFiles, ["go.mod"]);
+    },
+  },
+  {
+    id: "java",
+    stack: "java",
+    language: "java",
+    configPath(_root, repoFiles, moduleRoot = ".") {
+      const rootPath = normalizeRepoPath(moduleRoot || ".");
+      const candidates = rootPath === "."
+        ? ["pom.xml", "build.gradle", "build.gradle.kts", "settings.gradle", "settings.gradle.kts"]
+        : [`${rootPath}/pom.xml`, `${rootPath}/build.gradle`, `${rootPath}/build.gradle.kts`];
+      return findFirstConfig(repoFiles, candidates);
+    },
+  },
+  {
+    id: "dotnet",
+    stack: "dotnet",
+    language: "dotnet",
+    configPath(_root, repoFiles, moduleRoot = ".") {
+      const rootPath = normalizeRepoPath(moduleRoot || ".");
+      const candidates = repoFiles.filter((filePath) => {
+        if (!filePath.endsWith(".sln") && !filePath.endsWith(".csproj")) {
+          return false;
+        }
+        return rootPath === "." || filePath.startsWith(`${rootPath}/`);
+      });
+      return candidates.sort()[0] || null;
+    },
+  },
+];
+
+export async function discoverSemanticProjects(root, config = {}) {
   const relFiles = (await walkFiles(root, { respectIgnore: true })).map((file) => relative(root, file)).sort();
   const tsJsFiles = relFiles.filter(isTsJsFile);
   const configFiles = relFiles.filter(isConfigCandidate).map(normalizeRepoPath).sort();
@@ -276,17 +574,38 @@ export async function discoverSemanticProjects(root) {
     projects.push(defaultCompilerConfig(root, uncovered));
   }
 
-  return projects;
+  const tsAnalyzerVersion = config.semantic?.tsjs?.analyzerVersion || "semantic-tsjs-v1";
+  return projects.map((project) => ({
+    ...project,
+    adapterId: "tsjs",
+    analyzerVersion: tsAnalyzerVersion,
+    schemaVersion: "semantic-tsjs-1",
+  }));
 }
 
-function shouldRefreshProject(project, existing, analyzerVersion, contentFingerprint) {
+async function discoverAllSemanticProjects(root, config) {
+  const tsProjects = isSemanticAdapterEnabled(config, "tsjs")
+    ? await discoverSemanticProjects(root, config)
+    : [];
+  const enabledGenericAdapters = GENERIC_SEMANTIC_ADAPTERS
+    .filter((adapter) => isSemanticAdapterEnabled(config, adapter.id));
+  const repoIndex = enabledGenericAdapters.length > 0
+    ? await buildRepositoryIndex(root, config)
+    : null;
+  const genericProjects = repoIndex
+    ? enabledGenericAdapters.flatMap((adapter) => groupGenericProjects(root, repoIndex, adapter, config))
+    : [];
+  return { projects: [...tsProjects, ...genericProjects], repoIndex };
+}
+
+function shouldRefreshProject(project, existing, contentFingerprint) {
   if (!existing) {
     return true;
   }
   if (existing.status !== "ready") {
     return true;
   }
-  if (existing.analyzer_version !== analyzerVersion) {
+  if (existing.analyzer_version !== project.analyzerVersion) {
     return true;
   }
   if (existing.content_fingerprint !== contentFingerprint) {
@@ -295,7 +614,7 @@ function shouldRefreshProject(project, existing, analyzerVersion, contentFingerp
   return false;
 }
 
-async function analyzeProject(root, project, config) {
+async function analyzeTsJsProject(root, project, config) {
   const workerPath = path.join(path.dirname(fileURLToPath(import.meta.url)), "semantic-worker.js");
   const args = [
     `--max-old-space-size=${config.semantic?.tsjs?.memoryMb || 1536}`,
@@ -316,6 +635,17 @@ async function analyzeProject(root, project, config) {
   return JSON.parse(stdout);
 }
 
+async function analyzeProject(root, project, config, repoIndex) {
+  if (project.adapterId === "tsjs") {
+    return analyzeTsJsProject(root, project, config);
+  }
+  const adapter = GENERIC_SEMANTIC_ADAPTERS.find((item) => item.id === project.adapterId);
+  if (!adapter) {
+    throw new Error(`No semantic adapter registered for ${project.adapterId}`);
+  }
+  return buildGenericSnapshot(repoIndex, project, adapter);
+}
+
 function buildStatusSummary(projects, refreshedIds) {
   return projects.map((project) => ({
     project_id: project.project_id,
@@ -334,13 +664,13 @@ function buildStatusSummary(projects, refreshedIds) {
 }
 
 export async function runSemanticRefresh(root, config, options = {}) {
-  if (!config.semantic?.tsjs?.enabled) {
+  if (!isSemanticEnabled(config)) {
     const result = {
       command: "semantic",
       enabled: false,
       refreshed_projects: [],
       skipped_projects: [],
-      reason: "semantic.tsjs.enabled is false",
+      reason: "semantic.enabled is false",
     };
     if (!options.skipOutput && (config.json || !options.silent)) {
       console.log(JSON.stringify(result, null, 2));
@@ -353,8 +683,7 @@ export async function runSemanticRefresh(root, config, options = {}) {
     await ensureDir(path.join(artifactRoot, ".agents"));
   }
   const db = openIndexDatabase(artifactRoot);
-  const discoveredProjects = await discoverSemanticProjects(root);
-  const analyzerVersion = config.semantic?.tsjs?.analyzerVersion || "semantic-tsjs-v1";
+  const { projects: discoveredProjects, repoIndex } = await discoverAllSemanticProjects(root, config);
   const existingProjects = new Map(listSemanticProjects(db).map((item) => [item.project_id, item]));
   const refreshedIds = new Set();
   const refreshed = [];
@@ -373,16 +702,17 @@ export async function runSemanticRefresh(root, config, options = {}) {
     for (const project of discoveredProjects) {
       const contentFingerprint = await computeFingerprint(root, project.filePaths);
       const existing = existingProjects.get(project.id);
-      if (!shouldRefreshProject(project, existing, analyzerVersion, contentFingerprint)) {
+      if (!shouldRefreshProject(project, existing, contentFingerprint)) {
         skipped.push(project.id);
         continue;
       }
 
-      const snapshot = await analyzeProject(root, project, config);
+      const snapshot = await analyzeProject(root, project, config, repoIndex);
       inTransaction(db, () => {
         replaceSemanticProjectSnapshot(db, snapshot);
-        upsertSemanticMeta(db, "semantic_tsjs_enabled", true);
-        upsertSemanticMeta(db, "semantic_tsjs_analyzer_version", analyzerVersion);
+        upsertSemanticMeta(db, "semantic_enabled", true);
+        upsertSemanticMeta(db, `semantic_${project.adapterId}_enabled`, true);
+        upsertSemanticMeta(db, `semantic_${project.adapterId}_analyzer_version`, project.analyzerVersion);
       });
       refreshedIds.add(project.id);
       refreshed.push(project.id);
@@ -421,7 +751,7 @@ export function renderSemanticRepoMap(root, meta, modules, semanticProjects, rou
   const structuralEntrypoints = modules.flatMap((moduleInfo) => moduleInfo.entry_files || []);
   const projectLines = semanticProjects.length > 0
     ? semanticProjects.map((project) => `- \`${project.config_path || "inferred"}\` (${project.status}, ${project.file_count} files, ${project.symbol_count} symbols, ${project.edge_count} edges)`)
-    : ["- No semantic TS/JS projects indexed."];
+    : ["- No semantic projects indexed."];
   const routeLines = routeSurfaces.length > 0
     ? routeSurfaces.map((surface) => `- \`${surface.surface_key}\` (${surface.role}) -> \`${surface.file_path}\``)
     : ["- No route surfaces detected."];
@@ -473,14 +803,14 @@ function buildDeterministicSummary(facts) {
     parts.push(`runtime deps: ${runtimeDeps.join(", ")}`);
   }
   if (parts.length === 0) {
-    parts.push("Semantic facts indexed from the TypeScript/JavaScript project graph");
+    parts.push("Semantic facts indexed from the project graph");
   }
   const summary = parts.join("; ");
   return summary.charAt(0).toUpperCase() + summary.slice(1);
 }
 
 export async function applySemanticHeaders(root, artifactRoot, config, { ghost = false } = {}) {
-  if (!config.semantic?.tsjs?.enabled || config.dryRun) {
+  if (!isSemanticEnabled(config) || config.dryRun) {
     return { plannedHeaders: [], changed: 0 };
   }
 

--- a/src/core/toolchain.js
+++ b/src/core/toolchain.js
@@ -4,6 +4,7 @@ import { promisify } from "node:util";
 import { closeIndexDatabase, openIndexDatabase } from "./db/connection.js";
 import { listSemanticProjects } from "./db/semantic-store.js";
 import { exists } from "./fs.js";
+import { isSemanticEnabled } from "./semantic.js";
 import * as ui from "./ui.js";
 
 const execFileAsync = promisify(execFile);
@@ -147,14 +148,14 @@ export async function runDoctor(root, config) {
   ui.log(ui.label("Node.js", process.version));
   ui.log(ui.label("Platform", `${process.platform} ${process.arch}`));
 
-  if (config.semantic?.tsjs?.enabled && root) {
+  if (isSemanticEnabled(config) && root) {
     const dbPath = `${root}/.agents/index.db`;
     if (await exists(dbPath)) {
       const db = openIndexDatabase(root, { readOnly: true });
       try {
         const semanticProjects = listSemanticProjects(db);
         ui.newline();
-        ui.log(ui.bold("Semantic TS/JS"));
+        ui.log(ui.bold("Semantic"));
         if (semanticProjects.length === 0) {
           ui.log(ui.dim("No semantic projects indexed yet. Run `agentify semantic refresh`."));
         } else {

--- a/src/core/validate.js
+++ b/src/core/validate.js
@@ -8,6 +8,7 @@ import { closeIndexDatabase, openIndexDatabase } from "./db/connection.js";
 import { getRepoMeta } from "./db/metadata-store.js";
 import { loadModules } from "./db/structural-store.js";
 import { listSemanticProjects } from "./db/semantic-store.js";
+import { isSemanticEnabled } from "./semantic.js";
 
 const ALLOWED_DOC_PATHS = [
   /^AGENTIFY\.md$/,
@@ -123,7 +124,7 @@ async function validateFreshness(root, failures, options = {}) {
       }
     }
 
-    if (options.config?.semantic?.tsjs?.enabled) {
+    if (isSemanticEnabled(options.config || {})) {
       const semanticProjects = listSemanticProjects(db);
       for (const projectInfo of semanticProjects) {
         if (projectInfo.status !== "ready") {

--- a/src/main.js
+++ b/src/main.js
@@ -263,7 +263,7 @@ function printHelp() {
     `    ${c("issue-killer")}    ${d("Launch labelled GitHub issues into supervised tmux worktrees")}`,
     `    ${c("hooks")}           ${d("Install/remove git hooks")}`,
     `    ${c("doctor")}          ${d("Check toolchain health and capability tier")}`,
-    `    ${c("semantic")}        ${d("Refresh semantic TS/JS project facts")}`,
+    `    ${c("semantic")}        ${d("Refresh semantic project facts")}`,
     `    ${c("clean")}           ${d("Prune stale generated artifacts and dead Agentify folders")}`,
     `    ${c("cache")}           ${d("Manage the content cache")}`,
     ``,

--- a/test/semantic.test.js
+++ b/test/semantic.test.js
@@ -135,6 +135,64 @@ async function writeLayeredSemanticFixture(root) {
   );
 }
 
+async function writeMultiLanguageSemanticFixture(root) {
+  await fs.writeFile(path.join(root, "pyproject.toml"), "[project]\nname = \"semantic-python\"\n", "utf8");
+  await fs.mkdir(path.join(root, "src", "auth"), { recursive: true });
+  await fs.writeFile(path.join(root, "src", "auth", "__init__.py"), "", "utf8");
+  await fs.writeFile(
+    path.join(root, "src", "auth", "service.py"),
+    "def normalize_token(raw_token: str) -> str:\n    return raw_token.strip()\n",
+    "utf8"
+  );
+  await fs.writeFile(
+    path.join(root, "src", "api.py"),
+    "from auth.service import normalize_token\n\n\ndef handle_login(raw_token: str) -> str:\n    return normalize_token(raw_token)\n",
+    "utf8"
+  );
+
+  await fs.writeFile(path.join(root, "go.mod"), "module example.com/semantic\n\ngo 1.22\n", "utf8");
+  await fs.mkdir(path.join(root, "cmd", "server"), { recursive: true });
+  await fs.mkdir(path.join(root, "internal", "auth"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "cmd", "server", "main.go"),
+    "package main\n\nimport \"example.com/semantic/internal/auth\"\n\nfunc HandleLogin(raw string) string {\n\treturn auth.NormalizeToken(raw)\n}\n",
+    "utf8"
+  );
+  await fs.writeFile(
+    path.join(root, "internal", "auth", "token.go"),
+    "package auth\n\nfunc NormalizeToken(raw string) string { return raw }\n",
+    "utf8"
+  );
+
+  await fs.writeFile(path.join(root, "pom.xml"), "<project />\n", "utf8");
+  await fs.mkdir(path.join(root, "java", "com", "example", "api"), { recursive: true });
+  await fs.mkdir(path.join(root, "java", "com", "example", "auth"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "java", "com", "example", "auth", "AuthService.java"),
+    "package com.example.auth;\n\npublic class AuthService {\n  public String normalizeToken(String raw) { return raw.trim(); }\n}\n",
+    "utf8"
+  );
+  await fs.writeFile(
+    path.join(root, "java", "com", "example", "api", "LoginController.java"),
+    "package com.example.api;\n\nimport com.example.auth.AuthService;\n\npublic class LoginController {\n  public String handleLogin(String raw) { return new AuthService().normalizeToken(raw); }\n}\n",
+    "utf8"
+  );
+
+  await fs.writeFile(path.join(root, "SemanticFixture.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\" />\n", "utf8");
+  await fs.mkdir(path.join(root, "dotnet", "Auth"), { recursive: true });
+  await fs.mkdir(path.join(root, "dotnet", "Api"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "dotnet", "Auth", "AuthService.cs"),
+    "namespace Demo.Auth;\n\npublic class AuthService\n{\n    public string NormalizeToken(string raw) { return raw.Trim(); }\n}\n",
+    "utf8"
+  );
+  await fs.writeFile(
+    path.join(root, "dotnet", "Api", "LoginController.cs"),
+    "using Demo.Auth;\n\nnamespace Demo.Api;\n\npublic class LoginController\n{\n    public string HandleLogin(string raw) { return new AuthService().NormalizeToken(raw); }\n}\n",
+    "utf8"
+  );
+}
+
 test("semantic refresh indexes TS/JS projects and surfaces", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-semantic-refresh-"));
   await writeSemanticFixture(root);
@@ -159,6 +217,39 @@ test("semantic refresh indexes TS/JS projects and surfaces", async () => {
   } finally {
     closeIndexDatabase(db);
   }
+});
+
+test("semantic refresh indexes Python, Go, Java, and .NET adapters", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-semantic-multilang-"));
+  await writeMultiLanguageSemanticFixture(root);
+  const config = await loadConfig(root, {
+    provider: "local",
+    dryRun: false,
+    "semantic.enabled": true,
+  });
+
+  await runScan(root, config);
+  await runSemanticRefresh(root, config, { silent: true, skipOutput: true });
+
+  const db = openIndexDatabase(root);
+  try {
+    const projects = listSemanticProjects(db);
+    for (const language of ["python", "go", "java", "dotnet"]) {
+      const project = projects.find((item) => item.project_id.startsWith(`${language}:`));
+      assert.ok(project, `${language} semantic project should be indexed`);
+      assert.ok(project.symbol_count > 0, `${language} semantic project should store symbols`);
+      assert.ok(project.edge_count > 0, `${language} semantic project should store edges`);
+    }
+  } finally {
+    closeIndexDatabase(db);
+  }
+
+  const search = await querySearch(root, "NormalizeToken");
+  const plan = await buildExecutionPlan(root, config, "fix NormalizeToken auth handling");
+
+  assert.ok(search.semantic_symbols.some((symbolInfo) => symbolInfo.name === "NormalizeToken"));
+  assert.ok(search.semantic_surfaces.some((surface) => surface.display_name === "NormalizeToken"));
+  assert.ok(plan.selected_symbols.some((symbolInfo) => symbolInfo.name === "NormalizeToken" && symbolInfo.source === "symbol"));
 });
 
 test("doc uses semantic repo map and deterministic semantic headers when enabled", async () => {


### PR DESCRIPTION
## Summary
- add semantic adapter plumbing while keeping the TS/JS worker path intact
- store normalized project, symbol, public surface, and import-edge facts for Python, Go, Java, and .NET
- wire semantic-enabled planner/doc/doctor/validation paths to the broader semantic mode and update docs

## Tests
- npm test -- test/semantic.test.js
- npm test -- test/planner.test.js test/config.test.js test/query.test.js test/db.test.js
- env -u AGENTIFY_MEMPALACE_CMD npm test

Closes #7
