### PR TITLE
fix: respect gitignored traversal paths

### DIFF
--- a/src/core/fs.js
+++ b/src/core/fs.js
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -87,6 +88,49 @@ function isAgentIgnored(relativePath, patterns) {
   return patterns.some((p) => p.test(relativePath));
 }
 
+async function loadGitIgnored(root) {
+  return new Promise((resolve) => {
+    const child = spawn(
+      "git",
+      ["-C", root, "ls-files", "--others", "--ignored", "--exclude-standard", "--directory", "-z"],
+      { stdio: ["ignore", "pipe", "ignore"] },
+    );
+    const chunks = [];
+
+    child.stdout.on("data", (chunk) => chunks.push(chunk));
+    child.on("error", () => resolve(new Set()));
+    child.on("close", (code) => {
+      if (code !== 0) {
+        resolve(new Set());
+        return;
+      }
+      const ignored = Buffer.concat(chunks)
+        .toString("utf8")
+        .split("\0")
+        .filter(Boolean)
+        .map((ignoredPath) => ignoredPath.replace(/^\.\//, "").split(path.sep).join("/"));
+      resolve(new Set(ignored));
+    });
+  });
+}
+
+function isGitIgnored(relativePath, ignoredPaths) {
+  if (ignoredPaths.size === 0) {
+    return false;
+  }
+  if (ignoredPaths.has(relativePath) || ignoredPaths.has(relativePath.endsWith("/") ? relativePath : `${relativePath}/`)) {
+    return true;
+  }
+  let slashIndex = relativePath.indexOf("/");
+  while (slashIndex !== -1) {
+    if (ignoredPaths.has(`${relativePath.slice(0, slashIndex)}/`)) {
+      return true;
+    }
+    slashIndex = relativePath.indexOf("/", slashIndex + 1);
+  }
+  return false;
+}
+
 export function resetIgnoreCache() {
   ignorePatternCache.clear();
 }
@@ -119,6 +163,7 @@ export async function writeJson(targetPath, value) {
 export async function walkFiles(root, { respectIgnore = false } = {}) {
   const files = [];
   const ignorePatterns = respectIgnore ? await loadAgentignore(root) : [];
+  const gitIgnoredPaths = respectIgnore ? await loadGitIgnored(root) : new Set();
 
   async function visit(current) {
     const entries = await fs.readdir(current, { withFileTypes: true });
@@ -134,7 +179,12 @@ export async function walkFiles(root, { respectIgnore = false } = {}) {
         }
         if (respectIgnore) {
           const relDir = `${rel}/`;
-          if (isHardExcluded(relDir) || isAgentIgnored(rel, ignorePatterns) || isAgentIgnored(relDir, ignorePatterns)) {
+          if (
+            isHardExcluded(relDir) ||
+            isAgentIgnored(rel, ignorePatterns) ||
+            isAgentIgnored(relDir, ignorePatterns) ||
+            isGitIgnored(relDir, gitIgnoredPaths)
+          ) {
             continue;
           }
         }
@@ -142,7 +192,7 @@ export async function walkFiles(root, { respectIgnore = false } = {}) {
         continue;
       }
       if (respectIgnore) {
-        if (isHardExcluded(rel) || isAgentIgnored(rel, ignorePatterns)) {
+        if (isHardExcluded(rel) || isAgentIgnored(rel, ignorePatterns) || isGitIgnored(rel, gitIgnoredPaths)) {
           continue;
         }
       }

--- a/test/fs.test.js
+++ b/test/fs.test.js
@@ -3,8 +3,25 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { spawn } from "node:child_process";
 
 import { resetIgnoreCache, walkFiles, relative } from "../src/core/fs.js";
+
+async function runGit(root, args) {
+  await new Promise((resolve, reject) => {
+    const child = spawn("git", ["-C", root, ...args], { stdio: ["ignore", "ignore", "pipe"] });
+    const stderr = [];
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(Buffer.concat(stderr).toString("utf8") || `git ${args.join(" ")} exited with ${code}`));
+    });
+  });
+}
 
 test("walkFiles respects hard excludes and does not leak ignore cache across roots", async () => {
   resetIgnoreCache();
@@ -88,6 +105,22 @@ test("walkFiles picks up a newly created .agentignore within the same root", asy
 
   const after = (await walkFiles(root, { respectIgnore: true })).map((file) => relative(root, file));
   assert.deepEqual(after, [".agentignore"]);
+});
+
+test("walkFiles skips gitignored transient directories when respecting ignores", async () => {
+  resetIgnoreCache();
+
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-fs-gitignore-"));
+  await runGit(root, ["init"]);
+  await fs.writeFile(path.join(root, ".gitignore"), "*.tmp\n", "utf8");
+  await fs.mkdir(path.join(root, ".tmp", "e2e", "repos", "fixture"), { recursive: true });
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, ".tmp", "e2e", "repos", "fixture", "index.js"), "export const fixture = true;\n", "utf8");
+  await fs.writeFile(path.join(root, "src", "index.js"), "export const visible = true;\n", "utf8");
+
+  const files = (await walkFiles(root, { respectIgnore: true })).map((file) => relative(root, file)).sort();
+
+  assert.deepEqual(files, [".gitignore", "src/index.js"]);
 });
 
 test("walkFiles treats unreadable .agentignore as an empty ignore list", async () => {


### PR DESCRIPTION
## Summary
- load Git ignored paths once per respectful traversal using Git's exclude-standard rules
- skip Git ignored files/directories alongside existing hard excludes and .agentignore patterns
- add traversal coverage for a gitignored .tmp/e2e/repos fixture while keeping visible source files indexed

Fixes #152

## Validation
- node --test test/fs.test.js
- node --test test/fs.test.js test/indexer.test.js
- issue-specific .tmp probe: git check-ignore confirmed .tmp paths ignored; walkFiles reported walkTmp=0; buildRepositoryIndex reported indexTmp=0 and visibleIndexed=true
- npm test: 288 pass, 3 fail, 1 skipped; remaining failures appear unrelated to this change (automatic session memory selected mempalace instead of local-session-search; skill catalog expected missing jira built-in)