### PR TITLE
ci: run node test suite

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,0 +1,35 @@
+name: Node tests
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: npm test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Node test suite
+        run: npm test


### PR DESCRIPTION
## Summary
- Add a dedicated Node tests GitHub Actions workflow for pull requests and pushes to main.
- Use Node 20 with pnpm lockfile installation, then run `npm test`.
- Keep Pages deployment separate from routine test validation.

Closes #158

## Validation
- `CI=true npx pnpm@9 install --frozen-lockfile`
- `node --input-type=module -e "import fs from 'node:fs'; import YAML from 'yaml'; YAML.parse(fs.readFileSync('.github/workflows/node-tests.yml', 'utf8')); console.log('workflow yaml parsed')"`\n- `git diff --cached --check`\n- `npm test` fails with the known baseline failures from #153 and #154: `test/session.test.js:190`, `test/skills.test.js:53`, and `test/skills.test.js:281`.\n\n## Notes\nThis PR intentionally does not fix the existing red test baseline because #158 is scoped to exercising the suite in GitHub Actions.