### PR TITLE
fix: register jira built-in skill

### DIFF
--- a/src/core/skills.js
+++ b/src/core/skills.js
@@ -84,6 +84,12 @@ const BUILTIN_SKILLS = [
       "Launch opted-in GitHub issues into supervised tmux panes, each with its own Worktrunk worktree and Codex or Claude agent prompt running with provider permission checks bypassed for draft PR creation.",
   },
   {
+    name: "jira",
+    aliases: [],
+    description:
+      "Manage Jira work items through Atlassian CLI `acli`, including picking up assigned tickets, daily to-do triage, transitioning statuses, editing summaries/descriptions/assignees/labels, updating the current ticket, and creating new Jira tasks or bugs.",
+  },
+  {
     name: "migrate-to-shoehorn",
     aliases: [],
     description:

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -66,6 +66,7 @@ test("listBuiltinSkills exposes built-in catalog and alias", async () => {
   assert.deepEqual(resolveBuiltinSkill("worktree-verifier").name, "worktree-autopilot");
   assert.deepEqual(resolveBuiltinSkill("gh-issue-autopilot").name, "gh-autopilot");
   assert.deepEqual(resolveBuiltinSkill("gh-issue-killer").name, "issue-killer");
+  assert.deepEqual(resolveBuiltinSkill("jira").name, "jira");
 });
 
 test("resolveSkillInstallTargets expands provider all for project scope", () => {


### PR DESCRIPTION
## Summary
- add the shipped jira skill to the hard-coded built-in skill registry
- add a direct resolveBuiltinSkill("jira") assertion alongside existing alias coverage

## Validation
- node --test test/skills.test.js: pass
- git diff --check: pass
- env -u AGENTIFY_MEMPALACE_CMD npm test: fails 1 unrelated session-memory assertion in test/session.test.js:225, where loadAutomaticSessionMemory reports strategy "mempalace" instead of "local-session-search"

Fixes #153