### PR TITLE
fix: reject invalid read-only index databases

### DIFF
--- a/src/core/db/connection.js
+++ b/src/core/db/connection.js
@@ -59,20 +59,48 @@ export function getIndexDbPath(root) {
 function createIndexSnapshot(dbPath) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentify-index-"));
   const snapshotPath = path.join(tempDir, "index.db");
-  fs.chmodSync(tempDir, SNAPSHOT_DIR_MODE);
-  fs.copyFileSync(dbPath, snapshotPath);
-  fs.chmodSync(snapshotPath, SNAPSHOT_FILE_MODE);
 
-  for (const suffix of ["-wal", "-shm"]) {
-    const sourcePath = `${dbPath}${suffix}`;
-    if (fs.existsSync(sourcePath)) {
-      const snapshotSidecarPath = `${snapshotPath}${suffix}`;
-      fs.copyFileSync(sourcePath, snapshotSidecarPath);
-      fs.chmodSync(snapshotSidecarPath, SNAPSHOT_FILE_MODE);
+  try {
+    fs.chmodSync(tempDir, SNAPSHOT_DIR_MODE);
+    fs.copyFileSync(dbPath, snapshotPath);
+    fs.chmodSync(snapshotPath, SNAPSHOT_FILE_MODE);
+
+    for (const suffix of ["-wal", "-shm"]) {
+      const sourcePath = `${dbPath}${suffix}`;
+      if (fs.existsSync(sourcePath)) {
+        const snapshotSidecarPath = `${snapshotPath}${suffix}`;
+        fs.copyFileSync(sourcePath, snapshotSidecarPath);
+        fs.chmodSync(snapshotSidecarPath, SNAPSHOT_FILE_MODE);
+      }
     }
-  }
 
-  return { tempDir, snapshotPath };
+    return { tempDir, snapshotPath };
+  } catch (error) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function getErrorReason(error) {
+  return error instanceof Error && error.message
+    ? `: ${error.message}`
+    : "";
+}
+
+function createInvalidIndexDatabaseError(dbPath, cause) {
+  const error = new Error(
+    `invalid index database at ${dbPath}${getErrorReason(cause)}. Rebuild the index with "agentify scan" or "agentify up".`
+  );
+  error.code = "AGENTIFY_INDEX_DATABASE_INVALID";
+  error.cause = cause;
+  return error;
+}
+
+function shouldUseReadOnlySnapshotFallback(error) {
+  const message = error instanceof Error ? error.message : "";
+  return error?.code === "SQLITE_READONLY"
+    || error?.errcode === 1544
+    || /attempt to write a readonly database|read-?only database/i.test(message);
 }
 
 function openDatabaseFile(dbPath, options = {}) {
@@ -116,7 +144,14 @@ function configureIndexConnection(db, implementation, { readOnly }) {
   db.exec("PRAGMA foreign_keys = ON");
 
   if (readOnly) {
-    db.prepare("SELECT value_json FROM repo_meta WHERE key = 'schema_version' LIMIT 1").get();
+    const row = db.prepare("SELECT value_json FROM repo_meta WHERE key = 'schema_version' LIMIT 1").get();
+    if (!row) {
+      throw new Error("index database is missing schema_version metadata");
+    }
+    const schemaVersion = JSON.parse(row.value_json);
+    if (schemaVersion !== DB_SCHEMA_VERSION) {
+      throw new Error(`index database schema version ${schemaVersion} is not supported; expected ${DB_SCHEMA_VERSION}`);
+    }
     return;
   }
 
@@ -347,18 +382,33 @@ function openReadOnlyIndexDatabase(sourceDbPath, options) {
       return opened.db;
     } catch (error) {
       opened.db.close();
-      throw error;
+      if (shouldUseReadOnlySnapshotFallback(error)) {
+        throw error;
+      }
+      throw createInvalidIndexDatabaseError(sourceDbPath, error);
     }
-  } catch {
-    const snapshot = createIndexSnapshot(sourceDbPath);
+  } catch (openError) {
+    if (openError?.code === "AGENTIFY_INDEX_DATABASE_INVALID") {
+      throw openError;
+    }
+
+    let snapshot;
     try {
+      snapshot = createIndexSnapshot(sourceDbPath);
       const opened = openDatabaseFile(snapshot.snapshotPath, { ...options, readOnly: false });
+      try {
+        configureIndexConnection(opened.db, opened.implementation, { readOnly: true });
+      } catch (error) {
+        opened.db.close();
+        throw error;
+      }
       opened.db.__agentifyTempDir = snapshot.tempDir;
-      configureIndexConnection(opened.db, opened.implementation, { readOnly: false });
       return opened.db;
     } catch (error) {
-      fs.rmSync(snapshot.tempDir, { recursive: true, force: true });
-      throw error;
+      if (snapshot) {
+        fs.rmSync(snapshot.tempDir, { recursive: true, force: true });
+      }
+      throw createInvalidIndexDatabaseError(sourceDbPath, error);
     }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -149,10 +149,33 @@ function isMissingIndexError(error) {
   return error instanceof Error && /missing index database at /.test(error.message);
 }
 
+function isInvalidIndexDatabaseError(error) {
+  return error instanceof Error && (
+    error.code === "AGENTIFY_INDEX_DATABASE_INVALID"
+    || /invalid index database at /.test(error.message)
+  );
+}
+
 function createMissingIndexGuidance(root) {
   return new Error(
     `Agentify index missing for ${root}. Run "agentify scan --root ${root}" or "agentify up --root ${root}" before using plan/query/context commands.`
   );
+}
+
+function createInvalidIndexGuidance(root) {
+  return new Error(
+    `Agentify index unreadable for ${root}. Run "agentify scan --root ${root}" or "agentify up --root ${root}" to rebuild it before using plan/query/context commands.`
+  );
+}
+
+function throwWithIndexGuidance(error, root) {
+  if (isMissingIndexError(error)) {
+    throw createMissingIndexGuidance(root);
+  }
+  if (isInvalidIndexDatabaseError(error)) {
+    throw createInvalidIndexGuidance(root);
+  }
+  throw error;
 }
 
 function getSearchTerm(args, commandName) {
@@ -622,10 +645,7 @@ export async function runCli(argv, runtime = {}) {
             includeSource,
           });
         } catch (error) {
-          if (isMissingIndexError(error)) {
-            throw createMissingIndexGuidance(root);
-          }
-          throw error;
+          throwWithIndexGuidance(error, root);
         }
         if (args.explain === true && !args.json) {
           process.stdout.write(renderPlanExplanation(plan));
@@ -655,17 +675,23 @@ export async function runCli(argv, runtime = {}) {
           || args.explainPlan === true
         );
         const includeSource = contextMode !== "routed" || args.withContext === true;
-        const memoryContext = noTaskInteractiveLaunch
-          ? await loadAutomaticRunMemory(root, "", config)
-          : usesManagedContext
-          ? await loadAutomaticRunMemory(root, task, config)
-          : { markdown: "" };
-        const plan = usesManagedContext && task
-          ? await buildExecutionPlan(root, config, task, {
-            contextMode: contextMode === "routed" ? "routed" : "selected",
-            includeSource,
-          })
-          : null;
+        let memoryContext;
+        let plan;
+        try {
+          memoryContext = noTaskInteractiveLaunch
+            ? await loadAutomaticRunMemory(root, "", config)
+            : usesManagedContext
+            ? await loadAutomaticRunMemory(root, task, config)
+            : { markdown: "" };
+          plan = usesManagedContext && task
+            ? await buildExecutionPlan(root, config, task, {
+              contextMode: contextMode === "routed" ? "routed" : "selected",
+              includeSource,
+            })
+            : null;
+        } catch (error) {
+          throwWithIndexGuidance(error, root);
+        }
         if (args.explainPlan && plan) {
           console.log(JSON.stringify(plan, null, 2));
         }
@@ -728,10 +754,7 @@ export async function runCli(argv, runtime = {}) {
             throw new Error("context requires a subcommand: search, fetch, compact, or status");
           }
         } catch (error) {
-          if (isMissingIndexError(error)) {
-            throw createMissingIndexGuidance(root);
-          }
-          throw error;
+          throwWithIndexGuidance(error, root);
         }
         console.log(JSON.stringify(result, null, 2));
         return;
@@ -816,10 +839,7 @@ export async function runCli(argv, runtime = {}) {
             throw new Error("query requires a subcommand: owner, deps, changed, search, def, refs, callers, or impacts");
           }
         } catch (error) {
-          if (isMissingIndexError(error)) {
-            throw createMissingIndexGuidance(root);
-          }
-          throw error;
+          throwWithIndexGuidance(error, root);
         }
         console.log(JSON.stringify(result, null, 2));
         return;
@@ -832,10 +852,7 @@ export async function runCli(argv, runtime = {}) {
             since: normalizeOptionalSince(args, "risk"),
           });
         } catch (error) {
-          if (isMissingIndexError(error)) {
-            throw createMissingIndexGuidance(root);
-          }
-          throw error;
+          throwWithIndexGuidance(error, root);
         }
         if (config.json) {
           console.log(JSON.stringify(result, null, 2));

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 
@@ -23,6 +24,8 @@ import {
   replaceSemanticProjectSnapshot,
   searchSemanticIndex,
 } from "../src/core/db/semantic-store.js";
+
+const require = createRequire(import.meta.url);
 
 function octalMode(stats) {
   return (stats.mode & 0o777).toString(8);
@@ -57,12 +60,35 @@ test("openIndexDatabase read-only opens source database without snapshot when po
   }
 });
 
-test("openIndexDatabase read-only fallback snapshots use user-only permissions", async () => {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-db-readonly-"));
-  const dbDir = path.join(root, ".agents");
-  const dbPath = path.join(dbDir, "index.db");
-  await fs.mkdir(dbDir, { recursive: true });
-  await fs.writeFile(dbPath, "");
+test("openIndexDatabase read-only fallback snapshots valid databases without initializing them", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-db-readonly-fallback-"));
+  const writeDb = openIndexDatabase(root);
+  try {
+    writeDb.prepare("INSERT OR REPLACE INTO repo_meta (key, value_json) VALUES (?, ?)")
+      .run("fixture_marker", JSON.stringify("source"));
+  } finally {
+    closeIndexDatabase(writeDb);
+  }
+
+  const dbPath = path.join(root, ".agents", "index.db");
+  const sqlite = require("node:sqlite");
+  const OriginalDatabaseSync = sqlite.DatabaseSync;
+  const betterSqlitePath = require.resolve("better-sqlite3");
+  const betterSqliteCache = require.cache[betterSqlitePath];
+  const originalBetterSqlite = betterSqliteCache?.exports;
+
+  // Simulate the narrow case where the source cannot be opened read-only but its copied snapshot can be read.
+  sqlite.DatabaseSync = function DatabaseSync(filename, options) {
+    if (filename === dbPath && options?.readOnly) {
+      throw new Error("simulated read-only source open failure");
+    }
+    return new OriginalDatabaseSync(filename, options);
+  };
+  if (betterSqliteCache) {
+    betterSqliteCache.exports = function BetterSqlite3() {
+      throw new Error("simulated better-sqlite3 source open failure");
+    };
+  }
 
   let db;
   let tempDir;
@@ -70,8 +96,11 @@ test("openIndexDatabase read-only fallback snapshots use user-only permissions",
     db = openIndexDatabase(root, { readOnly: true });
     tempDir = db.__agentifyTempDir;
     assert.ok(tempDir);
-    const snapshotPath = path.join(tempDir, "index.db");
+    const marker = db.prepare("SELECT value_json FROM repo_meta WHERE key = ?")
+      .get("fixture_marker");
+    assert.equal(marker.value_json, JSON.stringify("source"));
 
+    const snapshotPath = path.join(tempDir, "index.db");
     assert.equal(octalMode(await fs.stat(tempDir)), "700");
     assert.equal(octalMode(await fs.stat(snapshotPath)), "600");
 
@@ -83,12 +112,59 @@ test("openIndexDatabase read-only fallback snapshots use user-only permissions",
       }
     }
   } finally {
+    sqlite.DatabaseSync = OriginalDatabaseSync;
+    if (betterSqliteCache) {
+      betterSqliteCache.exports = originalBetterSqlite;
+    }
     if (db) {
       closeIndexDatabase(db);
     }
   }
 
   await assert.rejects(() => fs.access(tempDir));
+});
+
+test("openIndexDatabase read-only rejects blank index database instead of initializing a snapshot", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-db-readonly-"));
+  const dbDir = path.join(root, ".agents");
+  const dbPath = path.join(dbDir, "index.db");
+  await fs.mkdir(dbDir, { recursive: true });
+  await fs.writeFile(dbPath, "");
+
+  assert.throws(
+    () => openIndexDatabase(root, { readOnly: true }),
+    /invalid index database at .*index\.db: no such table: repo_meta/,
+  );
+
+  assert.equal((await fs.stat(dbPath)).size, 0);
+});
+
+test("openIndexDatabase read-only rejects corrupt index database instead of initializing a snapshot", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-db-readonly-"));
+  const dbDir = path.join(root, ".agents");
+  await fs.mkdir(dbDir, { recursive: true });
+  await fs.writeFile(path.join(dbDir, "index.db"), "not sqlite", "utf8");
+
+  assert.throws(
+    () => openIndexDatabase(root, { readOnly: true }),
+    /invalid index database at .*index\.db: file is not a database/,
+  );
+});
+
+test("openIndexDatabase read-only rejects unsupported index schema version", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-db-readonly-"));
+  const db = openIndexDatabase(root);
+  try {
+    db.prepare("UPDATE repo_meta SET value_json = ? WHERE key = 'schema_version'")
+      .run(JSON.stringify("0.1"));
+  } finally {
+    closeIndexDatabase(db);
+  }
+
+  assert.throws(
+    () => openIndexDatabase(root, { readOnly: true }),
+    /invalid index database at .*index\.db: index database schema version 0\.1 is not supported; expected 3\.1/,
+  );
 });
 
 test("structural store writes and searches repository index data", async () => {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1045,6 +1045,22 @@ test("runCli plan reports actionable guidance when the index is missing", async 
   );
 });
 
+test("runCli plan reports actionable guidance when the index is unreadable", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-plan-invalid-index-"));
+  await runCli(["init", "--root", root]);
+  await fs.mkdir(path.join(root, ".agents"), { recursive: true });
+  await fs.writeFile(path.join(root, ".agents", "index.db"), "not sqlite", "utf8");
+
+  await assert.rejects(
+    () => runCli(["plan", "--root", root, "summarize setup"]),
+    new RegExp(`Agentify index unreadable for ${root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`),
+  );
+  await assert.rejects(
+    () => runCli(["plan", "--root", root, "summarize setup"]),
+    /Run "agentify scan --root .*" or "agentify up --root .*" to rebuild it before using plan\/query\/context commands\./,
+  );
+});
+
 test("runCli plan --explain renders text and JSON score breakdowns", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-plan-explain-"));
   await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");


### PR DESCRIPTION
## Summary
- Reject blank, corrupt, and unsupported-schema `.agents/index.db` files during read-only opens instead of initializing writable snapshot databases.
- Preserve the legitimate snapshot fallback for read-only filesystem/WAL cases, while validating snapshots in read-only mode.
- Add CLI repair guidance for unreadable indexes.

Fixes #155

## Tests
- `git diff --check`
- `node --test test/db.test.js`
- `node --test --test-name-pattern "index is (missing|unreadable)|read-only" test/main.test.js`
- `node --test test/db.test.js test/query.test.js test/planner.test.js`
- `node --test test/db.test.js test/main.test.js`
- `pnpm test` (fails outside this issue scope: `test/session.test.js` MemPalace provider expectation; `test/skills.test.js` missing `jira` catalog expectation)