### PR TITLE
test: cover interactive provider capture

### DIFF
--- a/test/main.test.js
+++ b/test/main.test.js
@@ -172,6 +172,42 @@ test("getSessionCaptureSettings preserves inherited stdio for custom session com
   );
 });
 
+test("prepareSessionLaunch records interactive template sessions through PTY capture for Codex and Claude", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-provider-template-capture-"));
+  const task = "Capture the provider transcript.";
+
+  for (const provider of ["codex", "claude"]) {
+    const sessionResult = {
+      manifest: {
+        session_id: `sess_${provider}_capture`,
+        provider,
+        name: `${provider} capture session`,
+      },
+      bootstrap: `# Session Context\n- Provider: ${provider}`,
+    };
+    const config = {
+      provider,
+      session: {
+        memoryPromptMaxKb: 4,
+        memoryResults: 3,
+        memoryTurns: 6,
+      },
+    };
+    const launch = await prepareSessionLaunch(root, config, parseArgs(["sess", "run", task]), sessionResult, task);
+
+    assert.equal(launch.provider, provider);
+    assert.equal(launch.captureSettings.captureMode, "interactive-pty");
+    assert.equal(launch.runExecFlags.captureOutputMode, "pty");
+    assert.equal(launch.sessionRecord.captureMode, "interactive-pty");
+    assert.equal(launch.sessionRecord.provider, provider);
+    assert.equal(launch.sessionRecord.task, task);
+    assert.equal(launch.runExecFlags.sessionRecord, launch.sessionRecord);
+    assert.equal(launch.agentCommand[0], provider);
+    assert.doesNotMatch(launch.agentCommand.join(" "), /\bexec\b|-p\b/);
+    assert.match(launch.agentCommand.at(-1), /Current task: Capture the provider transcript\./);
+  }
+});
+
 test("buildSessionPrompt injects automatic memory excerpts before the current task", () => {
   const prompt = buildSessionPrompt(
     "# Session Context\n- Provider: codex",

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -498,7 +498,7 @@ setInterval(() => {}, 1000);
     } finally {
       closeIndexDatabase(db);
     }
-    await fs.unlink(path.join(root, "docs", "modules", "auth.md"));
+    await fs.unlink(path.join(root, "src", "auth", "AGENTIFY.md"));
     assert.equal(await fs.stat(path.join(root, "docs", "repo-map.md")).then(() => true), true);
 
     await assert.rejects(


### PR DESCRIPTION
## Summary
- add provider-specific regression coverage that Codex and Claude interactive session templates launch through PTY capture
- assert template session launch avoids non-interactive command flags so transcripts can be recorded
- fix the provider-timeout regression test to delete the actual module-root AGENTIFY.md artifact for non-root modules

Closes #38

## Tests
- npm test -- --test-name-pattern='prepareSessionLaunch records interactive template sessions through PTY capture for Codex and Claude'
- npm test -- --test-name-pattern='runDoc fails closed when an external module provider stalls'
- npm test