### PR TITLE
fix: avoid retaining raw PTY session logs

### DIFF
--- a/src/core/exec.js
+++ b/src/core/exec.js
@@ -6,7 +6,7 @@ import { getChangedFiles, getChangedFilesSince, getHeadCommit } from "./git.js";
 import { runScan, runDoc } from "./commands.js";
 import { createRunReporter } from "./run-report.js";
 import { validateRepo } from "./validate.js";
-import { finalizeSessionMemoryRun, normalizeInteractiveCapture, prepareSessionMemoryRun } from "./session-memory.js";
+import { finalizeSessionMemoryRun, normalizeInteractiveCapture, prepareSessionMemoryRun, redactSensitiveText } from "./session-memory.js";
 import { createBoundedCaptureBuffer, DEFAULT_CAPTURE_MAX_KB, normalizeCaptureMaxBytes } from "./capture-buffer.js";
 import * as ui from "./ui.js";
 
@@ -158,6 +158,20 @@ function buildScriptCommand(argv, capturePath) {
   };
 }
 
+async function removeRawInteractiveLog(capturePath, raw) {
+  try {
+    await fs.rm(capturePath, { force: true });
+    return "";
+  } catch (removeError) {
+    try {
+      await fs.writeFile(capturePath, redactSensitiveText(raw), "utf8");
+      return `Unable to remove PTY transcript log; redacted it in place instead: ${removeError.message}`;
+    } catch (redactError) {
+      return `Unable to remove PTY transcript log: ${removeError.message}; unable to redact it in place: ${redactError.message}`;
+    }
+  }
+}
+
 function getCaptureBufferMaxBytes(config) {
   return normalizeCaptureMaxBytes(config?.session?.captureMaxKb, DEFAULT_CAPTURE_MAX_KB);
 }
@@ -300,6 +314,7 @@ function runWrappedCommand(argv, options) {
         try {
           const raw = await fs.readFile(options.capturePath, "utf8");
           interactiveTranscript = normalizeInteractiveCapture(raw);
+          interactiveCaptureError = await removeRawInteractiveLog(options.capturePath, raw);
         } catch (error) {
           interactiveCaptureError = `Unable to read PTY transcript log: ${error.message}`;
         }
@@ -311,7 +326,7 @@ function runWrappedCommand(argv, options) {
         stderr: captureMode === "pipe" ? stderrCapture.toString() : "",
         interactiveTranscript,
         interactiveCaptureError,
-        rawInteractiveLogPath: captureMode === "pty" && !interactiveCaptureError ? options.capturePath : null,
+        rawInteractiveLogPath: null,
       });
     });
   });

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -134,7 +134,6 @@ function fitContext(manifest, index, checklist, options, config) {
   const handoffJsonRef = options.root ? `.agents/session/${manifest.session_id}/handoff.json` : memoryArtifacts.handoffJsonPath;
   const handoffMarkdownRef = options.root ? `.agents/session/${manifest.session_id}/handoff.md` : memoryArtifacts.handoffMarkdownPath;
   const launchesRef = options.root ? `.agents/session/${manifest.session_id}/launches.jsonl` : memoryArtifacts.launchesPath;
-  const rawInteractiveLogRef = options.root ? `.agents/session/${manifest.session_id}/interactive.log` : memoryArtifacts.rawInteractiveLogPath;
   const turnsRef = options.root ? `.agents/session/${manifest.session_id}/turns.jsonl` : memoryArtifacts.turnsPath;
   const fetchOutputsRef = options.root ? `.agents/session/${manifest.session_id}/context-fetches.jsonl` : memoryArtifacts.fetchOutputsPath;
   const contextFactsRef = options.root ? `.agents/session/${manifest.session_id}/context-facts.json` : memoryArtifacts.contextFactsPath;
@@ -167,7 +166,6 @@ function fitContext(manifest, index, checklist, options, config) {
         handoff_markdown: handoffMarkdownRef,
       } : {}),
       launches: launchesRef,
-      raw_interactive_log: rawInteractiveLogRef,
       turns: turnsRef,
       context_fetches: fetchOutputsRef,
       context_fetches: fetchOutputsRef,
@@ -344,7 +342,6 @@ export async function forkSession(root, config, options = {}) {
       `.agents/session/${sessionId}/memory-context.md`,
       `.agents/session/${sessionId}/context-facts.json`,
       `.agents/session/${sessionId}/context-facts.md`,
-      `.agents/session/${sessionId}/interactive.log`,
       `.agents/session/${sessionId}/context-fetches.jsonl`,
     ],
     metadata: {
@@ -368,7 +365,6 @@ export async function forkSession(root, config, options = {}) {
         "memory-context.md",
         "handoff.md",
         "context-facts.md",
-        "interactive.log",
       ],
     },
   };

--- a/test/exec.test.js
+++ b/test/exec.test.js
@@ -441,7 +441,7 @@ test("runExec bounds captured stdout and stderr to the configured capture limit"
   }
 });
 
-test("runExec records interactive provider output into a raw PTY log and normalized transcript", async () => {
+test("runExec records redacted interactive provider output without retaining a raw PTY log", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-exec-interactive-"));
   await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
   await initGitRepo(root);
@@ -449,10 +449,16 @@ test("runExec records interactive provider output into a raw PTY log and normali
   for (const provider of ["codex", "claude"]) {
     const config = await loadConfig(root, { provider, dryRun: false, tokenReport: false });
     const session = await forkSession(root, config, { name: `${provider}-interactive` });
+    const command = [
+      "node",
+      "--input-type=module",
+      "-e",
+      "process.stdout.write('interactive transcript\\nOPENAI_API_KEY=sk-pty-secret12345\\n')",
+    ];
     const result = await runExec(
       root,
       config,
-      ["node", "--input-type=module", "-e", "process.stdout.write('interactive transcript\\n')"],
+      command,
       {
         captureOutputMode: "pty",
         sessionRecord: {
@@ -460,7 +466,7 @@ test("runExec records interactive provider output into a raw PTY log and normali
           provider,
           prompt: `Continue the ${provider} interactive session.`,
           task: `Verify PTY capture for ${provider}.`,
-          command: ["node", "--input-type=module", "-e", "process.stdout.write('interactive transcript\\n')"],
+          command,
           memoryContext: {
             sourceSessionId: null,
             transcriptRelativePath: null,
@@ -474,15 +480,26 @@ test("runExec records interactive provider output into a raw PTY log and normali
 
     const transcript = await fs.readFile(path.join(session.sessionDir, "transcript.md"), "utf8");
     const launches = await fs.readFile(path.join(session.sessionDir, "launches.jsonl"), "utf8");
-    const rawLog = await fs.readFile(path.join(session.sessionDir, "interactive.log"), "utf8");
+    const turns = await fs.readFile(path.join(session.sessionDir, "turns.jsonl"), "utf8");
+    const context = await fs.readFile(path.join(session.sessionDir, "context.json"), "utf8");
+    const manifest = await fs.readFile(path.join(session.sessionDir, "session-manifest.json"), "utf8");
+    const combined = [transcript, launches, turns, context, manifest].join("\n");
+    const launch = JSON.parse(launches.trim().split(/\r?\n/).at(-1));
 
     assert.equal(result.phase, "complete");
     assert.equal(result.exitCode, 0);
-    assert.match(transcript, /interactive transcript/);
-    assert.match(transcript, /Raw interactive log:/);
-    assert.match(launches, /interactive-pty/);
-    assert.match(launches, /interactive\.log/);
-    assert.match(rawLog, /interactive transcript/);
+    assert.equal(result.rawInteractiveLogPath, null);
+    assert.match(combined, /interactive transcript/);
+    assert.match(combined, /\[REDACTED\]/);
+    assert.doesNotMatch(combined, /sk-pty-secret12345/);
+    assert.doesNotMatch(combined, /interactive\.log/);
+    assert.doesNotMatch(transcript, /Raw interactive log:/);
+    assert.equal(launch.capture_mode, "interactive-pty");
+    assert.equal(launch.raw_interactive_log_path, null);
+    await assert.rejects(
+      () => fs.access(path.join(session.sessionDir, "interactive.log")),
+      /ENOENT/
+    );
   }
 });
 


### PR DESCRIPTION
## Summary
- treat PTY recorder output as a temporary normalization source and remove it after reading
- stop returning or advertising raw interactive log paths in default session artifacts
- update PTY regression coverage to prove secrets are redacted and interactive.log is not retained or referenced

Fixes #157

## Tests
- node --test --test-name-pattern='runExec (redacts obvious secrets|records redacted interactive provider output|writes a fallback transcript|finalizes session memory)' test/exec.test.js
- node --test test/session-structured.test.js
- git diff --check

## Notes
- Full npm test currently reports 287 passing, 3 failing, 1 skipped. The failures appear unrelated to this change: session.test expects local-session-search but the environment selected mempalace, and skills.test expects a jira built-in that is absent from the current catalog.