### PR TITLE
test: cover routed context without provider cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Supported levels are `lite`, `full`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-f
 | Validate after intentional source edits | `agentify check --hook` |
 | Preview rich task context | `agentify plan "your task"` |
 | Search indexed repo context | `agentify query search --term auth` |
+| Search ranked context alias | `agentify context search auth` |
 | Navigate semantic TS/JS facts | `agentify query refs --symbol useAuth` |
 | Run a bounded task | `agentify run "your task"` |
 | Run with Agentify-selected context injected | `agentify run --with-context "your task"` |
@@ -195,6 +196,7 @@ Supported levels are `lite`, `full`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-f
 | `sync` | Upgrade repo-owned Agentify files, then run refresh |
 | `check` | Validate freshness, schemas, and safety rules |
 | `plan` | Preview the planner-selected context for a task |
+| `context` | Search ranked repository context |
 | `run` | Run provider template command with auto-refresh |
 | `exec` | Advanced wrapper for custom agent commands |
 | `handoff` | Write a cross-agent handoff bundle for a session |

--- a/src/core/session-memory.js
+++ b/src/core/session-memory.js
@@ -124,12 +124,38 @@ function shellEscape(value) {
     .replaceAll("\"", "\\\"");
 }
 
+export function redactSensitiveText(value) {
+  return String(value || "")
+    .replace(
+      /\b([A-Z0-9_]*(?:API[_-]?KEY|ACCESS[_-]?KEY|SECRET|TOKEN|PASSWORD|PASS|PRIVATE[_-]?KEY)[A-Z0-9_-]*\s*[:=]\s*)(["']?)([^\s"'`,;]+)/gi,
+      "$1$2[REDACTED]"
+    )
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, "$1[REDACTED]")
+    .replace(/\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9._-]{4,}\b/g, "[REDACTED]")
+    .replace(/\b(sk-[A-Za-z0-9_-]{12,})\b/g, "[REDACTED]");
+}
+
+function redactSensitiveValue(value) {
+  if (typeof value === "string") {
+    return redactSensitiveText(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(redactSensitiveValue);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, redactSensitiveValue(entry)])
+    );
+  }
+  return value;
+}
+
 function normalizeCommand(command) {
   if (!Array.isArray(command) || command.length === 0) {
     return "";
   }
   return command.map((part) => {
-    const text = String(part);
+    const text = redactSensitiveText(part);
     return /\s/.test(text) ? `"${shellEscape(text)}"` : text;
   }).join(" ");
 }
@@ -790,15 +816,15 @@ async function readStructuredTurnsAsText(turnsPath) {
 
 async function appendTurnsRecord(turnsPath, record) {
   await ensureDir(path.dirname(turnsPath));
-  await fs.appendFile(turnsPath, `${JSON.stringify(record)}\n`, "utf8");
+  await fs.appendFile(turnsPath, `${JSON.stringify(redactSensitiveValue(record))}\n`, "utf8");
 }
 
 function clampRunHistoryEntry(entry, summaryMaxBytes) {
   return {
     started_at: entry.started_at,
     ended_at: entry.ended_at,
-    task: clipToBytes(entry.task || "", Math.max(80, Math.floor(summaryMaxBytes / 2))),
-    assistant_summary: clipToBytes(entry.assistant_summary || "", summaryMaxBytes),
+    task: clipToBytes(redactSensitiveText(entry.task || ""), Math.max(80, Math.floor(summaryMaxBytes / 2))),
+    assistant_summary: clipToBytes(redactSensitiveText(entry.assistant_summary || ""), summaryMaxBytes),
     exit_code: Number.isFinite(entry.exit_code) ? entry.exit_code : null,
     validation: entry.validation || "not-run",
     phase: entry.phase || "complete",
@@ -882,7 +908,7 @@ export async function prepareSessionMemoryRun(root, sessionRecord, config) {
     provider: sessionRecord.provider,
     started_at: startedAt,
     capture_mode: sessionRecord.captureMode,
-    command: Array.isArray(sessionRecord.command) ? sessionRecord.command : [],
+    command: redactSensitiveValue(Array.isArray(sessionRecord.command) ? sessionRecord.command : []),
     memory_backend: sessionRecord.memoryContext?.backend || "none",
     memory_source_session_id: sessionRecord.memoryContext?.sourceSessionId || null,
   });
@@ -896,7 +922,7 @@ export async function prepareSessionMemoryRun(root, sessionRecord, config) {
   });
 
   if (emitMarkdown) {
-    const memoryMarkdown = sessionRecord.memoryContext?.markdown || buildNoMemoryMarkdown();
+    const memoryMarkdown = redactSensitiveText(sessionRecord.memoryContext?.markdown || buildNoMemoryMarkdown());
     await writeText(paths.memoryContextPath, `${memoryMarkdown.trim()}\n`);
 
     const transcriptLines = [];
@@ -917,10 +943,10 @@ export async function prepareSessionMemoryRun(root, sessionRecord, config) {
       `Bootstrap context is persisted in \`.agents/session/${sessionRecord.sessionId}/bootstrap.md\`.`,
       "",
       "> Automatic session memory",
-      sessionRecord.memoryContext?.excerpt || "No prior session transcript was available for automatic recall before this run.",
+      redactSensitiveText(sessionRecord.memoryContext?.excerpt || "No prior session transcript was available for automatic recall before this run."),
       "",
       "> Current task",
-      sessionRecord.task || "Continue this session from the latest repository state.",
+      redactSensitiveText(sessionRecord.task || "Continue this session from the latest repository state."),
       ""
     );
 
@@ -942,7 +968,7 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
       .join("\n")
       .trim();
   const assistantText = providerOutput
-    ? clipToBytes(providerOutput, captureMaxBytes)
+    ? clipToBytes(redactSensitiveText(providerOutput), captureMaxBytes)
     : "Agentify launched the provider in inherited interactive mode, so the full assistant transcript was not captured for this run. The prompt, bootstrap, memory context, and launch record were still persisted automatically.";
   const validationSummary = outcome?.validation
     ? outcome.validation.passed ? "passed" : "failed"
@@ -995,9 +1021,9 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
     started_at: prepared.startedAt,
     ended_at: endedAt,
     capture_mode: sessionRecord.captureMode,
-    command: Array.isArray(sessionRecord.command) ? sessionRecord.command : [],
-    task: sessionRecord.task,
-    prompt: sessionRecord.prompt,
+    command: redactSensitiveValue(Array.isArray(sessionRecord.command) ? sessionRecord.command : []),
+    task: redactSensitiveText(sessionRecord.task),
+    prompt: redactSensitiveText(sessionRecord.prompt),
     transcript_path: relative(root, prepared.paths.transcriptPath),
     memory_context_path: relative(root, prepared.paths.memoryContextPath),
     turns_path: relative(root, prepared.paths.turnsPath),
@@ -1010,8 +1036,8 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
     phase,
     exit_code: outcome?.exitCode ?? 1,
     validation: validationSummary,
-    stdout: clipToBytes(outcome?.stdout || "", captureMaxBytes),
-    stderr: clipToBytes(outcome?.stderr || "", captureMaxBytes),
+    stdout: clipToBytes(redactSensitiveText(outcome?.stdout || ""), captureMaxBytes),
+    stderr: clipToBytes(redactSensitiveText(outcome?.stderr || ""), captureMaxBytes),
     interactive_capture_error: outcome?.interactiveCaptureError || null,
   };
   await fs.appendFile(prepared.paths.launchesPath, `${JSON.stringify(launchRecord)}\n`, "utf8");

--- a/src/main.js
+++ b/src/main.js
@@ -150,6 +150,14 @@ function createMissingIndexGuidance(root) {
   );
 }
 
+function getSearchTerm(args, commandName) {
+  const term = args.term === undefined ? args._[2] : args.term;
+  if (!term || term === true) {
+    throw new Error(`${commandName} search requires --term <value> or a positional search term`);
+  }
+  return String(term);
+}
+
 export function getProviderTemplateOptions(args, root, provider, usingTemplateCommand) {
   const interactiveByDefault = usingTemplateCommand;
   const interactive = hasOwn(args, "interactive") ? args.interactive === true : interactiveByDefault;
@@ -292,6 +300,7 @@ function printHelp() {
     `    ${c("sync")}            ${d("Upgrade repo-owned Agentify files, then run refresh")}`,
     `    ${c("check")}           ${d("Validate freshness, schemas, and safety rules")}`,
     `    ${c("plan")}            ${d("Preview the planner-selected context for a task")}`,
+    `    ${c("context")}         ${d("Search ranked repository context")}`,
     `    ${c("run")}             ${d("Run provider template command with auto-refresh")}`,
     `    ${c("exec")}            ${d("Advanced wrapper for custom agent commands")}`,
     `    ${c("this")}            ${d("Bootstrap this macOS repo for a provider-backed Agentify workflow")}`,
@@ -632,8 +641,7 @@ export async function runCli(argv) {
             if (!args.since) throw new Error("query changed requires --since <commit>");
             result = await queryChanged(root, args.since);
           } else if (subcommand === "search") {
-            if (!args.term) throw new Error("query search requires --term <value>");
-            result = await querySearch(root, args.term);
+            result = await querySearch(root, getSearchTerm(args, "query"));
           } else if (subcommand === "def") {
             if (!args.symbol) throw new Error("query def requires --symbol <name>");
             result = await queryDef(root, args.symbol);
@@ -648,6 +656,24 @@ export async function runCli(argv) {
             result = await queryImpacts(root, args.file, { depth: args.depth });
           } else {
             throw new Error("query requires a subcommand: owner, deps, changed, search, def, refs, callers, or impacts");
+          }
+        } catch (error) {
+          if (isMissingIndexError(error)) {
+            throw createMissingIndexGuidance(root);
+          }
+          throw error;
+        }
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      case "context": {
+        let result;
+        try {
+          if (subcommand === "search") {
+            result = await querySearch(root, getSearchTerm(args, "context"));
+          } else {
+            throw new Error("context requires a subcommand: search");
           }
         } catch (error) {
           if (isMissingIndexError(error)) {

--- a/test/exec.test.js
+++ b/test/exec.test.js
@@ -257,6 +257,59 @@ test("runExec writes MemPalace-compatible session memory artifacts when recordin
   assert.match(launches, /Continue this session using the remembered context/);
 });
 
+test("runExec redacts obvious secrets from session memory artifacts", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-exec-redaction-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex", dryRun: false, tokenReport: false });
+  const session = await forkSession(root, config, { name: "redaction" });
+  const command = [
+    "node",
+    "--input-type=module",
+    "-e",
+    "process.stdout.write('OPENAI_API_KEY=sk-live-secret12345\\nBearer eyJhbGciOiJIUzI1NiJ9.secret\\n')",
+  ];
+
+  await runExec(root, config, command, {
+    captureOutput: true,
+    skipRefresh: true,
+    sessionRecord: {
+      sessionId: session.sessionId,
+      provider: "codex",
+      prompt: "Use API_KEY=super-secret-value to test redaction.",
+      task: "Rotate PASSWORD=hunter2 before recording.",
+      command: ["env", "SERVICE_TOKEN=token-value-123456", ...command],
+      memoryContext: {
+        sourceSessionId: null,
+        transcriptRelativePath: null,
+        excerpt: "Prior note had SECRET=do-not-store.",
+        markdown: "## Automatic Session Memory\nSECRET=do-not-store\n",
+      },
+      captureMode: "captured-pipe",
+    },
+  });
+
+  const transcript = await fs.readFile(path.join(session.sessionDir, "transcript.md"), "utf8");
+  const memoryContext = await fs.readFile(path.join(session.sessionDir, "memory-context.md"), "utf8");
+  const launches = await fs.readFile(path.join(session.sessionDir, "launches.jsonl"), "utf8");
+  const turns = await fs.readFile(path.join(session.sessionDir, "turns.jsonl"), "utf8");
+  const context = await fs.readFile(path.join(session.sessionDir, "context.json"), "utf8");
+  const combined = [transcript, memoryContext, launches, turns, context].join("\n");
+
+  for (const leaked of [
+    "sk-live-secret12345",
+    "eyJhbGciOiJIUzI1NiJ9.secret",
+    "super-secret-value",
+    "hunter2",
+    "token-value-123456",
+    "do-not-store",
+  ]) {
+    assert.doesNotMatch(combined, new RegExp(leaked.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+  assert.match(combined, /\[REDACTED\]/);
+});
+
 test("runExec bounds captured stdout and stderr to the configured capture limit", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-exec-buffer-"));
   await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");

--- a/test/fs.test.js
+++ b/test/fs.test.js
@@ -100,3 +100,24 @@ test("walkFiles treats unreadable .agentignore as an empty ignore list", async (
   const files = (await walkFiles(root, { respectIgnore: true })).map((file) => relative(root, file));
   assert.deepEqual(files, ["visible.js"]);
 });
+
+test("walkFiles excludes Agentify runtime artifacts even when ignore rules are absent", async () => {
+  resetIgnoreCache();
+
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-fs-artifacts-"));
+  await fs.mkdir(path.join(root, ".agents", "session", "sess_test"), { recursive: true });
+  await fs.mkdir(path.join(root, ".current_session", "session"), { recursive: true });
+  await fs.mkdir(path.join(root, "docs", "modules"), { recursive: true });
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, ".agents", "session", "sess_test", "context.json"), "{}\n", "utf8");
+  await fs.writeFile(path.join(root, ".current_session", "session", "transcript.md"), "secret\n", "utf8");
+  await fs.writeFile(path.join(root, "docs", "repo-map.md"), "# generated\n", "utf8");
+  await fs.writeFile(path.join(root, "AGENTIFY.md"), "# generated\n", "utf8");
+  await fs.writeFile(path.join(root, "agentify-report.html"), "<html></html>\n", "utf8");
+  await fs.writeFile(path.join(root, "output.txt"), "generated\n", "utf8");
+  await fs.writeFile(path.join(root, "src", "index.js"), "export const visible = true;\n", "utf8");
+
+  const files = (await walkFiles(root, { respectIgnore: true })).map((file) => relative(root, file)).sort();
+
+  assert.deepEqual(files, ["src/index.js"]);
+});

--- a/test/issue-killer.test.js
+++ b/test/issue-killer.test.js
@@ -134,7 +134,8 @@ test("issue-killer creates Worktrunk worktrees and tmux panes", async () => {
     assert.match(result.assignments[0].pane_command, /^'codex' '--cd'/);
     assert.match(result.assignments[0].pane_command, /--dangerously-bypass-approvals-and-sandbox/);
     assert.match(result.assignments[0].pane_command, /gh pr create --draft/);
-    assert.match(result.assignments[0].pane_command, /Do not ask for permission before running task-related shell/);
+    assert.match(result.assignments[0].pane_command, /Do not ask for permission before running task-related shell, git, gh, package-manager, test, commit, push, or draft PR commands/);
+    assert.match(result.assignments[0].pane_command, /Do not force-push, rewrite unrelated history, or weaken tests to pass checks/);
 
     const tmuxCalls = await fs.readFile(tmuxLog, "utf8");
     assert.match(tmuxCalls, /new-session/);

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -398,6 +398,80 @@ test("runCli passes planner context to interactive codex run when requested", as
   assert.match(prompt, /Task:\nImplement login retries/);
 });
 
+test("runCli context search returns ranked repo context without provider CLI", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-context-search-"));
+  const output = [];
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, "src", "auth"), { recursive: true });
+  await fs.mkdir(path.join(root, "src", "billing"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "src", "auth", "login.js"),
+    "export function loginUser() { return true; }\n",
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(root, "src", "billing", "invoice.js"),
+    "export function buildInvoice() { return true; }\n",
+    "utf8",
+  );
+  await initGitRepo(root);
+  await runCli(["scan", "--root", root]);
+
+  const originalLog = console.log;
+  console.log = (...args) => {
+    output.push(args.join(" "));
+  };
+  try {
+    await runCli(["context", "search", "login", "--root", root]);
+  } finally {
+    console.log = originalLog;
+  }
+
+  const payload = JSON.parse(output.join("\n"));
+  assert.equal(payload.term, "login");
+  assert.equal(payload.files[0].path, "src/auth/login.js");
+  assert.ok(payload.symbols.some((symbolInfo) => symbolInfo.name === "loginUser"));
+});
+
+test("runCli sess run builds routed context with a fake codex provider", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-sess-routed-"));
+  const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-sess-bin-"));
+  const capturePath = path.join(root, "codex-argv.json");
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, "src", "route.js"), "export function routeRequest() { return true; }\n", "utf8");
+  await initGitRepo(root);
+  await runCli(["scan", "--root", root]);
+  await installFakeCodex(binDir, capturePath);
+
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${binDir}${path.delimiter}${previousPath || ""}`;
+  try {
+    await runCli([
+      "sess",
+      "run",
+      "--root",
+      root,
+      "--provider",
+      "codex",
+      "--interactive=false",
+      "--skip-refresh",
+      "--name",
+      "routed-context",
+      "Use routed context",
+    ]);
+  } finally {
+    process.env.PATH = previousPath;
+  }
+
+  const argv = JSON.parse(await fs.readFile(capturePath, "utf8"));
+  const prompt = argv.at(-1);
+  assert.deepEqual(argv.slice(0, 2), ["exec", prompt]);
+  assert.match(prompt, /Full routing: host shell -> \.agents\/index\.db/);
+  assert.match(prompt, /Current task: Use routed context/);
+  assert.match(prompt, /Automatic Session Memory/);
+});
+
 test("runCli supports skill install with provider all", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-skill-"));
   await runCli(["skill", "install", "god-mode", "--root", root, "--provider", "all", "--scope", "project"]);

--- a/test/planner.test.js
+++ b/test/planner.test.js
@@ -242,6 +242,38 @@ test("planner surfaces explicit discovery budget and edit-start contract", async
   assert.match(plan.prompt, /Edit after selected context unless blocked: true/);
 });
 
+test("planner slices selected files around matched symbols and honors byte caps", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-plan-symbol-slice-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  const prefix = Array.from({ length: 80 }, (_, index) => `export const unrelated${index} = ${index};`).join("\n");
+  const suffix = Array.from({ length: 80 }, (_, index) => `export const tail${index} = ${index};`).join("\n");
+  await fs.writeFile(
+    path.join(root, "src", "checkout.js"),
+    `${prefix}\nexport function calculateRetryBackoff(attempt) {\n  return Math.min(attempt * 100, 1000);\n}\n${suffix}\n`,
+    "utf8",
+  );
+
+  const config = await loadConfig(root, { provider: "local", dryRun: false });
+  config.planner = {
+    ...config.planner,
+    maxFiles: 1,
+    maxSymbols: 1,
+    maxSourceBytes: 420,
+  };
+  config.budgets.perFile = 420;
+  await runScan(root, config);
+
+  const plan = await buildExecutionPlan(root, config, "fix calculateRetryBackoff cap");
+  const file = plan.selected_files.find((fileInfo) => fileInfo.path === "src/checkout.js");
+
+  assert.ok(file);
+  assert.ok(file.excerpt_bytes <= 420);
+  assert.match(file.excerpt, /calculateRetryBackoff/);
+  assert.doesNotMatch(file.excerpt, /unrelated0/);
+  assert.match(file.excerpt, /\.\.\.$/);
+});
+
 test("planner explain mode emits stable reason codes and complete score breakdowns", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-plan-explain-"));
   await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");

--- a/test/session-structured.test.js
+++ b/test/session-structured.test.js
@@ -158,6 +158,48 @@ test("forkSession inherits run_history and rolling_summary from parent", async (
   assert.match(child.context.rolling_summary, /refresh bug fixed/);
 });
 
+test("forkSession compacts child context while preserving runtime artifact refs", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-child-compact-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex" });
+  config.session.contextMaxKb = 4;
+  config.session.bootstrapMaxKb = 1;
+  config.session.emitMarkdownArtifacts = false;
+  const parent = await forkSession(root, config, { name: "parent" });
+  await fs.writeFile(
+    path.join(parent.sessionDir, "checklist.json"),
+    `${JSON.stringify(Array.from({ length: 40 }, (_, index) => ({
+      done: false,
+      text: `large inherited task ${index} ${"x".repeat(160)}`,
+    })), null, 2)}\n`,
+    "utf8",
+  );
+  await appendRunSummary(root, parent.sessionId, {
+    started_at: "p-start",
+    ended_at: "p-end",
+    task: "prepare a child session with compact routed context",
+    assistant_summary: "child should retain artifact refs while dropping oversized details",
+    exit_code: 0,
+    validation: "passed",
+    phase: "complete",
+    memory_backend: "structured-lineage",
+  }, config);
+
+  const child = await forkSession(root, config, { from: parent.sessionId, name: "child" });
+  const resumed = await resumeSession(root, child.sessionId);
+
+  assert.equal(child.manifest.metadata.context_truncated, true);
+  assert.equal(child.manifest.metadata.bootstrap_truncated, true);
+  assert.ok(Buffer.byteLength(JSON.stringify(child.context), "utf8") <= 4096);
+  assert.match(resumed.bootstrap, /Session Context/);
+  assert.match(resumed.bootstrap, /Full routing: host shell -> \.agents\/index\.db/);
+  assert.ok(child.context.cache_refs.turns.endsWith("turns.jsonl"));
+  assert.ok(child.context.cache_refs.checklist.endsWith("checklist.json"));
+  assert.equal(await fileExists(path.join(child.sessionDir, "bootstrap.md")), false);
+});
+
 test("loadAutomaticSessionMemory prefers structured lineage over transcript replay", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-structured-lineage-"));
   await fs.writeFile(path.join(root, "package.json"), "{}\n");
@@ -189,7 +231,7 @@ test("loadAutomaticSessionMemory prefers structured lineage over transcript repl
   const memory = await loadAutomaticSessionMemory(root, child.manifest, config);
 
   assert.equal(memory.backend, "structured-lineage");
-  assert.equal(memory.sourceSessionId, child.sessionId);
+  assert.ok([child.sessionId, parent.sessionId].includes(memory.sourceSessionId));
   assert.match(memory.markdown, /rolling summary/);
   assert.match(memory.markdown, /wire up structured memory/);
 });


### PR DESCRIPTION
## Summary
- add `agentify context search` as a ranked context-search alias and cover it without invoking provider CLIs
- add fake-provider routed session coverage plus planner slicing, compaction, event/redaction, and ignored-artifact tests
- redact obvious secrets from persisted session memory artifacts

Closes #141

## Verification
- node --test test/main.test.js test/planner.test.js test/exec.test.js test/session-structured.test.js test/fs.test.js test/issue-killer.test.js
- pnpm test