### PR TITLE
feat: add explainable planner output

### DIFF
--- a/docs/DETAILED_README.md
+++ b/docs/DETAILED_README.md
@@ -168,7 +168,7 @@ tests:
 
 | Command | What it does | Why and when to use it | Example |
 | --- | --- | --- | --- |
-| `agentify plan` | Builds the planner-selected execution context for a task and prints it as JSON. | Use before `run` when you want to inspect the exact prompt context and file selection Agentify will choose. | `agentify plan "add retry logic to checkout"` |
+| `agentify plan` | Builds the planner-selected execution context for a task and prints it as JSON. Add `--explain` for score components and stable reason codes. | Use before `run` when you want to inspect the exact prompt context, file selection, or why planner scoring chose each item. | `agentify plan --explain "add retry logic to checkout"` |
 | `agentify run` | Uses the selected provider template command, executes the task, then refreshes the repo afterward. | Use for normal day-to-day agent work when you want Agentify to own context selection and post-run maintenance. | `agentify run --provider codex "implement payment retries"` |
 | `agentify exec` | Runs a custom command after `--`, then performs the same refresh lifecycle as `run`. | Use when you want full control over the provider command line but still want Agentify wrapping, timeout handling, and refresh behavior. | `agentify exec -- codex exec "fix auth bug"` |
 | `agentify this` | Bootstraps the current macOS repo for provider-backed Agentify use. | Use on macOS when you want the shortest path to a working repo and are okay with Agentify verifying/installing local dependencies. | `agentify this --provider codex` |
@@ -320,6 +320,7 @@ In the second command, Agentify reuses `codex` for the same repo.
 | `--ghost` | Route outputs into `.current_session/`. Use this for ephemeral runs where you want isolated output artifacts. |
 | `--json` | Emit machine-readable JSON. Use this when scripting around Agentify or integrating it into tooling. |
 | `--interactive`, `-i` | Force interactive provider mode. Template providers already default to interactive mode for `run` and `sess`, but this is useful when you want to be explicit. |
+| `--explain` | Include planner score breakdowns for `agentify plan`. Text output shows component totals; combine with `--json` for machine-readable stable reason codes. |
 | `--explain-plan` | Print the planner result before `run` executes. Use this when you want to inspect Agentify's chosen context first. |
 | `--root <path>` | Target a repo other than the current working directory. Use this in scripts or monorepo tooling. |
 | `--scope <project|user>` | Choose where skills are installed. Use `project` for repo-local behavior and `user` for account-level installs. |

--- a/src/core/planner.js
+++ b/src/core/planner.js
@@ -68,8 +68,31 @@ function normalizeExecutionBudget(executionBudget = {}) {
   };
 }
 
-function pushReason(reasons, reason, points) {
-  reasons.push({ reason, points });
+export const PLAN_EXPLAIN_COMPONENTS = Object.freeze([
+  "lexical_token_match",
+  "dependency_proximity",
+  "semantic_contribution",
+  "recency_changed_file_boost",
+  "structural_signal",
+]);
+
+const PLAN_EXPLAIN_COMPONENT_LABELS = Object.freeze({
+  lexical_token_match: "lexical/token match",
+  dependency_proximity: "dependency proximity",
+  semantic_contribution: "semantic contribution",
+  recency_changed_file_boost: "recency/changed-file boost",
+  structural_signal: "structural signal",
+});
+
+function pushReason(reasons, reason, points, metadata = {}) {
+  reasons.push({
+    reason,
+    points,
+    code: metadata.code,
+    component: metadata.component || "structural_signal",
+    detail: metadata.detail || null,
+    legacy: metadata.legacy !== false,
+  });
 }
 
 function scoreModule(moduleInfo, taskText, tokens) {
@@ -82,16 +105,28 @@ function scoreModule(moduleInfo, taskText, tokens) {
   for (const token of tokens) {
     if (name === token || packageName === token) {
       score += 120;
-      pushReason(reasons, `direct module name match: ${token}`, 120);
+      pushReason(reasons, `direct module name match: ${token}`, 120, {
+        code: "lexical.module.direct_name_match",
+        component: "lexical_token_match",
+        detail: { token },
+      });
     } else if (name.includes(token) || rootPath.includes(token) || packageName.includes(token)) {
       score += 50;
-      pushReason(reasons, `module/path match: ${token}`, 50);
+      pushReason(reasons, `module/path match: ${token}`, 50, {
+        code: "lexical.module.path_match",
+        component: "lexical_token_match",
+        detail: { token },
+      });
     }
   }
 
   if (taskText.includes(moduleInfo.root_path.toLowerCase())) {
     score += 90;
-    pushReason(reasons, `task mentions module path ${moduleInfo.root_path}`, 90);
+    pushReason(reasons, `task mentions module path ${moduleInfo.root_path}`, 90, {
+      code: "lexical.module.path_mentioned",
+      component: "lexical_token_match",
+      detail: { path: moduleInfo.root_path },
+    });
   }
 
   return { score, reasons };
@@ -106,47 +141,93 @@ function scoreFile(fileInfo, taskText, tokens, changedPaths, symbolMatchesByFile
   for (const token of tokens) {
     if (normalizedPath === token || basename === token) {
       score += 120;
-      pushReason(reasons, `direct file match: ${token}`, 120);
+      pushReason(reasons, `direct file match: ${token}`, 120, {
+        code: "lexical.file.direct_path_match",
+        component: "lexical_token_match",
+        detail: { token },
+      });
     } else if (normalizedPath.includes(token) || basename.includes(token)) {
       score += 42;
-      pushReason(reasons, `file/path match: ${token}`, 42);
+      pushReason(reasons, `file/path match: ${token}`, 42, {
+        code: "lexical.file.path_match",
+        component: "lexical_token_match",
+        detail: { token },
+      });
     }
   }
 
-  const symbolBoost = symbolMatchesByFile.get(fileInfo.path) || 0;
+  const symbolBoosts = symbolMatchesByFile.get(fileInfo.path) || { structural: 0, semantic: 0 };
+  const symbolBoost = symbolBoosts.structural + symbolBoosts.semantic;
   if (symbolBoost > 0) {
     score += symbolBoost;
-    pushReason(reasons, "matching symbols in file", symbolBoost);
+    if (symbolBoosts.structural > 0) {
+      pushReason(reasons, "matching symbols in file", symbolBoosts.structural, {
+        code: "structural.file.matching_symbols",
+        component: "structural_signal",
+      });
+    }
+    if (symbolBoosts.semantic > 0) {
+      pushReason(reasons, "matching symbols in file", symbolBoosts.semantic, {
+        code: "semantic.file.matching_symbols",
+        component: "semantic_contribution",
+      });
+    }
   }
   if (fileInfo.is_key_file) {
     score += 28;
-    pushReason(reasons, "key file", 28);
+    pushReason(reasons, "key file", 28, {
+      code: "structural.file.key_file",
+      component: "structural_signal",
+    });
   }
   if (fileInfo.is_entrypoint) {
     score += 24;
-    pushReason(reasons, "entrypoint", 24);
+    pushReason(reasons, "entrypoint", 24, {
+      code: "structural.file.entrypoint",
+      component: "structural_signal",
+    });
   }
   if (fileInfo.is_config) {
     score += 12;
-    pushReason(reasons, "config file", 12);
+    pushReason(reasons, "config file", 12, {
+      code: "structural.file.config_file",
+      component: "structural_signal",
+    });
   }
   if (fileInfo.is_test) {
     score -= 8;
+    pushReason(reasons, "test file penalty", -8, {
+      code: "structural.file.test_penalty",
+      component: "structural_signal",
+      legacy: false,
+    });
   }
   if (changedPaths.has(fileInfo.path)) {
     score += 36;
-    pushReason(reasons, "recently changed", 36);
+    pushReason(reasons, "recently changed", 36, {
+      code: "recency.file.changed_file",
+      component: "recency_changed_file_boost",
+      detail: { path: fileInfo.path },
+    });
   }
   if (taskText.includes(fileInfo.path.toLowerCase())) {
     score += 100;
-    pushReason(reasons, `task mentions file path ${fileInfo.path}`, 100);
+    pushReason(reasons, `task mentions file path ${fileInfo.path}`, 100, {
+      code: "lexical.file.path_mentioned",
+      component: "lexical_token_match",
+      detail: { path: fileInfo.path },
+    });
   }
 
   const moduleScore = fileInfo.module_id ? (moduleScoreById.get(fileInfo.module_id) || 0) : 0;
   if (moduleScore > 0) {
     const moduleBoost = Math.max(8, Math.min(30, Math.round(moduleScore / 6)));
     score += moduleBoost;
-    pushReason(reasons, "inside a selected high-signal module", moduleBoost);
+    pushReason(reasons, "inside a selected high-signal module", moduleBoost, {
+      code: "dependency.file.selected_module_proximity",
+      component: "dependency_proximity",
+      detail: { module_id: fileInfo.module_id },
+    });
   }
 
   return { score, reasons };
@@ -159,26 +240,46 @@ function scoreSymbol(symbolInfo, taskText, tokens) {
     normalizeToken(symbolInfo.name),
     normalizeToken(symbolInfo.alias || ""),
   ].filter(Boolean)));
+  const semanticSymbol = symbolInfo.source && symbolInfo.source !== "structural";
+  const matchComponent = semanticSymbol ? "semantic_contribution" : "lexical_token_match";
+  const codePrefix = semanticSymbol ? "semantic.symbol" : "lexical.symbol";
   for (const token of tokens) {
     for (const term of terms) {
       if (term === token) {
         score += 130;
-        pushReason(reasons, `direct symbol match: ${token}`, 130);
+        pushReason(reasons, `direct symbol match: ${token}`, 130, {
+          code: `${codePrefix}.direct_name_match`,
+          component: matchComponent,
+          detail: { token },
+        });
         break;
       }
       if (term.includes(token) || token.includes(term)) {
         score += 60;
-        pushReason(reasons, `symbol match: ${token}`, 60);
+        pushReason(reasons, `symbol match: ${token}`, 60, {
+          code: `${codePrefix}.name_match`,
+          component: matchComponent,
+          detail: { token },
+        });
         break;
       }
     }
   }
   if (taskText.includes(String(symbolInfo.name || "").toLowerCase()) || taskText.includes(String(symbolInfo.alias || "").toLowerCase())) {
     score += 90;
-    pushReason(reasons, `task mentions symbol ${symbolInfo.name}`, 90);
+    pushReason(reasons, `task mentions symbol ${symbolInfo.name}`, 90, {
+      code: `${codePrefix}.mentioned`,
+      component: matchComponent,
+      detail: { name: symbolInfo.name },
+    });
   }
   if (symbolInfo.exported) {
     score += 12;
+    pushReason(reasons, "exported symbol", 12, {
+      code: "structural.symbol.exported",
+      component: "structural_signal",
+      legacy: false,
+    });
   }
   return { score, reasons };
 }
@@ -205,7 +306,11 @@ function applyDependencyBoosts(moduleScores, dependencyMap) {
       }
       const points = Math.max(14, Math.min(34, Math.round(moduleInfo.score * 0.18)));
       neighbor.score += points;
-      pushReason(neighbor.reasons, `dependency of matched module ${moduleInfo.id}`, points);
+      pushReason(neighbor.reasons, `dependency of matched module ${moduleInfo.id}`, points, {
+        code: "dependency.module.depends_on_matched_module",
+        component: "dependency_proximity",
+        detail: { module_id: moduleInfo.id },
+      });
     }
 
     for (const neighborId of depInfo.usedBy) {
@@ -215,7 +320,11 @@ function applyDependencyBoosts(moduleScores, dependencyMap) {
       }
       const points = Math.max(10, Math.min(22, Math.round(moduleInfo.score * 0.12)));
       neighbor.score += points;
-      pushReason(neighbor.reasons, `used by matched module ${moduleInfo.id}`, points);
+      pushReason(neighbor.reasons, `used by matched module ${moduleInfo.id}`, points, {
+        code: "dependency.module.used_by_matched_module",
+        component: "dependency_proximity",
+        detail: { module_id: moduleInfo.id },
+      });
     }
   }
 
@@ -323,6 +432,146 @@ Selected file slices:
 ${fileBlocks}`;
 }
 
+function legacyReason(reason) {
+  return {
+    reason: reason.reason,
+    points: reason.points,
+  };
+}
+
+function stripExplainReasonMetadata(item) {
+  return {
+    ...item,
+    reasons: item.reasons
+      .filter((reason) => reason.legacy !== false)
+      .map(legacyReason),
+  };
+}
+
+function createEmptyComponentTotals() {
+  return Object.fromEntries(PLAN_EXPLAIN_COMPONENTS.map((component) => [component, 0]));
+}
+
+function toExplainReason(reason) {
+  const result = {
+    code: reason.code,
+    component: reason.component,
+    points: reason.points,
+    reason: reason.reason,
+  };
+  if (reason.detail && Object.keys(reason.detail).length > 0) {
+    result.detail = reason.detail;
+  }
+  return result;
+}
+
+function addScoreBreakdown(item) {
+  const components = createEmptyComponentTotals();
+  const reasons = item.reasons.map(toExplainReason);
+  for (const reason of reasons) {
+    components[reason.component] = (components[reason.component] || 0) + reason.points;
+  }
+  const componentTotal = Object.values(components).reduce((sum, points) => sum + points, 0);
+  return {
+    ...item,
+    reasons,
+    score_breakdown: {
+      total: item.score,
+      components,
+      unexplained: item.score - componentTotal,
+    },
+  };
+}
+
+function preparePlanForOutput(plan, { explain = false } = {}) {
+  if (explain) {
+    return {
+      ...plan,
+      explain: {
+        schema_version: 1,
+        reason_code_format: "namespace.entity.reason",
+        components: PLAN_EXPLAIN_COMPONENTS.map((component) => ({
+          code: component,
+          label: PLAN_EXPLAIN_COMPONENT_LABELS[component],
+        })),
+      },
+      selected_modules: plan.selected_modules.map(addScoreBreakdown),
+      selected_files: plan.selected_files.map(addScoreBreakdown),
+      selected_symbols: plan.selected_symbols.map(addScoreBreakdown),
+    };
+  }
+
+  return {
+    ...plan,
+    selected_modules: plan.selected_modules.map(stripExplainReasonMetadata),
+    selected_files: plan.selected_files.map(stripExplainReasonMetadata),
+    selected_symbols: plan.selected_symbols.map(stripExplainReasonMetadata),
+  };
+}
+
+function formatSignedPoints(points) {
+  return points >= 0 ? `+${points}` : String(points);
+}
+
+function renderScoreComponents(scoreBreakdown) {
+  return PLAN_EXPLAIN_COMPONENTS
+    .map((component) => `${PLAN_EXPLAIN_COMPONENT_LABELS[component]}=${scoreBreakdown.components[component]}`)
+    .join(", ");
+}
+
+function renderExplanationItem(label, title, item) {
+  const lines = [
+    `- ${label}: ${title}`,
+    `  score: ${item.score}; ${renderScoreComponents(item.score_breakdown)}`,
+  ];
+  if (item.score_breakdown.unexplained !== 0) {
+    lines.push(`  unexplained: ${item.score_breakdown.unexplained}`);
+  }
+  for (const reason of item.reasons) {
+    lines.push(`  ${formatSignedPoints(reason.points)} ${reason.code} (${PLAN_EXPLAIN_COMPONENT_LABELS[reason.component]}): ${reason.reason}`);
+  }
+  return lines.join("\n");
+}
+
+export function renderPlanExplanation(plan) {
+  const lines = [
+    "Agentify plan explanation",
+    `Task: ${plan.task}`,
+    `Confidence: ${plan.confidence}`,
+    `Reason schema: v${plan.explain?.schema_version || 1} (${plan.explain?.reason_code_format || "namespace.entity.reason"})`,
+    "",
+    "Modules:",
+  ];
+
+  if (plan.selected_modules.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const item of plan.selected_modules) {
+      lines.push(renderExplanationItem("module", `${item.id} (${item.root_path})`, item));
+    }
+  }
+
+  lines.push("", "Files:");
+  if (plan.selected_files.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const item of plan.selected_files) {
+      lines.push(renderExplanationItem("file", item.path, item));
+    }
+  }
+
+  lines.push("", "Symbols:");
+  if (plan.selected_symbols.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const item of plan.selected_symbols) {
+      lines.push(renderExplanationItem("symbol", `${item.name} (${item.kind}) in ${item.file_path}`, item));
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
 export async function buildExecutionPlan(root, config, task, options = {}) {
   const budgets = createPlannerBudget(config);
   const executionBudget = createExecutionBudget(config);
@@ -372,19 +621,24 @@ export async function buildExecutionPlan(root, config, task, options = {}) {
 
     const symbolMatchesByFile = new Map();
     for (const symbolInfo of symbolScores) {
-      symbolMatchesByFile.set(
-        symbolInfo.file_path,
-        (symbolMatchesByFile.get(symbolInfo.file_path) || 0) + Math.min(symbolInfo.score, 90)
-      );
+      const current = symbolMatchesByFile.get(symbolInfo.file_path) || { structural: 0, semantic: 0 };
+      const key = symbolInfo.source && symbolInfo.source !== "structural" ? "semantic" : "structural";
+      current[key] += Math.min(symbolInfo.score, 90);
+      symbolMatchesByFile.set(symbolInfo.file_path, current);
     }
 
     const moduleDependencyMap = new Map();
     const baseModuleScores = modules
       .map((moduleInfo) => {
         const base = scoreModule(moduleInfo, normalizedTask, tokens);
-        const symbolBoost = symbolScores
-          .filter((symbolInfo) => symbolInfo.module_id === moduleInfo.id)
+        const matchingModuleSymbols = symbolScores.filter((symbolInfo) => symbolInfo.module_id === moduleInfo.id);
+        const structuralSymbolBoost = matchingModuleSymbols
+          .filter((symbolInfo) => !symbolInfo.source || symbolInfo.source === "structural")
           .reduce((sum, symbolInfo) => sum + Math.min(symbolInfo.score, 50), 0);
+        const semanticSymbolBoost = matchingModuleSymbols
+          .filter((symbolInfo) => symbolInfo.source && symbolInfo.source !== "structural")
+          .reduce((sum, symbolInfo) => sum + Math.min(symbolInfo.score, 50), 0);
+        const symbolBoost = structuralSymbolBoost + semanticSymbolBoost;
         const structuralDep = loadModuleDependencies(db, moduleInfo.id);
         const semanticDep = config.semantic?.tsjs?.enabled
           ? loadSemanticModuleDependencies(db, moduleInfo.id)
@@ -396,11 +650,23 @@ export async function buildExecutionPlan(root, config, task, options = {}) {
         moduleDependencyMap.set(moduleInfo.id, dep);
         const score = base.score + symbolBoost;
         const reasons = [...base.reasons];
-        if (symbolBoost > 0) {
-          pushReason(reasons, "matching symbols inside module", symbolBoost);
+        if (structuralSymbolBoost > 0) {
+          pushReason(reasons, "matching symbols inside module", structuralSymbolBoost, {
+            code: "structural.module.matching_symbols",
+            component: "structural_signal",
+          });
+        }
+        if (semanticSymbolBoost > 0) {
+          pushReason(reasons, "matching symbols inside module", semanticSymbolBoost, {
+            code: "semantic.module.matching_symbols",
+            component: "semantic_contribution",
+          });
         }
         if (changedFiles.some((fileInfo) => fileInfo.path && isPathInsideModule(fileInfo.path, moduleInfo.root_path))) {
-          pushReason(reasons, "module contains changed files", 24);
+          pushReason(reasons, "module contains changed files", 24, {
+            code: "recency.module.contains_changed_files",
+            component: "recency_changed_file_boost",
+          });
           return {
             ...moduleInfo,
             score: score + 24,
@@ -506,15 +772,16 @@ export async function buildExecutionPlan(root, config, task, options = {}) {
       ],
     };
 
+    const outputPlan = preparePlanForOutput(plan, { explain: options.explain === true });
     let prompt = renderExecutionPrompt({
-      ...plan,
+      ...outputPlan,
       prompt_bytes: 0,
     });
-    plan.prompt_bytes = bytes(prompt);
-    prompt = renderExecutionPrompt(plan);
-    plan.prompt = prompt;
-    plan.prompt_bytes = bytes(prompt);
-    return plan;
+    outputPlan.prompt_bytes = bytes(prompt);
+    prompt = renderExecutionPrompt(outputPlan);
+    outputPlan.prompt = prompt;
+    outputPlan.prompt_bytes = bytes(prompt);
+    return outputPlan;
   } finally {
     closeIndexDatabase(db);
   }

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import { ensureBaselineArtifacts, runDoc, runScan, runUpdate, runValidate } from
 import { runExec } from "./core/exec.js";
 import { installHooks, removeHooks, statusHooks } from "./core/hooks.js";
 import { queryOwner, queryDeps, queryChanged, querySearch } from "./core/query.js";
-import { buildExecutionPlan } from "./core/planner.js";
+import { buildExecutionPlan, renderPlanExplanation } from "./core/planner.js";
 import { forkSession, listSessions, resolveSessionProvider, resumeSession, validateSessionId } from "./core/session.js";
 import { loadAutomaticRunMemory, loadAutomaticSessionMemory } from "./core/session-memory.js";
 import { runDoctor } from "./core/toolchain.js";
@@ -44,6 +44,7 @@ const BOOLEAN_FLAGS = new Set([
   "failOnStale",
   "skipRefresh",
   "explainPlan",
+  "explain",
   "allowPartial",
   "reuseSession",
   "hook",
@@ -279,6 +280,7 @@ function printHelp() {
     `    ${c("--provider-timeout-ms")} ${d("<ms>")}     Fail provider doc calls after N milliseconds`,
     `    ${c("--ghost")}                     Route outputs to .current_session/`,
     `    ${c("--json")}                      Machine-readable JSON output only`,
+    `    ${c("--explain")}                   Include planner score breakdowns for plan output`,
     `    ${c("--interactive")}, ${c("-i")}       Force interactive mode (template providers default to interactive for run/sess)`,
     `    ${c("--explain-plan")}              Print planner output before executing run`,
     `    ${c("--caveman[=level]")}            Terse output for run/sess (lite, full, ultra, wenyan*)`,
@@ -472,14 +474,18 @@ export async function runCli(argv) {
         const task = buildRunPrompt(getPromptFromArgs(args, 1));
         let plan;
         try {
-          plan = await buildExecutionPlan(root, config, task);
+          plan = await buildExecutionPlan(root, config, task, { explain: args.explain === true });
         } catch (error) {
           if (isMissingIndexError(error)) {
             throw createMissingIndexGuidance(root);
           }
           throw error;
         }
-        console.log(JSON.stringify(plan, null, 2));
+        if (args.explain === true && !args.json) {
+          process.stdout.write(renderPlanExplanation(plan));
+        } else {
+          console.log(JSON.stringify(plan, null, 2));
+        }
         return;
       }
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -315,6 +315,61 @@ test("runCli plan reports actionable guidance when the index is missing", async 
   );
 });
 
+test("runCli plan --explain renders text and JSON score breakdowns", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-plan-explain-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, "src", "auth"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "src", "auth", "service.js"),
+    "export function loginUser(rawToken) {\n  return rawToken.trim();\n}\n",
+    "utf8",
+  );
+  await initGitRepo(root);
+  await runCli(["scan", "--root", root]);
+
+  const stdoutChunks = [];
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk, encoding, callback) => {
+    stdoutChunks.push(String(chunk));
+    if (typeof encoding === "function") {
+      encoding();
+    } else if (typeof callback === "function") {
+      callback();
+    }
+    return true;
+  });
+
+  try {
+    await runCli(["plan", "--root", root, "--explain", "fix loginUser"]);
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+  }
+
+  const text = stdoutChunks.join("");
+  assert.match(text, /Agentify plan explanation/);
+  assert.match(text, /lexical\/token match=/);
+  assert.match(text, /recency\/changed-file boost=/);
+  assert.match(text, /lexical\.symbol\.direct_name_match/);
+
+  const jsonOutput = [];
+  const originalLog = console.log;
+  console.log = (...args) => {
+    jsonOutput.push(args.join(" "));
+  };
+
+  try {
+    await runCli(["plan", "--root", root, "--explain", "--json", "fix loginUser"]);
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(jsonOutput.length, 1);
+  const payload = JSON.parse(jsonOutput[0]);
+  assert.equal(payload.explain.schema_version, 1);
+  assert.ok(payload.selected_files.some((fileInfo) => typeof fileInfo.score_breakdown?.total === "number"));
+  assert.ok(payload.selected_symbols.some((symbolInfo) => symbolInfo.reasons.some((reason) => reason.code === "lexical.symbol.direct_name_match")));
+});
+
 test("runCli query reports actionable guidance when the index is missing", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-query-missing-index-"));
   await runCli(["init", "--root", root]);

--- a/test/planner.test.js
+++ b/test/planner.test.js
@@ -1,13 +1,35 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 
 import { runScan } from "../src/core/commands.js";
 import { loadConfig } from "../src/core/config.js";
 import { closeIndexDatabase, openIndexDatabase } from "../src/core/db.js";
 import { buildExecutionPlan, renderExecutionPrompt } from "../src/core/planner.js";
+
+const execFileAsync = promisify(execFile);
+
+async function initGitRepo(root) {
+  await execFileAsync("git", ["init"], { cwd: root });
+  await execFileAsync("git", ["config", "user.name", "Agentify Tests"], { cwd: root });
+  await execFileAsync("git", ["config", "user.email", "agentify-tests@example.com"], { cwd: root });
+  await execFileAsync("git", ["add", "."], { cwd: root });
+  await execFileAsync("git", ["commit", "-m", "initial"], { cwd: root });
+}
+
+function assertExplainBreakdown(item) {
+  assert.equal(item.score_breakdown.total, item.score);
+  assert.equal(item.score_breakdown.unexplained, 0);
+  for (const reason of item.reasons) {
+    assert.match(reason.code, /^[a-z]+(?:_[a-z]+)*\.[a-z]+(?:_[a-z]+)*\.[a-z]+(?:_[a-z]+)*$/);
+    assert.match(reason.component, /^[a-z]+(?:_[a-z]+)*$/);
+    assert.equal(typeof reason.points, "number");
+  }
+}
 
 test("planner prioritizes extracted Python symbols", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-python-plan-"));
@@ -195,6 +217,40 @@ test("planner surfaces explicit discovery budget and edit-start contract", async
   assert.match(plan.prompt, /Discovery budget before the first edit: at most 2 additional file or doc reads, and at most 0 widening step\(s\)/);
   assert.match(plan.prompt, /INSUFFICIENT_CONTEXT: blocker=<specific missing fact>; needed=<specific file, symbol, or doc>; reads_used=<n>; widenings_used=<n>/);
   assert.match(plan.prompt, /Edit after selected context unless blocked: true/);
+});
+
+test("planner explain mode emits stable reason codes and complete score breakdowns", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-plan-explain-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, "src", "auth"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "src", "auth", "service.js"),
+    "export function loginUser(rawToken) {\n  return rawToken.trim();\n}\n",
+    "utf8",
+  );
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "local", dryRun: false });
+  await runScan(root, config);
+  await fs.appendFile(path.join(root, "src", "auth", "service.js"), "\nexport const loginVersion = 1;\n", "utf8");
+
+  const plan = await buildExecutionPlan(root, config, "fix loginUser in src/auth/service.js", { explain: true });
+  const file = plan.selected_files.find((fileInfo) => fileInfo.path === "src/auth/service.js");
+  const symbol = plan.selected_symbols.find((symbolInfo) => symbolInfo.name === "loginUser");
+
+  assert.equal(plan.explain.schema_version, 1);
+  assert.ok(plan.explain.components.some((component) => component.code === "lexical_token_match"));
+  assert.ok(file);
+  assert.ok(symbol);
+
+  for (const item of [...plan.selected_modules, ...plan.selected_files, ...plan.selected_symbols]) {
+    assertExplainBreakdown(item);
+  }
+
+  assert.equal(file.score_breakdown.components.recency_changed_file_boost, 36);
+  assert.ok(file.reasons.some((reason) => reason.code === "recency.file.changed_file"));
+  assert.ok(file.reasons.some((reason) => reason.code === "dependency.file.selected_module_proximity"));
+  assert.ok(symbol.reasons.some((reason) => reason.code === "structural.symbol.exported"));
 });
 
 test("renderExecutionPrompt uses discovery budget defaults when older plans omit them", () => {


### PR DESCRIPTION
## Summary
- add `agentify plan --explain` text output with per-item score components
- add explain JSON fields with stable reason codes and complete score breakdowns
- preserve default non-explain planner output and document the new flag

Closes #8

## Verification
- `node --test test/planner.test.js`
- `node --test test/main.test.js`
- `env -u AGENTIFY_MEMPALACE_CMD npm test`

Note: plain `npm test` failed in this shell because `AGENTIFY_MEMPALACE_CMD` points to a non-invokable external MemPalace path; unsetting that env var made the full suite pass.