### PR TITLE
fix: require issue-killer permission bypass opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Supported levels are `lite`, `full`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-f
 | `--context-mode` | Choose `compact` or `routed` run prompt behavior |
 | `--with-context` | Inject planner-selected files, tests, and memory into `run` |
 | `--context-mode <direct|routed>` | Use routed context retrieval for `run`/`sess` prompts |
+| `--bypass-permissions` | Explicitly bypass provider permission prompts for `issue-killer` panes |
 | `--explain-plan` | Print planner output before executing `run` |
 | `--caveman[=level]` | Terse output for `run`/`sess` (`lite`, `full`, `ultra`, `wenyan*`) |
 | `--root <path>` | Target repo root (default: cwd) |

--- a/src/core/issue-killer.js
+++ b/src/core/issue-killer.js
@@ -264,7 +264,17 @@ async function createWorktree(root, assignment, options) {
   return getWorktreePathForBranch(root, assignment.branch);
 }
 
-function buildIssuePrompt(issue, assignment) {
+function buildIssuePrompt(issue, assignment, options = {}) {
+  const permissionRules = options.bypassPermissions
+    ? [
+        "- Provider permission bypass was explicitly requested for this pane; keep command side effects limited to this assigned issue.",
+        "- Do not ask for permission before running task-related shell, git, gh, package-manager, test, commit, push, or draft PR commands.",
+      ]
+    : [
+        "- Respect provider permission prompts and sandbox approvals; do not assume side-effecting commands are pre-approved.",
+        "- Keep task-related shell, git, gh, package-manager, test, commit, push, or draft PR commands scoped to this assigned issue.",
+      ];
+
   return [
     "You are working in an Agentify issue-killer tmux pane.",
     "",
@@ -275,8 +285,8 @@ function buildIssuePrompt(issue, assignment) {
     "Rules:",
     "- Solve exactly this issue and do not pick up other issues.",
     "- Keep changes scoped, minimal, and production-ready.",
-    "- You are running in an isolated issue-killer worktree with provider permissions pre-approved for this assigned issue.",
-    "- Do not ask for permission before running task-related shell, git, gh, package-manager, test, commit, push, or draft PR commands.",
+    "- You are running in an isolated issue-killer worktree.",
+    ...permissionRules,
     "- Run the relevant tests and checks for the touched area.",
     "- Commit with a clear Conventional Commit message.",
     "- Push the branch with upstream tracking.",
@@ -286,12 +296,12 @@ function buildIssuePrompt(issue, assignment) {
   ].join("\n");
 }
 
-function buildPaneCommand(assignment, agentProvider) {
-  const prompt = buildIssuePrompt(assignment.issue, assignment);
-  const argv = buildProviderTemplateCommand(agentProvider, prompt, {
+function buildPaneCommand(assignment, options) {
+  const prompt = buildIssuePrompt(assignment.issue, assignment, options);
+  const argv = buildProviderTemplateCommand(options.agentProvider, prompt, {
     root: assignment.worktreePath,
     interactive: true,
-    bypassPermissions: true,
+    bypassPermissions: options.bypassPermissions,
   });
   return argvToShell(argv);
 }
@@ -346,7 +356,7 @@ async function launchTmux(assignments, options) {
 
   for (let index = 0; index < assignments.length; index += 1) {
     const assignment = assignments[index];
-    const paneCommand = buildPaneCommand(assignment, options.agentProvider);
+    const paneCommand = buildPaneCommand(assignment, options);
     const shellArgs = [shell, "-lc", `exec ${paneCommand}`];
 
     if (index === 0 && !exists) {
@@ -398,6 +408,7 @@ function normalizeOptions(args, config) {
     base: args.base,
     sessionName: String(args.sessionName === undefined || args.sessionName === true ? DEFAULT_SESSION_NAME : args.sessionName).trim(),
     reuseSession: Boolean(args.reuseSession),
+    bypassPermissions: Boolean(args.bypassPermissions),
     dryRun: Boolean(config.dryRun),
   };
 }
@@ -414,6 +425,7 @@ function createAssignments(issues, options) {
 function renderSummary(result) {
   ui.success(`Prepared ${result.assignments.length} issue-killer pane(s).`);
   ui.log(`tmux session: ${ui.bold(result.session_name)}`);
+  ui.log(`provider permission bypass: ${ui.bold(result.provider_permission_bypass ? "enabled" : "disabled")}`);
   ui.log(`attach: ${ui.bold(`tmux attach -t ${result.session_name}`)}`);
   for (const assignment of result.assignments) {
     ui.log(`#${assignment.issue.number} ${assignment.branch}`);
@@ -432,7 +444,7 @@ export async function runIssueKiller(root, config, args = {}) {
   if (!options.dryRun) {
     for (const assignment of assignments) {
       assignment.worktreePath = await createWorktree(root, assignment, options);
-      assignment.paneCommand = buildPaneCommand(assignment, options.agentProvider);
+      assignment.paneCommand = buildPaneCommand(assignment, options);
     }
     await launchTmux(assignments, options);
   }
@@ -441,6 +453,7 @@ export async function runIssueKiller(root, config, args = {}) {
     command: "issue-killer",
     issue_provider: options.issueProvider,
     agent_provider: options.agentProvider,
+    provider_permission_bypass: options.bypassPermissions,
     session_name: options.sessionName,
     dry_run: options.dryRun,
     attach_command: `tmux attach -t ${options.sessionName}`,

--- a/src/core/skills.js
+++ b/src/core/skills.js
@@ -81,7 +81,7 @@ const BUILTIN_SKILLS = [
     name: "issue-killer",
     aliases: ["gh-issue-killer"],
     description:
-      "Launch opted-in GitHub issues into supervised tmux panes, each with its own Worktrunk worktree and Codex or Claude agent prompt running with provider permission checks bypassed for draft PR creation.",
+      "Launch opted-in GitHub issues into supervised tmux panes, each with its own Worktrunk worktree and Codex or Claude agent prompt. Provider permission bypass is available only through an explicit issue-killer opt-in.",
   },
   {
     name: "migrate-to-shoehorn",

--- a/src/main.js
+++ b/src/main.js
@@ -60,6 +60,7 @@ const BOOLEAN_FLAGS = new Set([
   "explain",
   "allowPartial",
   "reuseSession",
+  "bypassPermissions",
   "hook",
   "withContext",
   "continue",
@@ -408,6 +409,7 @@ function printHelp() {
     `    ${c("--context-mode")} ${d("<compact|routed>")}  Use compact prompts or routed bounded retrieval prompts`,
     `    ${c("--with-context")}              Inject planner-selected files, tests, and memory into run`,
     `    ${c("--context-mode")} ${d("<direct|routed>")}     Use routed context retrieval for run/sess prompts`,
+    `    ${c("--bypass-permissions")}        Explicitly bypass provider permission prompts for issue-killer panes`,
     `    ${c("--explain-plan")}              Print planner output before executing run`,
     `    ${c("--caveman[=level]")}            Terse output for run/sess (lite, full, ultra, wenyan*)`,
     `    ${c("--root")} ${d("<path>")}               Target repo root (default: cwd)`,
@@ -447,6 +449,7 @@ function printHelp() {
     `    ${d("$")} agentify sess run --provider codex --interactive --name "payments-v2" "continue in Codex TUI"`,
     `    ${d("$")} agentify handoff --session sess_20260101000000_abcdef "continue payments-v2"`,
     `    ${d("$")} agentify issue-killer --label agentify-ready --agent-provider codex --limit 5`,
+    `    ${d("$")} agentify issue-killer --label agentify-ready --agent-provider codex --bypass-permissions`,
     `    ${d("$")} agentify exec -- codex exec "fix auth bug"`,
     ``,
   ];

--- a/test/issue-killer.test.js
+++ b/test/issue-killer.test.js
@@ -129,12 +129,15 @@ test("issue-killer creates Worktrunk worktrees and tmux panes", async () => {
     );
 
     assert.equal(result.assignments.length, 2);
+    assert.equal(result.provider_permission_bypass, false);
     assert.ok(result.assignments[0].worktree_path.endsWith("wt-issue-101-fix-login-redirect"));
     assert.ok(result.assignments[1].worktree_path.endsWith("wt-issue-102-add-billing-retry"));
     assert.match(result.assignments[0].pane_command, /^'codex' '--cd'/);
-    assert.match(result.assignments[0].pane_command, /--dangerously-bypass-approvals-and-sandbox/);
+    assert.doesNotMatch(result.assignments[0].pane_command, /--dangerously-bypass-approvals-and-sandbox/);
     assert.match(result.assignments[0].pane_command, /gh pr create --draft/);
-    assert.match(result.assignments[0].pane_command, /Do not ask for permission before running task-related shell, git, gh, package-manager, test, commit, push, or draft PR commands/);
+    assert.doesNotMatch(result.assignments[0].pane_command, /permissions pre-approved/);
+    assert.doesNotMatch(result.assignments[0].pane_command, /Do not ask for permission before running task-related shell, git, gh, package-manager, test, commit, push, or draft PR commands/);
+    assert.match(result.assignments[0].pane_command, /Respect provider permission prompts and sandbox approvals/);
     assert.match(result.assignments[0].pane_command, /Do not force-push, rewrite unrelated history, or weaken tests to pass checks/);
 
     const tmuxCalls = await fs.readFile(tmuxLog, "utf8");
@@ -144,7 +147,28 @@ test("issue-killer creates Worktrunk worktrees and tmux panes", async () => {
   });
 });
 
-test("issue-killer launches claude with bypass permissions", async () => {
+test("issue-killer can explicitly bypass codex permissions", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-issue-killer-codex-bypass-"));
+  await initGitRepo(root);
+
+  await withFakePath(root, async () => {
+    const result = await withQuietConsole(() =>
+      runIssueKiller(root, { provider: "codex", dryRun: false, json: true }, {
+        label: "agentify-ready",
+        limit: 1,
+        bypassPermissions: true,
+      })
+    );
+
+    assert.equal(result.provider_permission_bypass, true);
+    assert.match(result.assignments[0].pane_command, /^'codex' '--cd'/);
+    assert.match(result.assignments[0].pane_command, /--dangerously-bypass-approvals-and-sandbox/);
+    assert.match(result.assignments[0].pane_command, /Provider permission bypass was explicitly requested/);
+    assert.match(result.assignments[0].pane_command, /Do not ask for permission before running task-related shell, git, gh, package-manager, test, commit, push, or draft PR commands/);
+  });
+});
+
+test("issue-killer launches claude without bypass permissions by default", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-issue-killer-claude-"));
   await initGitRepo(root);
 
@@ -158,8 +182,34 @@ test("issue-killer launches claude with bypass permissions", async () => {
     );
 
     assert.equal(result.agent_provider, "claude");
+    assert.equal(result.provider_permission_bypass, false);
+    assert.match(result.assignments[0].pane_command, /^'claude'/);
+    assert.doesNotMatch(result.assignments[0].pane_command, /--dangerously-skip-permissions/);
+    assert.doesNotMatch(result.assignments[0].pane_command, /--permission-mode' 'bypassPermissions/);
+    assert.match(result.assignments[0].pane_command, /gh pr create --draft/);
+    assert.match(result.assignments[0].pane_command, /Respect provider permission prompts and sandbox approvals/);
+  });
+});
+
+test("issue-killer can explicitly bypass claude permissions", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-issue-killer-claude-bypass-"));
+  await initGitRepo(root);
+
+  await withFakePath(root, async () => {
+    const result = await withQuietConsole(() =>
+      runIssueKiller(root, { provider: "claude", dryRun: false, json: true }, {
+        label: "agentify-ready",
+        limit: 1,
+        agentProvider: "claude",
+        bypassPermissions: true,
+      })
+    );
+
+    assert.equal(result.agent_provider, "claude");
+    assert.equal(result.provider_permission_bypass, true);
     assert.match(result.assignments[0].pane_command, /^'claude' '--dangerously-skip-permissions' '--permission-mode' 'bypassPermissions'/);
     assert.match(result.assignments[0].pane_command, /gh pr create --draft/);
+    assert.match(result.assignments[0].pane_command, /Provider permission bypass was explicitly requested/);
   });
 });
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -91,6 +91,18 @@ test("parseArgs normalizes dashed flags to camelCase", () => {
   assert.equal(args.maxFilesPerModule, 12);
 });
 
+test("parseArgs treats issue-killer bypass permissions as a boolean flag", () => {
+  const args = parseArgs([
+    "issue-killer",
+    "--bypass-permissions",
+    "--label",
+    "agentify-ready",
+  ]);
+
+  assert.equal(args.bypassPermissions, true);
+  assert.equal(args.label, "agentify-ready");
+});
+
 test("parseArgs and config resolve context mode explicitly", () => {
   const args = parseArgs(["run", "--context-mode", "routed", "implement login"]);
 


### PR DESCRIPTION
## Summary
- stop enabling provider permission bypass for issue-killer panes by default
- add explicit --bypass-permissions opt-in and expose provider_permission_bypass in results/summary
- update Codex and Claude issue-killer tests for safe defaults and explicit bypass mode

## Tests
- node --test test/issue-killer.test.js
- node --test test/provider-command.test.js
- node --test test/main.test.js
- pnpm test (fails in unrelated existing areas: session memory provider expected local-session-search but got mempalace; skills catalog tests expect missing jira skill)

Closes #151