### PR TITLE
fix: time out project test commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Supported levels are `lite`, `full`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-f
 | Install optional built-in skills into the repo | `agentify skill install all --provider codex --scope project` |
 | Update Agentify-owned repo files after upgrading the CLI | `agentify sync` |
 
-> **Note** — `agentify up` runs the repo's detected test command in a **sanitized environment** by default. Agentify detects common JavaScript/TypeScript, Python, Go, Rust, .NET, Java/Kotlin, and Swift test commands; if a non-JS stack is detected but no runnable test command is known, the test phase reports `unsupported` instead of silently skipping. The host shell's environment is not forwarded to the test subprocess; configure `tests.env.passthrough` / `tests.env.extra` (or set `tests.env.inherit: true`) in `.agentify.yaml` if a test suite needs specific variables. See [docs/DETAILED_README.md](./docs/DETAILED_README.md#project-test-environment) for the allowlist and override schema.
+> **Note** — `agentify up` runs the repo's detected test command in a **sanitized environment** by default and enforces `tests.timeoutMs` to avoid hanging indefinitely. Agentify detects common JavaScript/TypeScript, Python, Go, Rust, .NET, Java/Kotlin, and Swift test commands; if a non-JS stack is detected but no runnable test command is known, the test phase reports `unsupported` instead of silently skipping. The host shell's environment is not forwarded to the test subprocess; configure `tests.env.passthrough` / `tests.env.extra` (or set `tests.env.inherit: true`) in `.agentify.yaml` if a test suite needs specific variables. See [docs/DETAILED_README.md](./docs/DETAILED_README.md#project-test-environment) for the allowlist and override schema.
 
 ## CLI Reference
 

--- a/docs/DETAILED_README.md
+++ b/docs/DETAILED_README.md
@@ -141,7 +141,7 @@ It is written so the model treats the current working directory as the target re
 
 #### Project Test Environment
 
-`agentify up` (and any flow that runs the detected project test command) executes the repo-owned test command in a **sanitized environment by default**. Agentify detects common JavaScript/TypeScript package scripts plus Python, Go, Rust, .NET, Java/Kotlin, and Swift project test commands. If a non-JS stack is detected but no runnable command is known, the test phase reports `unsupported` and exits non-zero instead of silently downgrading the run to a skipped test phase.
+`agentify up` (and any flow that runs the detected project test command) executes the repo-owned test command in a **sanitized environment by default** and enforces a wall-clock timeout. Agentify detects common JavaScript/TypeScript package scripts plus Python, Go, Rust, .NET, Java/Kotlin, and Swift project test commands. If a non-JS stack is detected but no runnable command is known, the test phase reports `unsupported` and exits non-zero instead of silently downgrading the run to a skipped test phase.
 
 The host shell's `process.env` is *not* passed through; instead Agentify constructs a minimal allowlist containing runtime essentials (`PATH`, `HOME`, `SHELL`, `USER`, `LOGNAME`, `PWD`, locale `LANG`/`LC_*`, terminal `TERM`/`COLORTERM`, temp dirs `TMPDIR`/`TEMP`/`TMP`, Node version-manager paths such as `NVM_DIR`/`VOLTA_HOME`, `XDG_*` paths, and the equivalent Windows essentials). This prevents repository-controlled test commands (e.g., `npm test`, `pnpm test`, `python3 -m unittest discover`, `go test ./...`) from reading credentials or other sensitive variables that may be exported in the invoking shell.
 
@@ -149,6 +149,7 @@ Configure overrides in `.agentify.yaml` under the `tests.env` key:
 
 ```yaml
 tests:
+  timeoutMs: 600000       # wall-clock timeout for the detected test command
   env:
     inherit: false        # set to true to forward the entire host environment (legacy behavior, not recommended)
     passthrough: []       # list of additional env var names to forward from the host shell

--- a/src/core/commands.js
+++ b/src/core/commands.js
@@ -170,7 +170,11 @@ function summarizeTestResult(testResult) {
     stdout_bytes: testResult.stdout_bytes ?? 0,
     stderr_bytes: testResult.stderr_bytes ?? 0,
     output_max_bytes: testResult.output_max_bytes ?? null,
-    exit_code: testResult.exit_code
+    exit_code: testResult.exit_code,
+    signal: testResult.signal ?? null,
+    timed_out: Boolean(testResult.timed_out),
+    timeout_ms: testResult.timeout_ms ?? null,
+    reason: testResult.reason ?? null,
   };
   if (testResult.discovery_error) {
     summary.discovery_error = testResult.discovery_error;

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -108,6 +108,7 @@ const DEFAULT_CONFIG = {
     },
   },
   tests: {
+    timeoutMs: 600000,
     outputMaxKb: 48,
     env: {
       inherit: false,

--- a/src/core/project-tests.js
+++ b/src/core/project-tests.js
@@ -5,6 +5,9 @@ import { createBoundedCaptureBuffer, DEFAULT_CAPTURE_MAX_KB, normalizeCaptureMax
 import { detectStacks } from "./detect.js";
 import { exists, readJson, relative, walkFiles } from "./fs.js";
 
+const DEFAULT_TEST_TIMEOUT_MS = 10 * 60 * 1000;
+const FORCE_KILL_TIMEOUT_MS = 1000;
+
 const DEFAULT_PASSTHROUGH_ENV = Object.freeze([
   "PATH",
   "HOME",
@@ -87,24 +90,80 @@ function getTestOutputMaxBytes(testsConfig = {}) {
   return normalizeCaptureMaxBytes(testsConfig.outputMaxKb, DEFAULT_CAPTURE_MAX_KB);
 }
 
-async function runChildCommand(command, args, { cwd, env, outputMaxBytes } = {}) {
+function getTestTimeoutMs(testsConfig = {}) {
+  const timeoutMs = Number(testsConfig.timeoutMs);
+  return Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_TEST_TIMEOUT_MS;
+}
+
+function killChildProcess(child, signal) {
+  if (process.platform !== "win32" && child.pid) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch (error) {
+      if (error?.code === "ESRCH") return;
+    }
+  }
+  try {
+    child.kill(signal);
+  } catch {
+    // The process may have exited between timeout scheduling and signal delivery.
+  }
+}
+
+async function runChildCommand(command, args, { cwd, env, outputMaxBytes, timeoutMs } = {}) {
   const stdoutCapture = createBoundedCaptureBuffer(outputMaxBytes);
   const stderrCapture = createBoundedCaptureBuffer(outputMaxBytes);
 
-  const code = await new Promise((resolve, reject) => {
-    const child = spawn(command, args, { cwd, env });
+  const outcome = await new Promise((resolve, reject) => {
+    let timedOut = false;
+    let timeout = null;
+    let killTimer = null;
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      detached: process.platform !== "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    function clearTimers() {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      if (killTimer) {
+        clearTimeout(killTimer);
+      }
+    }
+
+    timeout = setTimeout(() => {
+      timedOut = true;
+      killChildProcess(child, "SIGTERM");
+      killTimer = setTimeout(() => {
+        killChildProcess(child, "SIGKILL");
+      }, FORCE_KILL_TIMEOUT_MS);
+    }, timeoutMs);
+
     child.stdout.on("data", (chunk) => {
       stdoutCapture.append(chunk);
     });
     child.stderr.on("data", (chunk) => {
       stderrCapture.append(chunk);
     });
-    child.on("error", reject);
-    child.on("close", resolve);
+    child.on("error", (error) => {
+      clearTimers();
+      reject(error);
+    });
+    child.on("close", (code, signal) => {
+      clearTimers();
+      resolve({ code, signal, timedOut });
+    });
   });
 
   return {
-    code: Number(code ?? 1),
+    code: outcome.timedOut ? null : Number(outcome.code ?? 1),
+    signal: outcome.signal || null,
+    timedOut: outcome.timedOut,
+    timeoutMs,
     stdout: stdoutCapture.toString(),
     stderr: stderrCapture.toString(),
     stdoutTruncated: stdoutCapture.truncated,
@@ -327,6 +386,7 @@ async function buildNoTestCommandResult(root, options, outputMaxBytes) {
 export async function runProjectTests(root, reporter, options = {}) {
   const testsConfig = options.config?.tests || options.tests || {};
   const outputMaxBytes = getTestOutputMaxBytes(testsConfig);
+  const timeoutMs = getTestTimeoutMs(testsConfig);
   const testCommand = await detectTestCommand(root);
   if (testCommand?.error) {
     const result = {
@@ -356,7 +416,7 @@ export async function runProjectTests(root, reporter, options = {}) {
   if (testsConfig.env?.inherit !== true) {
     reporter.log("tests: subprocess env is sanitized; configure tests.env.passthrough or tests.env.extra to expose vars");
   }
-  const outcome = await runChildCommand(testCommand.command, testCommand.args, { cwd: root, env, outputMaxBytes });
+  const outcome = await runChildCommand(testCommand.command, testCommand.args, { cwd: root, env, outputMaxBytes, timeoutMs });
   if (outcome.stdoutTruncated) {
     reporter.log(`tests: stdout truncated to ${outcome.outputMaxBytes} bytes from ${outcome.stdoutBytes} bytes; configure tests.outputMaxKb to adjust`);
   }
@@ -369,10 +429,13 @@ export async function runProjectTests(root, reporter, options = {}) {
   if (outcome.stderr) {
     reporter.appendSection("[tests stderr]", outcome.stderr);
   }
+  if (outcome.timedOut) {
+    reporter.log(`tests: timed out after ${outcome.timeoutMs}ms; terminated subprocess`);
+  }
 
   const result = {
-    status: outcome.code === 0 ? "passed" : "failed",
-    passed: outcome.code === 0,
+    status: outcome.code === 0 && !outcome.timedOut ? "passed" : "failed",
+    passed: outcome.code === 0 && !outcome.timedOut,
     command: `${testCommand.command} ${testCommand.args.join(" ")}`,
     stdout: outcome.stdout,
     stderr: outcome.stderr,
@@ -382,7 +445,13 @@ export async function runProjectTests(root, reporter, options = {}) {
     stderr_bytes: outcome.stderrBytes,
     output_max_bytes: outcome.outputMaxBytes,
     exit_code: outcome.code,
+    signal: outcome.signal,
+    timed_out: outcome.timedOut,
+    timeout_ms: outcome.timeoutMs,
   };
+  if (outcome.timedOut) {
+    result.reason = "timeout";
+  }
   reporter.log(`tests: ${result.status}`);
   reporter.setTests(result);
   return result;

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -62,6 +62,14 @@ test("loadConfig applies planner execution budget overrides", async () => {
   assert.equal(config.planner.editAfterSelectedContextUnlessBlocked, false);
 });
 
+test("loadConfig provides project test timeout defaults", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-config-test-timeout-"));
+
+  const config = await loadConfig(root);
+
+  assert.equal(config.tests.timeoutMs, 600000);
+});
+
 test("loadConfig provides context orchestration defaults", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-config-context-defaults-"));
 

--- a/test/project-tests.test.js
+++ b/test/project-tests.test.js
@@ -306,3 +306,34 @@ test("runProjectTests bounds captured stdout and stderr and reports truncation",
   assert.equal(Buffer.byteLength(reporter.sections.find((section) => section.title === "[tests stdout]").body, "utf8"), 1024);
   assert.equal(Buffer.byteLength(reporter.sections.find((section) => section.title === "[tests stderr]").body, "utf8"), 1024);
 });
+
+test("runProjectTests times out a hanging test command", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-test-timeout-"));
+  const scriptPath = path.join(root, "hang.js");
+
+  await fs.writeFile(scriptPath, `
+    process.stdout.write("started");
+    setInterval(() => {}, 1000);
+  `);
+  await fs.writeFile(path.join(root, "package.json"), JSON.stringify({
+    name: "agentify-timeout",
+    scripts: { test: "node hang.js" },
+  }, null, 2));
+
+  const reporter = createReporter();
+  const started = Date.now();
+  const result = await runProjectTests(root, reporter, {
+    config: { tests: { timeoutMs: 75 } },
+  });
+  const durationMs = Date.now() - started;
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.passed, false);
+  assert.equal(result.exit_code, null);
+  assert.equal(result.timed_out, true);
+  assert.equal(result.timeout_ms, 75);
+  assert.equal(result.reason, "timeout");
+  assert.equal(reporter.tests, result);
+  assert.match(reporter.logs.join("\n"), /tests: timed out after 75ms; terminated subprocess/);
+  assert.ok(durationMs < 3000, `timeout test took ${durationMs}ms`);
+});


### PR DESCRIPTION
## Summary
- add a default `tests.timeoutMs` wall-clock timeout for detected project test commands
- terminate timed-out test subprocesses and return structured timeout metadata
- preserve timeout fields in `agentify up`/`sync` test payloads and document the config

Closes #156

## Tests
- `npm test -- test/project-tests.test.js test/config.test.js`
- `npm test -- test/update.test.js test/run-report.test.js`
- `git diff --check`

## Notes
- `npm test` was also run and still has unrelated existing failures in `test/session.test.js` and `test/skills.test.js` around session-memory selection and the built-in `jira` skill catalog entry.
