### PR TITLE
chore: add context config and event schema

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -37,6 +37,15 @@ const DEFAULT_CONFIG = {
     maxAgeDays: 7,
     maxSizeMb: 100,
   },
+  context: {
+    mode: "compact",
+    routedDefaultProvider: null,
+    compactAfterRun: true,
+    autoPrepareChildAboveKb: 96,
+    maxFetchBytes: 12000,
+    maxSearchResults: 12,
+    allowProviderSummary: true,
+  },
   cleanup: {
     keepRuns: 20,
     maxRunAgeDays: 14,
@@ -209,6 +218,7 @@ export async function writeDefaultConfig(root, config, { dryRun = false } = {}) 
     toolchain: config.toolchain,
     hooks: normalizeConfig(config).hooks,
     cache: config.cache,
+    context: config.context,
     cleanup: config.cleanup,
     session: config.session,
     planner: config.planner,

--- a/src/core/context-events.js
+++ b/src/core/context-events.js
@@ -1,0 +1,86 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { ensureDir, exists } from "./fs.js";
+import { checkSchema, SCHEMA_VERSIONS } from "./schema.js";
+
+const CONTEXT_RUNTIME_ID_PATTERN = /^[A-Za-z0-9_.-]+$/;
+
+function assertRuntimeId(value, label) {
+  if (typeof value !== "string" || value.length === 0 || value.length > 160 || !CONTEXT_RUNTIME_ID_PATTERN.test(value)) {
+    throw new Error(`Invalid ${label}`);
+  }
+  return value;
+}
+
+function normalizeTextField(value, label) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Context event ${label} is required`);
+  }
+  return value;
+}
+
+function normalizeConfidence(value) {
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue) || numberValue < 0 || numberValue > 1) {
+    throw new Error("Context event confidence must be a number between 0 and 1");
+  }
+  return numberValue;
+}
+
+export function getContextEventLogPath(root, options = {}) {
+  if (options.sessionId) {
+    const sessionId = assertRuntimeId(options.sessionId, "session id");
+    return path.join(root, ".agents", "session", sessionId, "context-events.jsonl");
+  }
+
+  const runId = assertRuntimeId(options.runId, "run id");
+  return path.join(root, ".agentify", "work", "context-events", `${runId}.jsonl`);
+}
+
+export function createContextEventRecord(event, options = {}) {
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    throw new Error("Context event must be an object");
+  }
+
+  return {
+    schema_version: SCHEMA_VERSIONS.CONTEXT_EVENT,
+    run_id: assertRuntimeId(normalizeTextField(event.run_id ?? event.runId, "run id"), "run id"),
+    path: normalizeTextField(event.path, "path"),
+    event_type: normalizeTextField(event.event_type ?? event.eventType, "event type"),
+    source: normalizeTextField(event.source, "source"),
+    hash: normalizeTextField(event.hash, "hash"),
+    summary: typeof event.summary === "string" ? event.summary : "",
+    confidence: normalizeConfidence(event.confidence),
+    created_at: options.now || event.created_at || event.createdAt || new Date().toISOString(),
+  };
+}
+
+export function checkContextEventSchema(record) {
+  return checkSchema(record, SCHEMA_VERSIONS.CONTEXT_EVENT);
+}
+
+export async function appendContextEvent(root, event, options = {}) {
+  const record = createContextEventRecord(event, options);
+  const targetPath = getContextEventLogPath(root, {
+    sessionId: options.sessionId,
+    runId: options.runId || record.run_id,
+  });
+  await ensureDir(path.dirname(targetPath));
+  await fs.appendFile(targetPath, `${JSON.stringify(record)}\n`, "utf8");
+  return { path: targetPath, record };
+}
+
+export async function readContextEvents(root, options = {}) {
+  const targetPath = getContextEventLogPath(root, options);
+  if (!(await exists(targetPath))) {
+    return [];
+  }
+
+  const raw = await fs.readFile(targetPath, "utf8");
+  return raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}

--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -3,6 +3,7 @@ export const SCHEMA_VERSIONS = {
   MODULE_METADATA: "1.1",
   SESSION: "1.0",
   CACHE: "1.0",
+  CONTEXT_EVENT: "1.0",
 };
 
 export function checkSchema(artifact, expectedVersion) {

--- a/src/core/session-memory.js
+++ b/src/core/session-memory.js
@@ -746,6 +746,7 @@ export function getSessionArtifactPaths(root, sessionId) {
     handoffMarkdownPath: path.join(sessionDir, "handoff.md"),
     launchesPath: path.join(sessionDir, "launches.jsonl"),
     turnsPath: path.join(sessionDir, "turns.jsonl"),
+    contextEventsPath: path.join(sessionDir, "context-events.jsonl"),
     rawInteractiveLogPath: path.join(sessionDir, "interactive.log"),
     contextPath: path.join(sessionDir, "context.json"),
   };

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -329,6 +329,7 @@ export async function forkSession(root, config, options = {}) {
       `.agents/session/${sessionId}/checklist.json`,
       `.agents/session/${sessionId}/launches.jsonl`,
       `.agents/session/${sessionId}/turns.jsonl`,
+      `.agents/session/${sessionId}/context-events.jsonl`,
       `.agents/session/${sessionId}/handoff.json`,
       `.agents/session/${sessionId}/handoff.md`,
       `.agents/session/${sessionId}/bootstrap.md`,
@@ -347,6 +348,7 @@ export async function forkSession(root, config, options = {}) {
         "checklist.json",
         "launches.jsonl",
         "turns.jsonl",
+        "context-events.jsonl",
         "handoff.json",
       ],
       optional_markdown_artifacts: [

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -62,6 +62,50 @@ test("loadConfig applies planner execution budget overrides", async () => {
   assert.equal(config.planner.editAfterSelectedContextUnlessBlocked, false);
 });
 
+test("loadConfig provides context orchestration defaults", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-config-context-defaults-"));
+
+  const config = await loadConfig(root);
+
+  assert.deepEqual(config.context, {
+    mode: "compact",
+    routedDefaultProvider: null,
+    compactAfterRun: true,
+    autoPrepareChildAboveKb: 96,
+    maxFetchBytes: 12000,
+    maxSearchResults: 12,
+    allowProviderSummary: true,
+  });
+});
+
+test("loadConfig applies nested context file and flag overrides", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-config-context-overrides-"));
+  await fs.writeFile(
+    path.join(root, ".agentify.yaml"),
+    [
+      "context:",
+      "  routedDefaultProvider: codex",
+      "  maxFetchBytes: 8000",
+      "  allowProviderSummary: false",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const config = await loadConfig(root, {
+    "context.mode": "routed",
+    "context.max-search-results": 5,
+    "context.auto-prepare-child-above-kb": 128,
+  });
+
+  assert.equal(config.context.mode, "routed");
+  assert.equal(config.context.routedDefaultProvider, "codex");
+  assert.equal(config.context.maxFetchBytes, 8000);
+  assert.equal(config.context.maxSearchResults, 5);
+  assert.equal(config.context.autoPrepareChildAboveKb, 128);
+  assert.equal(config.context.allowProviderSummary, false);
+});
+
 test("hook config drops deprecated autoRefresh setting", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-config-hooks-"));
   await fs.writeFile(

--- a/test/context-events.test.js
+++ b/test/context-events.test.js
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  appendContextEvent,
+  checkContextEventSchema,
+  createContextEventRecord,
+  getContextEventLogPath,
+  readContextEvents,
+} from "../src/core/context-events.js";
+import { SCHEMA_VERSIONS } from "../src/core/schema.js";
+
+test("createContextEventRecord normalizes the context event schema", () => {
+  const record = createContextEventRecord({
+    runId: "run_1",
+    path: "src/core/config.js",
+    eventType: "fetch",
+    source: "local-index",
+    hash: "sha256:abc123",
+    summary: "Config defaults were loaded.",
+    confidence: 0.91,
+  }, { now: "2026-05-04T00:00:00.000Z" });
+
+  assert.deepEqual(record, {
+    schema_version: SCHEMA_VERSIONS.CONTEXT_EVENT,
+    run_id: "run_1",
+    path: "src/core/config.js",
+    event_type: "fetch",
+    source: "local-index",
+    hash: "sha256:abc123",
+    summary: "Config defaults were loaded.",
+    confidence: 0.91,
+    created_at: "2026-05-04T00:00:00.000Z",
+  });
+  assert.deepEqual(checkContextEventSchema(record), { compatible: true, needsMigration: false });
+});
+
+test("context event schema rejects incompatible major versions", () => {
+  const result = checkContextEventSchema({ schema_version: "2.0" });
+
+  assert.equal(result.compatible, false);
+  assert.match(result.reason, /Major version mismatch/);
+});
+
+test("appendContextEvent persists session events under ignored session artifacts", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-context-events-session-"));
+
+  const result = await appendContextEvent(root, {
+    run_id: "run_2",
+    path: "src/core/session.js",
+    event_type: "compact",
+    source: "provider-summary",
+    hash: "sha256:def456",
+    summary: "Session context was compacted.",
+    confidence: 0.8,
+  }, {
+    sessionId: "sess_context",
+    now: "2026-05-04T01:00:00.000Z",
+  });
+
+  assert.equal(result.path, path.join(root, ".agents", "session", "sess_context", "context-events.jsonl"));
+  const raw = await fs.readFile(result.path, "utf8");
+  assert.equal(raw.trim().split(/\r?\n/).length, 1);
+
+  const events = await readContextEvents(root, { sessionId: "sess_context" });
+  assert.equal(events.length, 1);
+  assert.equal(events[0].event_type, "compact");
+  assert.equal(events[0].run_id, "run_2");
+});
+
+test("appendContextEvent persists run events under ignored Agentify work artifacts", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-context-events-run-"));
+
+  const result = await appendContextEvent(root, {
+    run_id: "run_3",
+    path: "docs/repo-map.md",
+    event_type: "search",
+    source: "local-search",
+    hash: "sha256:ghi789",
+    summary: "",
+    confidence: 1,
+  });
+
+  assert.equal(result.path, getContextEventLogPath(root, { runId: "run_3" }));
+  assert.equal(path.relative(root, result.path).split(path.sep).join("/"), ".agentify/work/context-events/run_3.jsonl");
+});

--- a/test/session-structured.test.js
+++ b/test/session-structured.test.js
@@ -49,6 +49,8 @@ test("forkSession initializes structured run_history and rolling_summary in cont
   assert.equal(result.context.rolling_summary, "");
   assert.ok(result.context.cache_refs.turns.endsWith("turns.jsonl"));
   assert.ok(result.manifest.metadata.runtime_artifacts.includes("turns.jsonl"));
+  assert.ok(result.manifest.cache_refs.some((item) => item.endsWith("context-events.jsonl")));
+  assert.ok(result.manifest.metadata.runtime_artifacts.includes("context-events.jsonl"));
   assert.ok(result.manifest.metadata.optional_markdown_artifacts.includes("bootstrap.md"));
 });
 


### PR DESCRIPTION
## Summary
- add default context orchestration config with nested override coverage
- add versioned local context event JSONL schema and persistence helpers
- expose context-events.jsonl as a session runtime artifact while keeping paths under existing ignored Agentify runtime directories

Closes https://github.com/ixigo/agentify/issues/140

## Verification
- npm test -- test/config.test.js test/context-events.test.js test/session-structured.test.js
- npm test -- test/main.test.js
- npm test