### PR TITLE
feat: add routed context mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,10 @@ Supported levels are `lite`, `full`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-f
 | Validate after intentional source edits | `agentify check --hook` |
 | Preview rich task context | `agentify plan "your task"` |
 | Search indexed repo context | `agentify query search --term auth` |
+| Search routed context | `agentify context search auth` |
 | Navigate semantic TS/JS facts | `agentify query refs --symbol useAuth` |
 | Run a bounded task | `agentify run "your task"` |
+| Run with routed retrieval | `agentify run --context-mode routed "your task"` |
 | Run with Agentify-selected context injected | `agentify run --with-context "your task"` |
 | Start durable multi-run work | `agentify sess run --name "<stream>" "your task"` |
 | Write a cross-agent handoff bundle | `agentify handoff --session <id> "next task"` |
@@ -199,6 +201,7 @@ Supported levels are `lite`, `full`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-f
 | `exec` | Advanced wrapper for custom agent commands |
 | `handoff` | Write a cross-agent handoff bundle for a session |
 | `this` | Bootstrap this macOS repo for a provider-backed Agentify workflow |
+| `context` | Search, fetch, compact, and inspect routed context |
 | `query` | Query the repository index (owner, deps, changed, def, refs, callers, impacts) |
 | `risk` | Score PR blast radius and recommend regression tests |
 | `skill` | Manage built-in agent skills |
@@ -228,6 +231,7 @@ Supported levels are `lite`, `full`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-f
 | `--explain` | Include planner score breakdowns for plan output |
 | `--interactive`, `-i` | Force interactive mode (template providers default to interactive for `run`/`sess`) |
 | `--with-context` | Inject planner-selected files, tests, and memory into `run` |
+| `--context-mode <direct|routed>` | Use routed context retrieval for `run`/`sess` prompts |
 | `--explain-plan` | Print planner output before executing `run` |
 | `--caveman[=level]` | Terse output for `run`/`sess` (`lite`, `full`, `ultra`, `wenyan*`) |
 | `--root <path>` | Target repo root (default: cwd) |

--- a/docs/DETAILED_README.md
+++ b/docs/DETAILED_README.md
@@ -172,6 +172,7 @@ tests:
 | --- | --- | --- | --- |
 | `agentify plan` | Builds the planner-selected execution context for a task and prints it as JSON. | Use before `run` when you want to inspect the exact prompt context and file selection Agentify will choose. | `agentify plan "add retry logic to checkout"` |
 | `agentify run` | Uses the selected provider template command, executes the task, then refreshes the repo afterward. | Use for normal day-to-day agent work when you want Agentify to own context selection and post-run maintenance. | `agentify run --provider codex "implement payment retries"` |
+| `agentify context` | Searches indexed refs, fetches bounded source slices, compacts session facts, and reports routed context status. | Use with `--context-mode routed` prompts when agents should retrieve context through bounded Agentify commands instead of receiving full file bodies. | `agentify context fetch src/auth.ts --lines 20:80` |
 | `agentify exec` | Runs a custom command after `--`, then performs the same refresh lifecycle as `run`. | Use when you want full control over the provider command line but still want Agentify wrapping, timeout handling, and refresh behavior. | `agentify exec -- codex exec "fix auth bug"` |
 | `agentify this` | Bootstraps the current macOS repo for provider-backed Agentify use. | Use on macOS when you want the shortest path to a working repo and are okay with Agentify verifying/installing local dependencies. | `agentify this --provider codex` |
 | `agentify sess run` | Creates or resumes a session and launches the provider with session bootstrap context. | Use for work that will span multiple agent runs and needs durable context under `.agents/session/`. | `agentify sess run --provider codex --name "payments-v2" "add tests"` |
@@ -331,6 +332,7 @@ In the second command, Agentify reuses `codex` for the same repo.
 | `--json` | Emit machine-readable JSON. Use this when scripting around Agentify or integrating it into tooling. |
 | `--interactive`, `-i` | Force interactive provider mode. Template providers already default to interactive mode for `run` and `sess`, but this is useful when you want to be explicit. |
 | `--with-context` | Inject planner-selected files, related tests, prior memory, and execution rules into `run`. Use this when you want the older rich first prompt instead of the default clean interactive prompt. |
+| `--context-mode <direct|routed>` | Use `routed` to launch `run` and `sess` with docs/DB-first instructions and only bounded `agentify context ...` retrieval commands. |
 | `--explain-plan` | Print the planner result before `run` executes. Use this when you want to inspect Agentify's chosen context first. |
 | `--root <path>` | Target a repo other than the current working directory. Use this in scripts or monorepo tooling. |
 | `--scope <project|user>` | Choose where skills are installed. Use `project` for repo-local behavior and `user` for account-level installs. |

--- a/src/core/context.js
+++ b/src/core/context.js
@@ -1,0 +1,224 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { closeIndexDatabase, openIndexDatabase } from "./db/connection.js";
+import { searchIndex } from "./db/structural-store.js";
+import { searchSemanticIndex } from "./db/semantic-store.js";
+
+const MAX_FETCH_LINES = 240;
+
+function normalizePathForOutput(filePath) {
+  return String(filePath || "").split(path.sep).join("/");
+}
+
+function resolveRepoPath(root, filePath) {
+  const normalized = normalizePathForOutput(filePath);
+  if (!normalized || normalized.startsWith("../") || path.isAbsolute(normalized)) {
+    throw new Error("context fetch path must be a repository-relative path");
+  }
+  const fullPath = path.resolve(root, normalized);
+  const rootPath = path.resolve(root);
+  if (fullPath !== rootPath && !fullPath.startsWith(`${rootPath}${path.sep}`)) {
+    throw new Error("context fetch path resolved outside the repository");
+  }
+  return { normalized, fullPath };
+}
+
+function parseLineRange(raw) {
+  const match = String(raw || "").trim().match(/^(\d+):(\d+)$/);
+  if (!match) {
+    throw new Error("context fetch --lines requires A:B line range");
+  }
+  const startLine = Number(match[1]);
+  const endLine = Number(match[2]);
+  if (!Number.isInteger(startLine) || !Number.isInteger(endLine) || startLine < 1 || endLine < startLine) {
+    throw new Error("context fetch --lines requires a valid ascending A:B range");
+  }
+  const boundedEnd = Math.min(endLine, startLine + MAX_FETCH_LINES - 1);
+  return {
+    startLine,
+    endLine: boundedEnd,
+    requestedEndLine: endLine,
+    truncated: boundedEnd < endLine,
+  };
+}
+
+function rankedRefs(searchResult) {
+  const refs = [];
+  const groups = [
+    ["semantic_symbols", 500],
+    ["semantic_surfaces", 450],
+    ["symbols", 400],
+    ["files", 300],
+    ["modules", 200],
+  ];
+  for (const [key, baseRank] of groups) {
+    const items = searchResult[key] || [];
+    for (let index = 0; index < items.length; index += 1) {
+      const item = items[index];
+      refs.push({
+        rank: baseRank - index,
+        type: key.replace(/^semantic_/, "semantic-").replace(/s$/, ""),
+        path: item.file_path || item.path || item.root_path || item.doc_path || null,
+        name: item.name || item.display_name || item.id || item.surface_key || null,
+        kind: item.kind || item.stack || null,
+        ref: item,
+      });
+    }
+  }
+  return refs.sort((left, right) => {
+    const rankDelta = right.rank - left.rank;
+    if (rankDelta !== 0) return rankDelta;
+    return String(left.path || left.name || "").localeCompare(String(right.path || right.name || ""));
+  });
+}
+
+export async function searchContext(root, term, options = {}) {
+  const query = String(term || "").trim();
+  if (!query || query === "true") {
+    throw new Error("context search requires a search term");
+  }
+  const db = openIndexDatabase(root, { readOnly: true });
+  try {
+    const structural = searchIndex(db, query, options.limit || 20);
+    const semantic = searchSemanticIndex(db, query, options.limit || 20);
+    const result = {
+      command: "context search",
+      term: query,
+      refs: rankedRefs({ ...structural, ...semantic }),
+    };
+    return result;
+  } finally {
+    closeIndexDatabase(db);
+  }
+}
+
+function findSymbolRange(root, normalizedPath, symbol) {
+  const db = openIndexDatabase(root, { readOnly: true });
+  try {
+    const semantic = db.prepare(`
+      SELECT name, display_name, kind, start_line, end_line
+      FROM semantic_symbols
+      WHERE file_path = ?
+        AND (name = ? OR display_name = ? OR export_name = ?)
+      ORDER BY
+        CASE WHEN name = ? THEN 0 ELSE 1 END,
+        start_line
+      LIMIT 1
+    `).get(normalizedPath, symbol, symbol, symbol, symbol);
+    if (semantic) {
+      return {
+        symbol: semantic.name,
+        display_name: semantic.display_name,
+        kind: semantic.kind,
+        startLine: semantic.start_line,
+        endLine: semantic.end_line,
+      };
+    }
+
+    const structural = db.prepare(`
+      SELECT name, kind, start_line, end_line
+      FROM symbols
+      WHERE file_path = ?
+        AND name = ?
+      ORDER BY start_line
+      LIMIT 1
+    `).get(normalizedPath, symbol);
+    if (structural) {
+      return {
+        symbol: structural.name,
+        display_name: structural.name,
+        kind: structural.kind,
+        startLine: structural.start_line,
+        endLine: structural.end_line,
+      };
+    }
+  } finally {
+    closeIndexDatabase(db);
+  }
+  return null;
+}
+
+function renderSlice(lines, startLine, endLine) {
+  return lines
+    .slice(startLine - 1, endLine)
+    .map((line, index) => `${String(startLine + index).padStart(4, " ")}: ${line}`)
+    .join("\n");
+}
+
+export async function fetchContext(root, filePath, options = {}) {
+  const { normalized, fullPath } = resolveRepoPath(root, filePath);
+  let range;
+  let symbol = null;
+  if (options.symbol) {
+    const symbolName = String(options.symbol).trim();
+    if (!symbolName || symbolName === "true") {
+      throw new Error("context fetch --symbol requires a symbol name");
+    }
+    symbol = findSymbolRange(root, normalized, symbolName);
+    if (!symbol) {
+      throw new Error(`context fetch could not find symbol "${symbolName}" in ${normalized}`);
+    }
+    const endLine = Math.max(symbol.startLine, symbol.endLine || symbol.startLine);
+    range = {
+      startLine: symbol.startLine,
+      endLine: Math.min(endLine, symbol.startLine + MAX_FETCH_LINES - 1),
+      requestedEndLine: endLine,
+      truncated: endLine > symbol.startLine + MAX_FETCH_LINES - 1,
+    };
+  } else if (options.lines) {
+    range = parseLineRange(options.lines);
+  } else {
+    throw new Error("context fetch requires --lines A:B or --symbol <name>");
+  }
+
+  const text = await fs.readFile(fullPath, "utf8");
+  const lines = text.split(/\r?\n/);
+  const totalLines = lines.length;
+  const startLine = Math.min(range.startLine, totalLines);
+  const endLine = Math.min(range.endLine, totalLines);
+
+  return {
+    command: "context fetch",
+    path: normalized,
+    start_line: startLine,
+    end_line: endLine,
+    requested_end_line: range.requestedEndLine,
+    total_lines: totalLines,
+    truncated: range.truncated || range.endLine > totalLines,
+    symbol,
+    content: renderSlice(lines, startLine, endLine),
+  };
+}
+
+export function normalizeContextMode(value) {
+  const mode = String(value || "direct").trim().toLowerCase();
+  if (mode === "direct" || mode === "routed") {
+    return mode;
+  }
+  throw new Error("--context-mode must be direct or routed");
+}
+
+export function buildRoutedPrompt(basePrompt, memoryMarkdown = "", options = {}) {
+  const task = String(basePrompt || "").trim();
+  const sections = [
+    "You are running in Agentify routed context mode.",
+    "",
+    "Context routing rules:",
+    "- Start from repo docs and DB refs: AGENTIFY.md, docs/repo-map.md, docs/modules/, and .agents/index.db.",
+    "- No full source file bodies are injected by default.",
+    "- For more repository context, use only these bounded Agentify commands:",
+    "  - agentify context search <term>",
+    "  - agentify context fetch <path> --lines A:B",
+    "  - agentify context fetch <path> --symbol X",
+    "  - agentify context compact --session <id>",
+    "  - agentify context status --session <id>",
+    "- Do not use nested agentify scan/doc/up/query commands or direct SQLite reads for context routing.",
+  ];
+  if (memoryMarkdown.trim()) {
+    sections.push("", memoryMarkdown.trim());
+  }
+  sections.push("", `Task: ${task}`);
+  return sections.join("\n");
+}
+

--- a/src/core/session-memory.js
+++ b/src/core/session-memory.js
@@ -746,6 +746,8 @@ export function getSessionArtifactPaths(root, sessionId) {
     handoffMarkdownPath: path.join(sessionDir, "handoff.md"),
     launchesPath: path.join(sessionDir, "launches.jsonl"),
     turnsPath: path.join(sessionDir, "turns.jsonl"),
+    contextFactsPath: path.join(sessionDir, "context-facts.json"),
+    contextFactsMarkdownPath: path.join(sessionDir, "context-facts.md"),
     rawInteractiveLogPath: path.join(sessionDir, "interactive.log"),
     contextPath: path.join(sessionDir, "context.json"),
   };
@@ -817,6 +819,94 @@ function buildRollingSummary(history) {
     ? `Last exit: ${latest.exit_code}, validation ${latest.validation || "not-run"}`
     : null;
   return [task, status, summary].filter(Boolean).join("\n");
+}
+
+async function readJsonLines(filePath) {
+  if (!(await exists(filePath))) {
+    return [];
+  }
+  const raw = await fs.readFile(filePath, "utf8");
+  const rows = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    try {
+      rows.push(JSON.parse(trimmed));
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return rows;
+}
+
+function renderContextFactsMarkdown(facts) {
+  const tasks = facts.recent_tasks.length
+    ? facts.recent_tasks.map((task) => `- ${task}`).join("\n")
+    : "- none";
+  return `# Context Facts
+
+Session: ${facts.session_id}
+Turns: ${facts.event_counts.turns}
+Launches: ${facts.event_counts.launches}
+Latest phase: ${facts.latest_phase || "none"}
+Latest exit code: ${facts.latest_exit_code ?? "none"}
+Latest validation: ${facts.latest_validation || "none"}
+
+## Recent Tasks
+${tasks}
+`;
+}
+
+export async function compactSessionContext(root, sessionId, config = {}) {
+  const paths = getSessionArtifactPaths(root, sessionId);
+  if (!(await exists(paths.contextPath))) {
+    throw new Error(`Session ${sessionId} does not have context.json`);
+  }
+
+  const [context, turns, launches] = await Promise.all([
+    readJson(paths.contextPath),
+    readJsonLines(paths.turnsPath),
+    readJsonLines(paths.launchesPath),
+  ]);
+  const latestLaunch = launches.at(-1) || null;
+  const summaryBytes = getSessionMemoryLimit(config, "runSummaryMaxBytes", 256);
+  const recentTasks = turns
+    .filter((turn) => turn.turn_type === "task" && turn.content)
+    .slice(-5)
+    .map((turn) => clipToBytes(turn.content, summaryBytes));
+  const facts = {
+    schema_version: "1.0",
+    session_id: sessionId,
+    event_counts: {
+      turns: turns.length,
+      launches: launches.length,
+    },
+    latest_task: recentTasks.at(-1) || "",
+    latest_phase: latestLaunch?.phase || null,
+    latest_exit_code: latestLaunch?.exit_code ?? null,
+    latest_validation: latestLaunch?.validation || null,
+    recent_tasks: recentTasks,
+    source_paths: {
+      turns: relative(root, paths.turnsPath),
+      launches: relative(root, paths.launchesPath),
+      context: relative(root, paths.contextPath),
+    },
+  };
+
+  context.context_facts = facts;
+  await writeJson(paths.contextPath, context);
+  await writeJson(paths.contextFactsPath, facts);
+  if (config?.session?.emitMarkdownArtifacts !== false) {
+    await writeText(paths.contextFactsMarkdownPath, renderContextFactsMarkdown(facts));
+  }
+  return {
+    session_id: sessionId,
+    facts_path: relative(root, paths.contextFactsPath),
+    markdown_path: config?.session?.emitMarkdownArtifacts === false ? null : relative(root, paths.contextFactsMarkdownPath),
+    facts,
+  };
 }
 
 export async function appendRunSummary(root, sessionId, entry, config) {
@@ -1026,4 +1116,5 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
     phase,
     memory_backend: sessionRecord.memoryContext?.backend || "none",
   }, config);
+  await compactSessionContext(root, sessionRecord.sessionId, config);
 }

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -136,6 +136,8 @@ function fitContext(manifest, index, checklist, options, config) {
   const launchesRef = options.root ? `.agents/session/${manifest.session_id}/launches.jsonl` : memoryArtifacts.launchesPath;
   const rawInteractiveLogRef = options.root ? `.agents/session/${manifest.session_id}/interactive.log` : memoryArtifacts.rawInteractiveLogPath;
   const turnsRef = options.root ? `.agents/session/${manifest.session_id}/turns.jsonl` : memoryArtifacts.turnsPath;
+  const contextFactsRef = options.root ? `.agents/session/${manifest.session_id}/context-facts.json` : memoryArtifacts.contextFactsPath;
+  const contextFactsMarkdownRef = options.root ? `.agents/session/${manifest.session_id}/context-facts.md` : memoryArtifacts.contextFactsMarkdownPath;
   const attempts = [
     { moduleLimit: moduleIds.length, checklistLimit: checklist.length, checklistTextBytes: 240, parentSummaryBytes: 2048, runHistoryLimit: 10, runSummaryBytes: 256, rollingSummaryBytes: 1024 },
     { moduleLimit: 64, checklistLimit: 20, checklistTextBytes: 180, parentSummaryBytes: 1024, runHistoryLimit: 6, runSummaryBytes: 180, rollingSummaryBytes: 512 },
@@ -166,6 +168,8 @@ function fitContext(manifest, index, checklist, options, config) {
       launches: launchesRef,
       raw_interactive_log: rawInteractiveLogRef,
       turns: turnsRef,
+      context_facts: contextFactsRef,
+      context_facts_markdown: contextFactsMarkdownRef,
     };
     const candidate = {
       schema_version: "1.0",
@@ -334,6 +338,8 @@ export async function forkSession(root, config, options = {}) {
       `.agents/session/${sessionId}/bootstrap.md`,
       `.agents/session/${sessionId}/transcript.md`,
       `.agents/session/${sessionId}/memory-context.md`,
+      `.agents/session/${sessionId}/context-facts.json`,
+      `.agents/session/${sessionId}/context-facts.md`,
       `.agents/session/${sessionId}/interactive.log`,
     ],
     metadata: {
@@ -348,12 +354,14 @@ export async function forkSession(root, config, options = {}) {
         "launches.jsonl",
         "turns.jsonl",
         "handoff.json",
+        "context-facts.json",
       ],
       optional_markdown_artifacts: [
         "bootstrap.md",
         "transcript.md",
         "memory-context.md",
         "handoff.md",
+        "context-facts.md",
         "interactive.log",
       ],
     },
@@ -455,4 +463,48 @@ export async function resumeSession(root, sessionId) {
 
 export function resolveSessionProvider(manifest, fallback = "local") {
   return manifest?.provider || manifest?.tool || fallback;
+}
+
+export async function maybePrepareChildSession(root, config, parentSessionId, options = {}) {
+  const thresholdKb = Number(config?.session?.prepareChildAboveKb ?? config?.session?.childContextThresholdKb ?? 0);
+  if (!Number.isFinite(thresholdKb) || thresholdKb <= 0) {
+    return null;
+  }
+
+  const parentDir = resolveSessionDirSafely(root, parentSessionId, "parent session id");
+  const contextPath = path.join(parentDir, "context.json");
+  if (!(await exists(contextPath))) {
+    return null;
+  }
+
+  const contextText = await fs.readFile(contextPath, "utf8");
+  const contextBytes = bytes(contextText);
+  if (contextBytes <= thresholdKb * 1024) {
+    return null;
+  }
+
+  const child = await forkSession(root, config, {
+    from: parentSessionId,
+    provider: options.provider || null,
+    name: options.name ? `${options.name} child` : `child of ${parentSessionId}`,
+  });
+  const parentManifestPath = path.join(parentDir, "session-manifest.json");
+  const parentManifest = await readJson(parentManifestPath);
+  parentManifest.prepared_child_session = {
+    session_id: child.sessionId,
+    reason: "context-threshold",
+    context_bytes: contextBytes,
+    threshold_bytes: thresholdKb * 1024,
+    resume_command: `agentify sess resume --session ${child.sessionId}`,
+  };
+  await writeJson(parentManifestPath, parentManifest);
+
+  return {
+    parent_session_id: parentSessionId,
+    child_session_id: child.sessionId,
+    child_session_dir: child.sessionDir,
+    context_bytes: contextBytes,
+    threshold_bytes: thresholdKb * 1024,
+    resume_command: `agentify sess resume --session ${child.sessionId}`,
+  };
 }

--- a/src/core/toolchain.js
+++ b/src/core/toolchain.js
@@ -1,4 +1,6 @@
 import { execFile } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
 import { promisify } from "node:util";
 
 import { closeIndexDatabase, openIndexDatabase } from "./db/connection.js";
@@ -39,6 +41,10 @@ function getConfiguredToolCommand(name, spec = {}) {
 }
 
 async function resolveToolCommand(command) {
+  if (command.includes("/") || command.includes("\\")) {
+    await fs.access(command, fsConstants.X_OK);
+    return command;
+  }
   const { stdout } = await execFileAsync("sh", ["-lc", 'command -v -- "$0"', command]);
   return stdout.trim() || command;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import { ensureBaselineArtifacts, runDoc, runScan, runUpdate, runValidate } from
 import { runExec } from "./core/exec.js";
 import { writeHandoffBundle } from "./core/handoff.js";
 import { installHooks, removeHooks, statusHooks } from "./core/hooks.js";
+import { buildRoutedPrompt, fetchContext, normalizeContextMode, searchContext } from "./core/context.js";
 import {
   queryCallers,
   queryChanged,
@@ -19,8 +20,8 @@ import {
 } from "./core/query.js";
 import { buildRiskReport, renderRiskReport } from "./core/risk.js";
 import { buildExecutionPlan, renderPlanExplanation } from "./core/planner.js";
-import { forkSession, listSessions, resolveSessionProvider, resumeSession, validateSessionId } from "./core/session.js";
-import { loadAutomaticRunMemory, loadAutomaticSessionMemory } from "./core/session-memory.js";
+import { forkSession, listSessions, maybePrepareChildSession, resolveSessionProvider, resumeSession, validateSessionId } from "./core/session.js";
+import { compactSessionContext, loadAutomaticRunMemory, loadAutomaticSessionMemory } from "./core/session-memory.js";
 import { runDoctor } from "./core/toolchain.js";
 import { garbageCollect, cacheStatus } from "./core/cache.js";
 import { runClean } from "./core/cleanup.js";
@@ -190,6 +191,10 @@ function buildRunPrompt(userPrompt) {
   return "Continue implementation in this repository using small, validated changes.";
 }
 
+function buildRoutedExecutionPrompt(task, memoryMarkdown = "", options = {}) {
+  return applyCavemanPreamble(buildRoutedPrompt(task, memoryMarkdown), options.caveman, { promptKind: options.promptKind });
+}
+
 export function buildExecutionPrompt(basePrompt, memoryMarkdown = "", options = {}) {
   const prompt = String(basePrompt || "").trim();
   const promptWithMemory = [memoryMarkdown.trim(), prompt].filter(Boolean).join("\n\n");
@@ -231,7 +236,10 @@ export async function prepareSessionLaunch(root, config, args, sessionResult, ta
   const usingTemplateCommand = !args._exec?.length;
   const providerOptions = getProviderTemplateOptions(args, root, provider, usingTemplateCommand);
   const captureSettings = getSessionCaptureSettings(usingTemplateCommand, providerOptions);
-  const prompt = buildSessionPrompt(sessionResult.bootstrap, task, memoryContext.markdown, { caveman });
+  const contextMode = hasOwn(args, "contextMode") ? normalizeContextMode(args.contextMode) : "direct";
+  const prompt = contextMode === "routed"
+    ? buildRoutedExecutionPrompt(`${task || DEFAULT_SESSION_TASK}\n\nSession bootstrap:\n${sessionResult.bootstrap.trim()}`, memoryContext.markdown, { caveman })
+    : buildSessionPrompt(sessionResult.bootstrap, task, memoryContext.markdown, { caveman });
   const agentCommand = args._exec?.length
     ? args._exec
     : buildProviderTemplateCommand(
@@ -247,6 +255,7 @@ export async function prepareSessionLaunch(root, config, args, sessionResult, ta
     command: agentCommand,
     memoryContext,
     captureMode: captureSettings.captureMode,
+    contextMode,
   };
 
   return {
@@ -277,6 +286,17 @@ function resolveSessionIdForResume(args) {
   throw new Error("sess resume requires --session <id> or sess resume <id>");
 }
 
+async function maybePrintPreparedChild(root, config, launch) {
+  const child = await maybePrepareChildSession(root, config, launch.sessionRecord.sessionId, {
+    provider: launch.provider,
+  });
+  if (child && !config.json) {
+    success(`Prepared child session: ${child.child_session_id}`);
+    log(`Resume: ${dim(child.resume_command)}`);
+  }
+  return child;
+}
+
 function printHelp() {
   const c = (s) => bold(cyan(s));
   const d = (s) => dim(s);
@@ -295,6 +315,7 @@ function printHelp() {
     `    ${c("run")}             ${d("Run provider template command with auto-refresh")}`,
     `    ${c("exec")}            ${d("Advanced wrapper for custom agent commands")}`,
     `    ${c("this")}            ${d("Bootstrap this macOS repo for a provider-backed Agentify workflow")}`,
+    `    ${c("context")}         ${d("Search, fetch, compact, and inspect routed context")}`,
     `    ${c("query")}           ${d("Query the repository index (owner, deps, changed, def, refs, callers, impacts)")}`,
     `    ${c("risk")}            ${d("Score PR blast radius and recommend regression tests")}`,
     `    ${c("skill")}           ${d("Manage built-in agent skills")}`,
@@ -324,6 +345,7 @@ function printHelp() {
     `    ${c("--explain")}                   Include planner score breakdowns for plan output`,
     `    ${c("--interactive")}, ${c("-i")}       Force interactive mode (template providers default to interactive for run/sess)`,
     `    ${c("--with-context")}              Inject planner-selected files, tests, and memory into run`,
+    `    ${c("--context-mode")} ${d("<direct|routed>")}     Use routed context retrieval for run/sess prompts`,
     `    ${c("--explain-plan")}              Print planner output before executing run`,
     `    ${c("--caveman[=level]")}            Terse output for run/sess (lite, full, ultra, wenyan*)`,
     `    ${c("--root")} ${d("<path>")}               Target repo root (default: cwd)`,
@@ -540,19 +562,22 @@ export async function runCli(argv) {
       case "run": {
         const task = buildRunPrompt(getPromptFromArgs(args, 1));
         const caveman = resolveCavemanLevel(args);
+        const contextMode = hasOwn(args, "contextMode") ? normalizeContextMode(args.contextMode) : "direct";
         const usingTemplateCommand = !args._exec?.length;
         const providerOptions = getProviderTemplateOptions(args, root, config.provider, usingTemplateCommand);
-        const richContext = usingTemplateCommand && (providerOptions.interactive !== true || args.withContext === true || args.explainPlan === true);
+        const richContext = contextMode === "routed" || (usingTemplateCommand && (providerOptions.interactive !== true || args.withContext === true || args.explainPlan === true));
         const memoryContext = richContext
           ? await loadAutomaticRunMemory(root, task, config)
           : { markdown: "" };
-        const plan = richContext
+        const plan = richContext && contextMode !== "routed"
           ? await buildExecutionPlan(root, config, task)
           : null;
         if (args.explainPlan && plan) {
           console.log(JSON.stringify(plan, null, 2));
         }
-        const prompt = richContext
+        const prompt = contextMode === "routed"
+          ? buildRoutedExecutionPrompt(task, memoryContext.markdown, { caveman })
+          : richContext
           ? buildExecutionPrompt(plan?.prompt || task, memoryContext.markdown, { caveman })
           : buildMinimalRunPrompt(task, { caveman });
         const agentCommand = args._exec?.length
@@ -567,6 +592,54 @@ export async function runCli(argv) {
           commandName: "run",
           skipCodeBodyChanges: true,
         }));
+        return;
+      }
+
+      case "context": {
+        let result;
+        try {
+          if (subcommand === "search") {
+            const term = args.term || getPromptFromArgs(args, 2);
+            result = await searchContext(root, term);
+          } else if (subcommand === "fetch") {
+            const target = args._[2] || args.file || args.path;
+            if (!target) {
+              throw new Error("context fetch requires <path>");
+            }
+            result = await fetchContext(root, target, {
+              lines: args.lines,
+              symbol: args.symbol,
+            });
+          } else if (subcommand === "compact") {
+            if (!args.session) {
+              throw new Error("context compact requires --session <id>");
+            }
+            result = await compactSessionContext(root, validateSessionId(String(args.session), "--session id"), config);
+          } else if (subcommand === "status") {
+            if (!args.session) {
+              throw new Error("context status requires --session <id>");
+            }
+            const sessionId = validateSessionId(String(args.session), "--session id");
+            const session = await resumeSession(root, sessionId);
+            result = {
+              command: "context status",
+              session_id: sessionId,
+              provider: resolveSessionProvider(session.manifest, null),
+              context_bytes: Buffer.byteLength(JSON.stringify(session.context, null, 2), "utf8"),
+              run_history_count: Array.isArray(session.context.run_history) ? session.context.run_history.length : 0,
+              has_context_facts: Boolean(session.context.context_facts),
+              prepared_child_session: session.manifest.prepared_child_session || null,
+            };
+          } else {
+            throw new Error("context requires a subcommand: search, fetch, compact, or status");
+          }
+        } catch (error) {
+          if (isMissingIndexError(error)) {
+            throw createMissingIndexGuidance(root);
+          }
+          throw error;
+        }
+        console.log(JSON.stringify(result, null, 2));
         return;
       }
 
@@ -807,6 +880,7 @@ export async function runCli(argv) {
           }
 
           await runExec(root, launch.runExecConfig, launch.agentCommand, launch.runExecFlags);
+          await maybePrintPreparedChild(root, config, launch);
           return;
         }
 
@@ -817,6 +891,7 @@ export async function runCli(argv) {
           const launch = await prepareSessionLaunch(root, config, args, result, task);
 
           await runExec(root, launch.runExecConfig, launch.agentCommand, launch.runExecFlags);
+          await maybePrintPreparedChild(root, config, launch);
           return;
         }
 
@@ -853,6 +928,7 @@ export async function runCli(argv) {
           }
 
           await runExec(root, launch.runExecConfig, launch.agentCommand, launch.runExecFlags);
+          await maybePrintPreparedChild(root, config, launch);
           return;
         }
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -7,6 +7,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 import { CAVEMAN_PREAMBLE_MARKER, resolveCavemanLevel } from "../src/core/caveman.js";
+import { forkSession as forkContextSession } from "../src/core/session.js";
 import { buildExecutionPrompt, buildMinimalRunPrompt, buildSessionPrompt, getProviderTemplateOptions, getSessionCaptureSettings, parseArgs, prepareSessionLaunch, runCli } from "../src/main.js";
 
 const execFileAsync = promisify(execFile);
@@ -396,6 +397,128 @@ test("runCli passes planner context to interactive codex run when requested", as
   assert.match(prompt, /Planner summary/);
   assert.match(prompt, /Selected file slices/);
   assert.match(prompt, /Task:\nImplement login retries/);
+});
+
+test("runCli passes routed context prompt to codex run", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-run-routed-"));
+  const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-run-routed-bin-"));
+  const capturePath = path.join(root, "codex-argv.json");
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, "src", "login.js"), "export function login() { return true; }\n", "utf8");
+  await initGitRepo(root);
+  await installFakeCodex(binDir, capturePath);
+
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${binDir}${path.delimiter}${previousPath || ""}`;
+  try {
+    await runCli([
+      "run",
+      "--root",
+      root,
+      "--provider",
+      "codex",
+      "--context-mode",
+      "routed",
+      "--skip-refresh",
+      "Implement login retries",
+    ]);
+  } finally {
+    process.env.PATH = previousPath;
+  }
+
+  const argv = JSON.parse(await fs.readFile(capturePath, "utf8"));
+  const prompt = argv.at(-1);
+  assert.match(prompt, /Agentify routed context mode/);
+  assert.match(prompt, /agentify context search <term>/);
+  assert.match(prompt, /No full source file bodies are injected/);
+  assert.doesNotMatch(prompt, /Selected file slices/);
+});
+
+test("runCli passes routed context prompt to codex sess run and compacts facts", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-sess-routed-"));
+  const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-sess-routed-bin-"));
+  const capturePath = path.join(root, "codex-argv.json");
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await initGitRepo(root);
+  await installFakeCodex(binDir, capturePath);
+
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${binDir}${path.delimiter}${previousPath || ""}`;
+  try {
+    await runCli([
+      "sess",
+      "run",
+      "--root",
+      root,
+      "--provider",
+      "codex",
+      "--interactive=false",
+      "--context-mode",
+      "routed",
+      "--skip-refresh",
+      "--name",
+      "routed-session",
+      "Continue checkout work",
+    ]);
+  } finally {
+    process.env.PATH = previousPath;
+  }
+
+  const argv = JSON.parse(await fs.readFile(capturePath, "utf8"));
+  const prompt = argv.at(-1);
+  assert.match(prompt, /Agentify routed context mode/);
+  assert.match(prompt, /Session bootstrap:/);
+  assert.match(prompt, /agentify context fetch <path> --symbol X/);
+
+  const sessionsRoot = path.join(root, ".agents", "session");
+  const entries = await fs.readdir(sessionsRoot);
+  assert.equal(entries.length, 1);
+  const facts = JSON.parse(await fs.readFile(path.join(sessionsRoot, entries[0], "context-facts.json"), "utf8"));
+  assert.equal(facts.event_counts.launches, 1);
+  assert.equal(facts.latest_task, "Continue checkout work");
+});
+
+test("runCli context commands search, fetch, compact, and status", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-context-cmd-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, "src", "login.js"), [
+    "export function login() {",
+    "  return true;",
+    "}",
+    "",
+  ].join("\n"), "utf8");
+  await initGitRepo(root);
+  await runCli(["scan", "--root", root]);
+
+  const output = [];
+  const originalLog = console.log;
+  console.log = (...args) => {
+    output.push(args.join(" "));
+  };
+  try {
+    await runCli(["context", "search", "login", "--root", root]);
+    await runCli(["context", "fetch", "src/login.js", "--lines", "1:2", "--root", root]);
+    const config = { provider: "codex", session: { emitMarkdownArtifacts: true } };
+    const created = await forkContextSession(root, config, { name: "context commands" });
+    await fs.appendFile(path.join(created.sessionDir, "turns.jsonl"), `${JSON.stringify({
+      turn_type: "task",
+      content: "Index login context",
+    })}\n`, "utf8");
+    await runCli(["context", "compact", "--session", created.sessionId, "--root", root]);
+    await runCli(["context", "status", "--session", created.sessionId, "--root", root]);
+  } finally {
+    console.log = originalLog;
+  }
+
+  const [search, fetch, compact, status] = output.map((line) => JSON.parse(line));
+  assert.equal(search.command, "context search");
+  assert.ok(search.refs.some((ref) => ref.path === "src/login.js"));
+  assert.equal(fetch.command, "context fetch");
+  assert.match(fetch.content, /1: export function login/);
+  assert.equal(compact.facts.latest_task, "Index login context");
+  assert.equal(status.has_context_facts, true);
 });
 
 test("runCli supports skill install with provider all", async () => {

--- a/test/session-structured.test.js
+++ b/test/session-structured.test.js
@@ -9,6 +9,7 @@ import { promisify } from "node:util";
 import { loadConfig } from "../src/core/config.js";
 import {
   forkSession,
+  maybePrepareChildSession,
   resumeSession,
   synthesizeBootstrapFromContext,
 } from "../src/core/session.js";
@@ -156,6 +157,38 @@ test("forkSession inherits run_history and rolling_summary from parent", async (
   assert.equal(child.context.run_history.length, 1);
   assert.equal(child.context.run_history[0].task, "investigate refresh bug");
   assert.match(child.context.rolling_summary, /refresh bug fixed/);
+});
+
+test("maybePrepareChildSession creates child above context threshold without launching provider", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-child-threshold-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex" });
+  config.session.prepareChildAboveKb = 0.001;
+  const parent = await forkSession(root, config, { name: "parent" });
+  await appendRunSummary(root, parent.sessionId, {
+    started_at: "p-start",
+    ended_at: "p-end",
+    task: "large context handoff",
+    assistant_summary: "prepare child session without launching provider",
+    exit_code: 0,
+    validation: "passed",
+    phase: "complete",
+    memory_backend: "structured-lineage",
+  }, config);
+
+  const result = await maybePrepareChildSession(root, config, parent.sessionId, { provider: "codex" });
+  assert.ok(result.child_session_id.startsWith("sess_"));
+  assert.match(result.resume_command, new RegExp(result.child_session_id));
+
+  const childManifest = JSON.parse(await fs.readFile(
+    path.join(root, ".agents", "session", result.child_session_id, "session-manifest.json"),
+    "utf8"
+  ));
+  assert.equal(childManifest.parent_id, parent.sessionId);
+  const parentManifest = JSON.parse(await fs.readFile(path.join(parent.sessionDir, "session-manifest.json"), "utf8"));
+  assert.equal(parentManifest.prepared_child_session.session_id, result.child_session_id);
 });
 
 test("loadAutomaticSessionMemory prefers structured lineage over transcript replay", async () => {


### PR DESCRIPTION
## Summary
- add routed context prompts for run/sess via --context-mode routed
- add agentify context search/fetch/compact/status commands for bounded retrieval and session compaction
- compact session facts after managed runs and prepare child sessions when configured context threshold is exceeded
- harden configured tool detection for absolute/relative MemPalace command paths

## Verification
- npm test: 254 passed, 1 skipped
- npm test -- test/main.test.js: 42 passed
- npm test -- test/session.test.js: 13 passed, 1 skipped

Fixes #143