### PR TITLE
chore: migrate runtime artifacts to .agentify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 node_modules/
 .current_session/
-.agents/session/
-.agents/cache/
-.agents/.lock
-.agents/*
+.agentify/
 .claude/*
 *.tmp
 .codex/*

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Reply with: provider used, files created/modified (from `git status`), and
 the result of `agentify check` (pass/fail + first failing line if any).
 ````
 
-That's it. The agent will leave the repo with `.agentify.yaml`, `.agentignore`, `.guardrails`, an updated `.gitignore`, an `AGENTIFY.md`, and a populated `.agents/` index.
+That's it. The agent will leave the repo with `.agentify.yaml`, `.agentignore`, `.guardrails`, an updated `.gitignore`, an `AGENTIFY.md`, and a populated `.agentify/` index.
 
 ---
 
@@ -207,12 +207,12 @@ That's it. The agent will leave the repo with `.agentify.yaml`, `.agentignore`, 
 AGENTIFY.md                 # agent-facing repo overview (generated, gitignored)
 docs/repo-map.md            # routing map (generated, gitignored)
 <module>/AGENTIFY.md        # per-module context (generated, gitignored)
-.agents/index.db            # SQLite repo index (gitignored)
-.agents/runs/, .agents/session/   # run + session state (gitignored)
-.agentify/work/             # scratch / staging (gitignored)
+.agentify/index.db            # SQLite repo index (gitignored)
+.agentify/runs/, .agentify/session/   # run + session state (gitignored)
+.agentify/work/             # scratch / staging inside runtime root (gitignored)
 ```
 
-Commit `.agentify.yaml`, `.agentignore`, `.guardrails`, and the managed `.gitignore` block. Everything under `.agents/` and `.agentify/work/` is local runtime.
+Commit `.agentify.yaml`, `.agentignore`, `.guardrails`, and the managed `.gitignore` block. Everything under `.agentify/` is local runtime.
 
 ---
 
@@ -260,7 +260,7 @@ agentify sess resume --session <id> "write tests from the prepared compacted con
 
 Reported `prompt_bytes` and `session_context_bytes` are UTF-8 byte estimates for Agentify-managed material — **not** a provider token count or a guarantee about live provider context size.
 
-Routed artifacts are local/generated under `.agents/`, `.agentify/work/`, `AGENTIFY.md`, `docs/repo-map.md`, and `docs/modules/`. Agentify sanitizes test subprocess envs, but provider runs inherit the provider environment. **Agentify is not a secret redactor** — keep secrets out of the repo, add paths to `.agentignore`, and only opt variables into `tests.env.passthrough` / `tests.env.extra` when needed.
+Routed artifacts are local/generated under `.agentify/`, `AGENTIFY.md`, `docs/repo-map.md`, and `docs/modules/`. Agentify sanitizes test subprocess envs, but provider runs inherit the provider environment. **Agentify is not a secret redactor** — keep secrets out of the repo, add paths to `.agentignore`, and only opt variables into `tests.env.passthrough` / `tests.env.extra` when needed.
 
 ---
 
@@ -312,7 +312,8 @@ Levels: `lite`, `full`, `ultra`, `wenyan`, `wenyan-lite`, `wenyan-full`, `wenyan
 | Command | Description |
 | --- | --- |
 | `init` | Create baseline Agentify artifacts |
-| `index` / `scan` | Build the SQLite repository index |
+| `index` | Build the SQLite repository index |
+| `scan` | Alias for `index` |
 | `doc` | Generate docs, metadata, key-file headers |
 | `up` | scan → optional doc → check → test pipeline |
 | `sync` | Upgrade repo-owned Agentify files, then refresh |

--- a/docs/ADVANCED_ONBOARDING.md
+++ b/docs/ADVANCED_ONBOARDING.md
@@ -29,7 +29,7 @@ agentify up
 
 What this gives you:
 
-- baseline Agentify repo artifacts (`.agentify.yaml`, `.agentify/work`, `.agentignore`, `.guardrails`)
+- baseline Agentify repo artifacts (`.agentify.yaml`, `.agentify/`, `.agentignore`, `.guardrails`)
 - all built-in Codex skill packs in `.codex/skills/`
 - fresh index/docs/check artifacts for deterministic task execution
 

--- a/docs/DETAILED_README.md
+++ b/docs/DETAILED_README.md
@@ -128,7 +128,7 @@ It is written so the model treats the current working directory as the target re
 
 | Command | What it does | Why and when to use it | Example |
 | --- | --- | --- | --- |
-| `agentify init` | Creates baseline Agentify artifacts such as `.agentify.yaml`, `.agentignore`, `.guardrails`, `.agentify/work/`, `.agents/`, and `docs/modules/` for root-module fallback docs. | Use once when enabling a repo manually, especially on Linux or pre-provisioned machines where you do not want bootstrap automation. | `agentify init --provider codex` |
+| `agentify init` | Creates baseline Agentify artifacts such as `.agentify.yaml`, `.agentignore`, `.guardrails`, `.agentify/`, and `docs/modules/` for root-module fallback docs. | Use once when enabling a repo manually, especially on Linux or pre-provisioned machines where you do not want bootstrap automation. | `agentify init --provider codex` |
 | `agentify index` | Scans the repo and writes the SQLite index. | Use when you want the machine-readable repo graph refreshed but do not need markdown docs yet. | `agentify index` |
 | `agentify scan` | Alias for `index`. | Use it when you prefer the word "scan" in scripts or team docs. Functionally it is the same as `index`. | `agentify scan` |
 | `agentify doc` | Generates `AGENTIFY.md`, module docs, repo map updates, and refreshes eligible file headers. | Use after indexing when you want human-readable and agent-readable documentation updated. | `agentify doc` |
@@ -178,15 +178,15 @@ tests:
 | `agentify context` | Searches indexed refs, fetches bounded source slices, compacts session facts, and reports routed context status. | Use with `--context-mode routed` prompts when agents should retrieve context through bounded Agentify commands instead of receiving full file bodies. | `agentify context fetch src/auth.ts --lines 20:80` |
 | `agentify exec` | Runs a custom command after `--`, then performs the same refresh lifecycle as `run`. | Use when you want full control over the provider command line but still want Agentify wrapping, timeout handling, and refresh behavior. | `agentify exec -- codex exec "fix auth bug"` |
 | `agentify this` | Bootstraps the current macOS repo for provider-backed Agentify use. | Use on macOS when you want the shortest path to a working repo and are okay with Agentify verifying/installing local dependencies. | `agentify this --provider codex` |
-| `agentify sess run` | Creates or resumes a session and launches the provider with session bootstrap context. Without a task, asks the provider to collect one. | Use for work that will span multiple agent runs and needs durable context under `.agents/session/`. | `agentify sess run --provider codex --name "payments-v2"` |
+| `agentify sess run` | Creates or resumes a session and launches the provider with session bootstrap context. Without a task, asks the provider to collect one. | Use for work that will span multiple agent runs and needs durable context under `.agentify/session/`. | `agentify sess run --provider codex --name "payments-v2"` |
 | `agentify sess resume` | Resumes a previous session by id and relaunches the provider with that bootstrap context. | Use when you want to continue a prior thread without manually rebuilding context. | `agentify sess resume --session sess_20260331_ab12cd "continue"` |
 | `agentify sess fork` | Forks an existing session into a new branch of work. | Use when you want to preserve the old session but try a different implementation or direction. | `agentify sess fork --from sess_20260331_ab12cd --name "payments-alt" "try alternate design"` |
 | `agentify sess list` | Lists known sessions for the repo. | Use when you need to find an id to resume or audit previous work threads. | `agentify sess list` |
 | `agentify issue-killer` | Launches opted-in GitHub issues into supervised tmux panes, each with its own Worktrunk worktree and Codex or Claude prompt running with provider permission checks bypassed. | Use when you want several labelled or explicit issues handled in parallel without giving agents arbitrary access to the whole issue backlog. | `agentify issue-killer --label agentify-ready --agent-provider codex --limit 5` |
 
-Session memory is automatic for `sess *` commands. Session runs write durable artifacts such as `transcript.md`, `memory-context.md`, and `launches.jsonl` under `.agents/session/<id>/`, and `sess resume` / `sess fork` automatically inject recent transcript excerpts into the next prompt without requiring a separate memory command.
+Session memory is automatic for `sess *` commands. Session runs write durable artifacts such as `transcript.md`, `memory-context.md`, and `launches.jsonl` under `.agentify/session/<id>/`, and `sess resume` / `sess fork` automatically inject recent transcript excerpts into the next prompt without requiring a separate memory command.
 
-Normal `run` is intentionally lightweight. It does not persist durable session memory artifacts under `.agents/session/`; if you need reusable memory across multiple launches, use `sess *`.
+Normal `run` is intentionally lightweight. It does not persist durable session memory artifacts under `.agentify/session/`; if you need reusable memory across multiple launches, use `sess *`.
 
 ### Routed Context And Compaction Limits
 
@@ -208,9 +208,9 @@ Use the outputs differently:
 - `agentify context fetch <path> --symbol <name>`, `agentify context fetch <path> --lines A:B`, and selected file slices embedded in a plan are exact code from the worktree for the requested bounded range.
 - `prompt_bytes`, `session_context_bytes`, and `session_bootstrap_bytes` are UTF-8 byte counts of Agentify-managed text. They are useful for relative size control, but they are estimates, not provider token counts and not a measure of everything already present in a live provider context.
 
-Sessions are the compaction boundary. `sess run`, `sess resume`, and `sess fork` write structured local state under `.agents/session/<id>/`, including run history, rolling summaries, launch records, memory context, and optional markdown artifacts. On resume, Agentify prepares a compact child prompt from those artifacts and the current repo index. That gives the next provider launch a smaller prepared context, but it does not retroactively remove material from an older provider conversation.
+Sessions are the compaction boundary. `sess run`, `sess resume`, and `sess fork` write structured local state under `.agentify/session/<id>/`, including run history, rolling summaries, launch records, memory context, and optional markdown artifacts. On resume, Agentify prepares a compact child prompt from those artifacts and the current repo index. That gives the next provider launch a smaller prepared context, but it does not retroactively remove material from an older provider conversation.
 
-Routed context artifacts are local/generated by default. Keep `.agents/`, `.agentify/work/`, `.current_session/`, `AGENTIFY.md`, `docs/repo-map.md`, `docs/modules/`, `output.txt`, and `agentify-report.html` out of commits unless your team intentionally changes the ignore policy. Agentify sanitizes repo test subprocess environments by default, so arbitrary host secrets are not forwarded into detected test commands. Provider executions still run with the provider environment, and Agentify does not redact secrets that are already present in tracked files, generated summaries, selected slices, transcripts, or explicit `tests.env.passthrough` / `tests.env.extra` values. Put sensitive paths in `.agentignore` and keep credentials out of source files.
+Routed context artifacts are local/generated by default. Keep `.agentify/`, `.current_session/`, `AGENTIFY.md`, `docs/repo-map.md`, `docs/modules/`, `output.txt`, and `agentify-report.html` out of commits unless your team intentionally changes the ignore policy. Agentify sanitizes repo test subprocess environments by default, so arbitrary host secrets are not forwarded into detected test commands. Provider executions still run with the provider environment, and Agentify does not redact secrets that are already present in tracked files, generated summaries, selected slices, transcripts, or explicit `tests.env.passthrough` / `tests.env.extra` values. Put sensitive paths in `.agentignore` and keep credentials out of source files.
 
 ### Query, Skills, Hooks, And Cache
 
@@ -264,7 +264,7 @@ agentify sess resume --session <id> ["task"]
 agentify sess fork --from <id> [--provider <name>] [--name <label>] "task"
 ```
 
-Use sessions when the work is multi-step, the prompt context is too expensive to rebuild every time, or you want a durable audit trail under `.agents/session/`.
+Use sessions when the work is multi-step, the prompt context is too expensive to rebuild every time, or you want a durable audit trail under `.agentify/session/`.
 
 When a session is resumed or forked, Agentify first tries an automatic MemPalace-backed search across prior session transcripts for the current repo, then falls back to Agentify's built-in ranked transcript search, and finally to direct lineage replay if no broader match is found. Normal `run` prompts use the same automatic recall path, so relevant older session decisions can surface even without a session id or explicit memory command.
 
@@ -487,7 +487,7 @@ agentify sess resume --session <session-id> "finish the remaining tests"
 agentify sess fork --from <session-id> --name "payments-alt" "try a simpler design"
 ```
 
-Use this when the work spans multiple launches, you want a durable audit trail under `.agents/session/`, or you want later runs to reuse prior context automatically.
+Use this when the work spans multiple launches, you want a durable audit trail under `.agentify/session/`, or you want later runs to reuse prior context automatically.
 
 ### Deterministic maintenance before or after larger changes
 
@@ -582,12 +582,11 @@ AGENTIFY.md
 docs/repo-map.md
 <module-root>/AGENTIFY.md
 docs/modules/*.md for repository-root module fallback
-.agents/index.db
-.agents/runs/*.json
+.agentify/index.db
+.agentify/runs/*.json
 .agentignore
 .guardrails
-.agentify/work/*
-.agents/session/*
+.agentify/session/*
 .current_session/*
 ```
 
@@ -596,13 +595,13 @@ What creates them:
 - `init` creates baseline config and working directories, and installs a managed `.gitignore` block for local/generated Agentify output.
 - `index` or `scan` writes the SQLite index and refreshes repo map basics.
 - `doc` writes markdown docs, run reports, and eligible headers.
-- `sess *` writes session manifests and bootstrap context under `.agents/session/`.
+- `sess *` writes session manifests and bootstrap context under `.agentify/session/`.
 - `--ghost` writes isolated outputs under `.current_session/`.
 
 Git hygiene model:
 
 - Commit `.agentify.yaml`, `.agentignore`, `.guardrails`, and the managed `.gitignore` block when Agentify policy should be shared across the repository.
-- Keep `.agents/`, `.agentify/work/`, `.current_session/`, `AGENTIFY.md`, `docs/repo-map.md`, `docs/modules/`, `output.txt`, and `agentify-report.html` local/generated; Agentify ignores them in Git by default.
+- Keep `.agentify/`, `.current_session/`, `AGENTIFY.md`, `docs/repo-map.md`, `docs/modules/`, `output.txt`, and `agentify-report.html` local/generated; Agentify ignores them in Git by default.
 
 ## Development
 

--- a/docs/QNA.md
+++ b/docs/QNA.md
@@ -16,7 +16,7 @@ You can use providers directly for fast one-off tasks.
 
 Agentify adds value when you need:
 
-- repeatable repository artifacts (`.agents/index.db`, docs, run manifests),
+- repeatable repository artifacts (`.agentify/index.db`, docs, run manifests),
 - deterministic context selection (`agentify plan`),
 - safety checks/freshness validation (`agentify check`),
 - provider portability and sticky defaults,
@@ -49,7 +49,7 @@ This also makes context inspectable by humans in PR review.
 
 ---
 
-## 5) Why use `.agents/index.db` at all?
+## 5) Why use `.agentify/index.db` at all?
 
 SQLite gives a compact and queryable canonical model for:
 
@@ -90,7 +90,7 @@ There are two levels:
 
 1. **Structural indexer level**
    - Uses TypeScript parser APIs to extract symbols/import relations for TS/JS source.
-   - Provides deterministic symbol spans and module linkage in `.agents/index.db`.
+   - Provides deterministic symbol spans and module linkage in `.agentify/index.db`.
 
 2. **Semantic TS/JS level**
    - `semantic refresh` discovers TS/JS projects (`tsconfig`/`jsconfig`), runs semantic worker analysis, and stores symbols/surfaces/edges.
@@ -197,7 +197,7 @@ This supports resuming/forking work with bounded context and traceability across
 
 ---
 
-## 17) What is stored in `.agents/cache`?
+## 17) What is stored in `.agentify/cache`?
 
 Content-addressed blobs and manifests used by cache maintenance commands (`cache gc`, `cache status`) and cleanup workflows.
 
@@ -414,7 +414,7 @@ The roadmap items in section 22 have largely shipped. Recent implementations now
    - Planner output retains typed verification commands (test/lint/build) so agents can stage checks deterministically.
 
 6. **Session runs no longer leak provider conversations** (PR #117)
-   - `.agents/sess` artifacts stop persisting raw provider chat state, keeping session manifests reproducible without provider-specific noise.
+   - `.agentify/sess` artifacts stop persisting raw provider chat state, keeping session manifests reproducible without provider-specific noise.
 
 7. **`agentify up` runs tests on non-node repos** (PR #128)
    - Test phase no longer silently skips when `package.json` is absent; falls back to repo-declared verification commands.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -171,9 +171,8 @@ Use this after switching machines, changing Node/provider installs, pulling a la
 - `.agentify.yaml`
 - `.agentignore`
 - `.guardrails`
-- `.agentify/work/`
-- `.agents/`
-- `.agents/runs/`
+- `.agentify/`
+- `.agentify/runs/`
 - managed Agentify block in `.gitignore`
 
 `agentify this --provider codex` does the same setup and, on macOS, also checks Homebrew and installs missing bootstrap tools when you confirm.
@@ -194,11 +193,11 @@ Neither command installs skills. They only print the opt-in skill install comman
 
 Generated outputs include:
 
-- `.agents/index.db`
+- `.agentify/index.db`
 - `docs/repo-map.md`
 - root `AGENTIFY.md`
 - module-root `AGENTIFY.md` files
-- `.agents/runs/*.json`
+- `.agentify/runs/*.json`
 - `agentify-report.html`
 
 Use `agentify up --provider local` when you want a cheap deterministic refresh without spending provider tokens or changing the sticky provider.
@@ -218,7 +217,7 @@ agentify sess fork --from <session-id> --name "payments-alt" "try another approa
 agentify handoff --session <session-id> "handoff to the next developer"
 ```
 
-Session artifacts live under `.agents/session/<id>/`:
+Session artifacts live under `.agentify/session/<id>/`:
 
 - `bootstrap.md`
 - `context.json`

--- a/src/core/cleanup.js
+++ b/src/core/cleanup.js
@@ -57,7 +57,7 @@ async function listModuleRootDocs(root) {
     const relativePath = relative(root, filePath);
     if (
       relativePath === "AGENTIFY.md" ||
-      relativePath.startsWith(".agents/") ||
+      relativePath.startsWith(".agentify/") ||
       relativePath.startsWith(".current_session/") ||
       relativePath.startsWith("docs/")
     ) {
@@ -71,7 +71,7 @@ async function listModuleRootDocs(root) {
 async function pruneOrphanedModuleArtifacts(root, dryRun) {
   const expectedDocs = new Set();
   const expectedMetadata = new Set();
-  if (await exists(path.join(root, ".agents", "index.db"))) {
+  if (await exists(path.join(root, ".agentify", "index.db"))) {
     const db = openIndexDatabase(root);
     try {
       for (const moduleInfo of loadModules(db)) {
@@ -80,8 +80,8 @@ async function pruneOrphanedModuleArtifacts(root, dryRun) {
     } finally {
       closeIndexDatabase(db);
     }
-  } else if (await exists(path.join(root, ".agents", "index.json"))) {
-    const legacyIndex = await readJson(path.join(root, ".agents", "index.json"));
+  } else if (await exists(path.join(root, ".agentify", "index.json"))) {
+    const legacyIndex = await readJson(path.join(root, ".agentify", "index.json"));
     for (const moduleInfo of legacyIndex.modules || []) {
       addExpectedDocPath(expectedDocs, moduleInfo.doc_path);
       if (moduleInfo.metadata_path) {
@@ -115,13 +115,13 @@ async function pruneOrphanedModuleArtifacts(root, dryRun) {
     removed.push(relativePath);
   }
 
-  const metadataDir = path.join(root, ".agents", "modules");
+  const metadataDir = path.join(root, ".agentify", "modules");
   for (const file of await listFiles(metadataDir)) {
     if (!file.endsWith(".json") || expectedMetadata.has(file)) {
       continue;
     }
     await removePath(path.join(metadataDir, file), dryRun);
-    removed.push(`.agents/modules/${file}`);
+    removed.push(`.agentify/modules/${file}`);
   }
 
   return {
@@ -227,7 +227,7 @@ async function pruneInvalidSessionDirs(root, dryRun, enabled) {
     return [];
   }
 
-  const sessionsRoot = path.join(root, ".agents", "session");
+  const sessionsRoot = path.join(root, ".agentify", "session");
   const removed = [];
   for (const dirName of await listDirs(sessionsRoot)) {
     const manifestPath = path.join(sessionsRoot, dirName, "session-manifest.json");
@@ -235,7 +235,7 @@ async function pruneInvalidSessionDirs(root, dryRun, enabled) {
       continue;
     }
     await removePath(path.join(sessionsRoot, dirName), dryRun);
-    removed.push(`.agents/session/${dirName}`);
+    removed.push(`.agentify/session/${dirName}`);
   }
   return toArray(removed);
 }
@@ -282,11 +282,11 @@ export async function runClean(root, config) {
   const cleanupConfig = config.cleanup || {};
 
   const orphaned = await pruneOrphanedModuleArtifacts(root, dryRun);
-  const runReports = await pruneRetainedFiles(path.join(root, ".agents", "runs"), {
+  const runReports = await pruneRetainedFiles(path.join(root, ".agentify", "runs"), {
     keep: cleanupConfig.keepRuns ?? 20,
     maxAgeDays: cleanupConfig.maxRunAgeDays ?? 14,
     matcher: (name) => name.endsWith(".json"),
-    relativePrefix: ".agents/runs",
+    relativePrefix: ".agentify/runs",
     dryRun,
   });
   const ghostRuns = await pruneRetainedDirs(path.join(root, ".current_session"), {
@@ -299,15 +299,15 @@ export async function runClean(root, config) {
   const invalidSessions = await pruneInvalidSessionDirs(root, dryRun, cleanupConfig.pruneInvalidSessions !== false);
   const cacheRemoved = cleanupConfig.pruneCache === false
     ? 0
-    : (await garbageCollect(path.join(root, ".agents", "cache"), config.cache?.maxAgeDays || 7, { dryRun })).removed;
+    : (await garbageCollect(path.join(root, ".agentify", "cache"), config.cache?.maxAgeDays || 7, { dryRun })).removed;
 
   const emptyDirs = [
     ...(await pruneEmptyDirs(path.join(root, "docs", "modules"), dryRun)).map((item) => `docs/modules/${item}`),
-    ...(await pruneEmptyDirs(path.join(root, ".agents", "modules"), dryRun)).map((item) => `.agents/modules/${item}`),
-    ...(await pruneEmptyDirs(path.join(root, ".agents", "runs"), dryRun)).map((item) => `.agents/runs/${item}`),
-    ...(await pruneEmptyDirs(path.join(root, ".agents", "session"), dryRun)).map((item) => `.agents/session/${item}`),
+    ...(await pruneEmptyDirs(path.join(root, ".agentify", "modules"), dryRun)).map((item) => `.agentify/modules/${item}`),
+    ...(await pruneEmptyDirs(path.join(root, ".agentify", "runs"), dryRun)).map((item) => `.agentify/runs/${item}`),
+    ...(await pruneEmptyDirs(path.join(root, ".agentify", "session"), dryRun)).map((item) => `.agentify/session/${item}`),
     ...(await pruneEmptyDirs(path.join(root, ".current_session"), dryRun)).map((item) => `.current_session/${item}`),
-    ...(await pruneEmptyDirs(path.join(root, ".agents", "cache"), dryRun)).map((item) => `.agents/cache/${item}`),
+    ...(await pruneEmptyDirs(path.join(root, ".agentify", "cache"), dryRun)).map((item) => `.agentify/cache/${item}`),
   ];
 
   const removedPaths = toArray([

--- a/src/core/commands.js
+++ b/src/core/commands.js
@@ -108,7 +108,7 @@ ${sharedConventions}
 ## Conventions
 - Generated repo docs live under \`docs/\`
 - Generated module docs live at each module root as \`AGENTIFY.md\` when the module is not the repository root
-- Indexed metadata lives under \`.agents/index.db\` and is best accessed from the host shell
+- Indexed metadata lives under \`.agentify/index.db\` and is best accessed from the host shell
 - Repo guardrails live in \`.guardrails\`
 - Local working RFCs and notes live under \`.agentify/work/\`
 - Use \`.agentignore\` to keep local-only artifacts out of scans
@@ -116,8 +116,8 @@ ${sharedConventions}
 
 ## Artifacts
 - Repo map: \`docs/repo-map.md\`
-- Machine index: \`.agents/index.db\` (host shell access is the most reliable path)
-- Run report: \`.agents/runs/${runReport.run_id}.json\`
+- Machine index: \`.agentify/index.db\` (host shell access is the most reliable path)
+- Run report: \`.agentify/runs/${runReport.run_id}.json\`
 
 ## Run Metrics
 - Modules processed: ${runReport.results.modules_processed}
@@ -155,7 +155,7 @@ ${index.modules.map(moduleLink).join("\n")}
 }
 
 async function writeRunReport(root, report) {
-  const runPath = path.join(root, ".agents", "runs", `${report.run_id}.json`);
+  const runPath = path.join(root, ".agentify", "runs", `${report.run_id}.json`);
   await writeJson(runPath, report);
   return runPath;
 }
@@ -201,7 +201,7 @@ function renderDefaultGuardrails() {
 - Do not commit knowingly broken code just to checkpoint progress.
 
 ## Protected Paths
-- Do not edit \`.agents/\`, generated \`AGENTIFY.md\` files, \`docs/repo-map.md\`, \`output.txt\`, or \`agentify-report.html\` directly; regenerate them through Agentify commands.
+- Do not edit \`.agentify/\`, generated \`AGENTIFY.md\` files, \`docs/repo-map.md\`, \`output.txt\`, or \`agentify-report.html\` directly; regenerate them through Agentify commands.
 - Do not edit provider-installed skill directories under \`.codex/\`, \`.claude/\`, \`.gemini/\`, or \`.opencode/\` unless the task is specifically about those files.
 - Put local architecture RFCs, notes, and scratch outputs under \`.agentify/work/\`.
 
@@ -224,8 +224,8 @@ export async function ensureBaselineArtifacts(root, config) {
   if (config.dryRun) {
     return;
   }
-  await ensureDir(path.join(root, ".agents"));
-  await ensureDir(path.join(root, ".agents", "runs"));
+  await ensureDir(path.join(root, ".agentify"));
+  await ensureDir(path.join(root, ".agentify", "runs"));
   await ensureDir(path.join(root, ".agentify", "work"));
   await ensureDir(path.join(root, "docs", "modules"));
   await writeTextIfMissing(path.join(root, ".agentignore"), renderDefaultAgentignore());
@@ -271,7 +271,7 @@ function buildRenderableIndex(root, meta, modules) {
     entrypoints: modules.flatMap((moduleInfo) => moduleInfo.entry_files || []),
     symbol_index_hint: {
       enabled: true,
-      note: "symbol spans are stored in .agents/index.db"
+      note: "symbol spans are stored in .agentify/index.db"
     }
   };
 }
@@ -494,7 +494,7 @@ async function _runScanInner(root, config, options, progress) {
     detected_stacks: snapshot.repo.detected_stacks,
     default_stack: snapshot.repo.default_stack,
     modules: snapshot.modules.map((moduleInfo) => ({ id: moduleInfo.id, root_path: moduleInfo.root_path })),
-    wrote: config.dryRun ? [] : [".agents/index.db", "docs/repo-map.md"],
+    wrote: config.dryRun ? [] : [".agentify/index.db", "docs/repo-map.md"],
   };
   progress.setCommand(options.commandName || "scan");
   progress.setScan(result);
@@ -698,7 +698,7 @@ async function _runDocInner(root, config, options, progress) {
   const fallbackProvider = provider.name === "local" ? provider : createProvider("local", config);
   const now = new Date().toISOString();
   const headCommit = await getHeadCommit(root);
-  const dbPath = path.join(artifactRoot, ".agents", "index.db");
+  const dbPath = path.join(artifactRoot, ".agentify", "index.db");
   const scanSnapshot = options.scanSnapshot || null;
 
   if (!config.dryRun && (scanSnapshot || !(await exists(dbPath)))) {
@@ -1104,7 +1104,7 @@ async function _runDocInner(root, config, options, progress) {
       docs_written: docsWritten,
       provider_status: runReport.provider_status,
       token_usage: runReport.token_usage,
-      wrote: config.dryRun ? [] : ["AGENTIFY.md", "<module-root>/AGENTIFY.md", ".agents/index.db", ".agents/runs/*.json"],
+      wrote: config.dryRun ? [] : ["AGENTIFY.md", "<module-root>/AGENTIFY.md", ".agentify/index.db", ".agentify/runs/*.json"],
     };
     progress.setCommand("doc");
     progress.setDoc(result);

--- a/src/core/context-events.js
+++ b/src/core/context-events.js
@@ -31,7 +31,7 @@ function normalizeConfidence(value) {
 export function getContextEventLogPath(root, options = {}) {
   if (options.sessionId) {
     const sessionId = assertRuntimeId(options.sessionId, "session id");
-    return path.join(root, ".agents", "session", sessionId, "context-events.jsonl");
+    return path.join(root, ".agentify", "session", sessionId, "context-events.jsonl");
   }
 
   const runId = assertRuntimeId(options.runId, "run id");

--- a/src/core/context.js
+++ b/src/core/context.js
@@ -204,7 +204,7 @@ export function buildRoutedPrompt(basePrompt, memoryMarkdown = "", options = {})
     "You are running in Agentify routed context mode.",
     "",
     "Context routing rules:",
-    "- Start from repo docs and DB refs: AGENTIFY.md, docs/repo-map.md, docs/modules/, and .agents/index.db.",
+    "- Start from repo docs and DB refs: AGENTIFY.md, docs/repo-map.md, docs/modules/, and .agentify/index.db.",
     "- No full source file bodies are injected by default.",
     "- For more repository context, use only these bounded Agentify commands:",
     "  - agentify context search <term>",

--- a/src/core/db/connection.js
+++ b/src/core/db/connection.js
@@ -53,7 +53,7 @@ function openWithNodeSqlite(filename, options = {}) {
 }
 
 export function getIndexDbPath(root) {
-  return path.join(root, ".agents", "index.db");
+  return path.join(root, ".agentify", "index.db");
 }
 
 function createIndexSnapshot(dbPath) {

--- a/src/core/exec.js
+++ b/src/core/exec.js
@@ -13,9 +13,8 @@ import * as ui from "./ui.js";
 const AGENTIFY_EXIT_VALIDATE_FAILED = 80;
 const AGENTIFY_EXIT_REFRESH_ERROR = 81;
 const REFRESH_NEUTRAL_PATH_PATTERNS = [
-  /^\.agents(\/|$)/,
+  /^\.agentify(\/|$)/,
   /^\.current_session(\/|$)/,
-  /^\.agentify\/work(\/|$)/,
   /^docs\/repo-map\.md$/,
   /^docs\/modules(\/|$)/,
   /^output\.txt$/,

--- a/src/core/fs.js
+++ b/src/core/fs.js
@@ -23,7 +23,7 @@ const SKIP_DIRS = new Set([
 ]);
 
 const HARD_EXCLUDES = [
-  /^\.agents\//,
+  /^\.agentify\//,
   /^\.current_session\//,
   /^docs\//,
   /^agentify-report\.html$/,

--- a/src/core/gitignore.js
+++ b/src/core/gitignore.js
@@ -7,14 +7,18 @@ export const AGENTIFY_GITIGNORE_START = "# >>> agentify generated artifacts";
 export const AGENTIFY_GITIGNORE_END = "# <<< agentify generated artifacts";
 
 export const AGENTIFY_GITIGNORE_PATTERNS = [
-  ".agents/",
-  ".agentify/work/",
+  ".agentify/",
   ".current_session/",
   "AGENTIFY.md",
   "docs/repo-map.md",
   "docs/modules/",
   "output.txt",
   "agentify-report.html",
+];
+
+const LEGACY_AGENTIFY_GITIGNORE_PATTERNS = [
+  ".agents/",
+  ".agentify/work/",
 ];
 
 const AGENTIFY_GITIGNORE_HEADER =
@@ -42,7 +46,10 @@ function normalizeText(text) {
 }
 
 function collectPreservedBlockLines(blockText) {
-  const managedLines = new Set(getManagedGitignoreLines().map((line) => line.trim()));
+  const managedLines = new Set([
+    ...getManagedGitignoreLines(),
+    ...LEGACY_AGENTIFY_GITIGNORE_PATTERNS,
+  ].map((line) => line.trim()));
   const seen = new Set();
   const preserved = [];
 

--- a/src/core/handoff.js
+++ b/src/core/handoff.js
@@ -123,7 +123,7 @@ function summarizeTests(plan) {
 }
 
 async function loadTouchedSymbolNeighborhood(root, touchedFiles) {
-  if (touchedFiles.length === 0 || !(await exists(path.join(root, ".agents", "index.db")))) {
+  if (touchedFiles.length === 0 || !(await exists(path.join(root, ".agentify", "index.db")))) {
     return [];
   }
 
@@ -232,7 +232,7 @@ async function collectConflictHints(root, sessionId, touchedFiles) {
       name: session.name || null,
       severity: overlap.length >= 3 ? "high" : "medium",
       overlap_files: overlap,
-      handoff_path: `.agents/session/${session.session_id}/handoff.json`,
+      handoff_path: `.agentify/session/${session.session_id}/handoff.json`,
     });
   }
 
@@ -350,12 +350,12 @@ export async function buildHandoffBundle(root, config, sessionId, task = "") {
     base_head: manifest.head_commit_at_creation || "unknown",
     current_head: currentHead,
     artifact_refs: {
-      markdown: `.agents/session/${sessionId}/handoff.md`,
-      json: `.agents/session/${sessionId}/handoff.json`,
-      manifest: `.agents/session/${sessionId}/session-manifest.json`,
-      context: `.agents/session/${sessionId}/context.json`,
-      checklist: `.agents/session/${sessionId}/checklist.json`,
-      transcript: `.agents/session/${sessionId}/transcript.md`,
+      markdown: `.agentify/session/${sessionId}/handoff.md`,
+      json: `.agentify/session/${sessionId}/handoff.json`,
+      manifest: `.agentify/session/${sessionId}/session-manifest.json`,
+      context: `.agentify/session/${sessionId}/context.json`,
+      checklist: `.agentify/session/${sessionId}/checklist.json`,
+      transcript: `.agentify/session/${sessionId}/transcript.md`,
     },
     top_ranked_context: summarizePlan(plan),
     touched_files: touchedFiles,

--- a/src/core/lock.js
+++ b/src/core/lock.js
@@ -31,7 +31,7 @@ function canReclaimLock(existing) {
 }
 
 export async function acquireLock(root, operation) {
-  const lockPath = path.join(root, ".agents", ".lock");
+  const lockPath = path.join(root, ".agentify", ".lock");
 
   try {
     await fs.mkdir(path.dirname(lockPath), { recursive: true });

--- a/src/core/repo-sync.js
+++ b/src/core/repo-sync.js
@@ -9,8 +9,8 @@ import { syncProjectBuiltinSkills } from "./skills.js";
 import * as ui from "./ui.js";
 
 const BASELINE_ARTIFACTS = [
-  ".agents",
-  ".agents/runs",
+  ".agentify",
+  ".agentify/runs",
   ".agentify/work",
   "docs/modules",
   ".agentignore",

--- a/src/core/run-report.js
+++ b/src/core/run-report.js
@@ -1210,7 +1210,7 @@ export function createRunReporter(root) {
       loader.clear();
       summary.execution = normalizeExecutionTelemetry(result);
       if (summary.execution) {
-        const telemetryPath = `.agents/runs/${summary.execution.run_id}-execution-telemetry.json`;
+        const telemetryPath = `.agentify/runs/${summary.execution.run_id}-execution-telemetry.json`;
         summary.artifacts = Array.from(new Set([...summary.artifacts, telemetryPath]));
         record(renderExecutionOutputBlock(summary.execution));
       }
@@ -1220,7 +1220,7 @@ export function createRunReporter(root) {
       const htmlPath = path.join(root, "agentify-report.html");
       let telemetryJsonPath = null;
       if (summary.execution) {
-        telemetryJsonPath = path.join(root, ".agents", "runs", `${summary.execution.run_id}-execution-telemetry.json`);
+        telemetryJsonPath = path.join(root, ".agentify", "runs", `${summary.execution.run_id}-execution-telemetry.json`);
         await writeJson(telemetryJsonPath, summary.execution);
       }
       await writeText(outputPath, events.join(""));

--- a/src/core/semantic.js
+++ b/src/core/semantic.js
@@ -772,7 +772,7 @@ export async function runSemanticRefresh(root, config, options = {}) {
 
   const artifactRoot = options.artifactRoot || root;
   if (!config.dryRun) {
-    await ensureDir(path.join(artifactRoot, ".agents"));
+    await ensureDir(path.join(artifactRoot, ".agentify"));
   }
   const db = openIndexDatabase(artifactRoot);
   const { projects: discoveredProjects, repoIndex } = await discoverAllSemanticProjects(root, config);

--- a/src/core/session-memory.js
+++ b/src/core/session-memory.js
@@ -340,7 +340,7 @@ function getRepoWing(root) {
 }
 
 async function listSessionTranscripts(root) {
-  const sessionsDir = path.join(root, ".agents", "session");
+  const sessionsDir = path.join(root, ".agentify", "session");
   if (!(await exists(sessionsDir))) {
     return [];
   }
@@ -370,7 +370,7 @@ async function listSessionTranscripts(root) {
 }
 
 async function listStructuredSessionTurns(root) {
-  const sessionsDir = path.join(root, ".agents", "session");
+  const sessionsDir = path.join(root, ".agentify", "session");
   if (!(await exists(sessionsDir))) {
     return [];
   }
@@ -400,7 +400,7 @@ async function listStructuredSessionTurns(root) {
 }
 
 function getMemPalacePaths(root) {
-  const baseDir = path.join(root, ".agents", "mempalace");
+  const baseDir = path.join(root, ".agentify", "mempalace");
   return {
     baseDir,
     palacePath: path.join(baseDir, "palace"),
@@ -627,7 +627,7 @@ async function createTranscriptSearchBackend(root, query, config, sharedInventor
 
       return buildMemoryResult("local-session-search", hits, [
         `- Query: ${query}`,
-        `- Search scope: \`${relative(root, path.join(root, ".agents", "session"))}/\``,
+        `- Search scope: \`${relative(root, path.join(root, ".agentify", "session"))}/\``,
       ], maxBytes);
     },
   };
@@ -763,7 +763,7 @@ async function createMemoryBackends(root, options, config) {
 }
 
 export function getSessionArtifactPaths(root, sessionId) {
-  const sessionDir = path.join(root, ".agents", "session", sessionId);
+  const sessionDir = path.join(root, ".agentify", "session", sessionId);
   return {
     sessionDir,
     transcriptPath: path.join(sessionDir, "transcript.md"),
@@ -1082,11 +1082,11 @@ export async function prepareSessionMemoryRun(root, sessionRecord, config) {
       `Started: ${startedAt}`,
       `Capture mode: ${sessionRecord.captureMode}`,
       `Command: ${normalizeCommand(sessionRecord.command) || "n/a"}`,
-      `Bootstrap: .agents/session/${sessionRecord.sessionId}/bootstrap.md`,
+      `Bootstrap: .agentify/session/${sessionRecord.sessionId}/bootstrap.md`,
       `Memory context: ${relative(root, paths.memoryContextPath)}`,
       "",
       "> Session bootstrap reference",
-      `Bootstrap context is persisted in \`.agents/session/${sessionRecord.sessionId}/bootstrap.md\`.`,
+      `Bootstrap context is persisted in \`.agentify/session/${sessionRecord.sessionId}/bootstrap.md\`.`,
       "",
       "> Automatic session memory",
       redactSensitiveText(sessionRecord.memoryContext?.excerpt || "No prior session transcript was available for automatic recall before this run."),

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -32,11 +32,11 @@ export function validateSessionId(sessionId, label = "session id") {
 
 function resolveSessionDirSafely(root, sessionId, label = "session id") {
   validateSessionId(sessionId, label);
-  const sessionsRoot = path.resolve(root, ".agents", "session");
+  const sessionsRoot = path.resolve(root, ".agentify", "session");
   const sessionDir = path.resolve(sessionsRoot, sessionId);
   const expectedPrefix = sessionsRoot + path.sep;
   if (!sessionDir.startsWith(expectedPrefix) || path.dirname(sessionDir) !== sessionsRoot) {
-    throw new Error(`Invalid ${label}: resolved path escapes \`.agents/session/\``);
+    throw new Error(`Invalid ${label}: resolved path escapes \`.agentify/session/\``);
   }
   return sessionDir;
 }
@@ -89,25 +89,25 @@ function summarizeModules(moduleIds, maxItems) {
   const visible = moduleIds.slice(0, maxItems);
   const remaining = moduleIds.length - visible.length;
   if (visible.length === 0) {
-    return `${moduleIds.length} indexed modules (see .agents/index.db)`;
+    return `${moduleIds.length} indexed modules (see .agentify/index.db)`;
   }
 
   return remaining > 0
-    ? `${visible.join(", ")}, +${remaining} more (host shell index: .agents/index.db)`
+    ? `${visible.join(", ")}, +${remaining} more (host shell index: .agentify/index.db)`
     : visible.join(", ");
 }
 
 function renderChecklistMarkdown(sessionId, checklist, totalItems) {
   if (checklist.length === 0) {
     return totalItems > 0
-      ? `- ${totalItems} checklist item(s) omitted. See \`.agents/session/${sessionId}/checklist.json\`.`
+      ? `- ${totalItems} checklist item(s) omitted. See \`.agentify/session/${sessionId}/checklist.json\`.`
       : "- No checklist items.";
   }
 
   const lines = checklist.map((item) => `- [${item.done ? "x" : " "}] ${item.text}`);
   const remaining = totalItems - checklist.length;
   if (remaining > 0) {
-    lines.push(`- ... ${remaining} more item(s) in \`.agents/session/${sessionId}/checklist.json\`.`);
+    lines.push(`- ... ${remaining} more item(s) in \`.agentify/session/${sessionId}/checklist.json\`.`);
   }
   return lines.join("\n");
 }
@@ -129,15 +129,15 @@ function fitContext(manifest, index, checklist, options, config) {
   const staleModules = [];
   const maxBytes = getSessionLimitKb(config, "contextMaxKb", 16) * 1024;
   const memoryArtifacts = getSessionArtifactPaths(options.root || "", manifest.session_id);
-  const transcriptRef = options.root ? `.agents/session/${manifest.session_id}/transcript.md` : memoryArtifacts.transcriptPath;
-  const memoryContextRef = options.root ? `.agents/session/${manifest.session_id}/memory-context.md` : memoryArtifacts.memoryContextPath;
-  const handoffJsonRef = options.root ? `.agents/session/${manifest.session_id}/handoff.json` : memoryArtifacts.handoffJsonPath;
-  const handoffMarkdownRef = options.root ? `.agents/session/${manifest.session_id}/handoff.md` : memoryArtifacts.handoffMarkdownPath;
-  const launchesRef = options.root ? `.agents/session/${manifest.session_id}/launches.jsonl` : memoryArtifacts.launchesPath;
-  const turnsRef = options.root ? `.agents/session/${manifest.session_id}/turns.jsonl` : memoryArtifacts.turnsPath;
-  const fetchOutputsRef = options.root ? `.agents/session/${manifest.session_id}/context-fetches.jsonl` : memoryArtifacts.fetchOutputsPath;
-  const contextFactsRef = options.root ? `.agents/session/${manifest.session_id}/context-facts.json` : memoryArtifacts.contextFactsPath;
-  const contextFactsMarkdownRef = options.root ? `.agents/session/${manifest.session_id}/context-facts.md` : memoryArtifacts.contextFactsMarkdownPath;
+  const transcriptRef = options.root ? `.agentify/session/${manifest.session_id}/transcript.md` : memoryArtifacts.transcriptPath;
+  const memoryContextRef = options.root ? `.agentify/session/${manifest.session_id}/memory-context.md` : memoryArtifacts.memoryContextPath;
+  const handoffJsonRef = options.root ? `.agentify/session/${manifest.session_id}/handoff.json` : memoryArtifacts.handoffJsonPath;
+  const handoffMarkdownRef = options.root ? `.agentify/session/${manifest.session_id}/handoff.md` : memoryArtifacts.handoffMarkdownPath;
+  const launchesRef = options.root ? `.agentify/session/${manifest.session_id}/launches.jsonl` : memoryArtifacts.launchesPath;
+  const turnsRef = options.root ? `.agentify/session/${manifest.session_id}/turns.jsonl` : memoryArtifacts.turnsPath;
+  const fetchOutputsRef = options.root ? `.agentify/session/${manifest.session_id}/context-fetches.jsonl` : memoryArtifacts.fetchOutputsPath;
+  const contextFactsRef = options.root ? `.agentify/session/${manifest.session_id}/context-facts.json` : memoryArtifacts.contextFactsPath;
+  const contextFactsMarkdownRef = options.root ? `.agentify/session/${manifest.session_id}/context-facts.md` : memoryArtifacts.contextFactsMarkdownPath;
   const attempts = [
     { moduleLimit: moduleIds.length, checklistLimit: checklist.length, checklistTextBytes: 240, parentSummaryBytes: 2048, runHistoryLimit: 10, runSummaryBytes: 256, rollingSummaryBytes: 1024 },
     { moduleLimit: 64, checklistLimit: 20, checklistTextBytes: 180, parentSummaryBytes: 1024, runHistoryLimit: 6, runSummaryBytes: 180, rollingSummaryBytes: 512 },
@@ -152,13 +152,13 @@ function fitContext(manifest, index, checklist, options, config) {
     const runHistory = clampRunHistory(options.runHistory || [], attempt.runHistoryLimit, attempt.runSummaryBytes);
     const includeHandoffRefs = attempt !== attempts[attempts.length - 1];
     const cacheRefs = attempt.minimalRefs ? {
-      repo_index: ".agents/index.db",
+      repo_index: ".agentify/index.db",
       repo_docs: "AGENTIFY.md and module-root AGENTIFY.md files",
-      checklist: `.agents/session/${manifest.session_id}/checklist.json`,
+      checklist: `.agentify/session/${manifest.session_id}/checklist.json`,
     } : {
-      repo_index: ".agents/index.db",
+      repo_index: ".agentify/index.db",
       repo_docs: "AGENTIFY.md and module-root AGENTIFY.md files",
-      checklist: `.agents/session/${manifest.session_id}/checklist.json`,
+      checklist: `.agentify/session/${manifest.session_id}/checklist.json`,
       transcript: transcriptRef,
       memory_context: memoryContextRef,
       ...(includeHandoffRefs ? {
@@ -236,7 +236,7 @@ export function synthesizeBootstrapFromContext(manifest, context) {
 - HEAD: ${manifest.head_commit_at_creation}
 - Module count: ${moduleCount}
 - Module preview: ${summarizeModules(moduleIds, Math.min(moduleIds.length, 12))}
-- Full routing: host shell -> .agents/index.db
+- Full routing: host shell -> .agentify/index.db
 
 ## Checklist Status
 ${renderChecklistMarkdown(manifest.session_id, checklist, checklistSummary.total_items ?? checklist.length)}
@@ -255,7 +255,7 @@ function fitBootstrap(manifest, index, checklist, options, config) {
   const baseStartHere = options.startHere || [
     "- Read root `AGENTIFY.md` for the current repo snapshot and module guidance.",
     "- Use `docs/repo-map.md` and module-root `AGENTIFY.md` files for deterministic structure before reaching for provider tools.",
-    "- Treat `.agents/index.db` as a host-shell artifact. Inside provider sessions, prefer the generated markdown docs before reaching for nested Agentify or SQLite commands.",
+    "- Treat `.agentify/index.db` as a host-shell artifact. Inside provider sessions, prefer the generated markdown docs before reaching for nested Agentify or SQLite commands.",
   ].join("\n");
   const attempts = [
     { moduleLimit: moduleIds.length, checklistLimit: checklist.length, checklistTextBytes: 240, startHereBytes: 1200 },
@@ -280,7 +280,7 @@ function fitBootstrap(manifest, index, checklist, options, config) {
 - HEAD: ${manifest.head_commit_at_creation}
 - Module count: ${moduleIds.length}
 - Module preview: ${summarizeModules(moduleIds, attempt.moduleLimit)}
-- Full routing: host shell -> .agents/index.db
+- Full routing: host shell -> .agentify/index.db
 
 ## Checklist Status
 ${renderChecklistMarkdown(manifest.session_id, previewChecklist, checklist.length)}
@@ -300,12 +300,12 @@ ${clipToBytes(baseStartHere, attempt.startHereBytes) || "- Inspect the session c
 
 export async function forkSession(root, config, options = {}) {
   const sessionId = generateSessionId();
-  const sessionDir = path.join(root, ".agents", "session", sessionId);
+  const sessionDir = path.join(root, ".agentify", "session", sessionId);
   await ensureDir(sessionDir);
 
   const headCommit = await getHeadCommit(root);
   let index = null;
-  if (await exists(path.join(root, ".agents", "index.db"))) {
+  if (await exists(path.join(root, ".agentify", "index.db"))) {
     const db = openIndexDatabase(root, { readOnly: true });
     try {
       index = {
@@ -328,21 +328,21 @@ export async function forkSession(root, config, options = {}) {
     name: options.name || null,
     status: "active",
     head_commit_at_creation: headCommit,
-    index_snapshot: ".agents/index.db",
+    index_snapshot: ".agentify/index.db",
     cache_refs: [
-      `.agents/session/${sessionId}/context.json`,
-      `.agents/session/${sessionId}/checklist.json`,
-      `.agents/session/${sessionId}/launches.jsonl`,
-      `.agents/session/${sessionId}/turns.jsonl`,
-      `.agents/session/${sessionId}/context-events.jsonl`,
-      `.agents/session/${sessionId}/handoff.json`,
-      `.agents/session/${sessionId}/handoff.md`,
-      `.agents/session/${sessionId}/bootstrap.md`,
-      `.agents/session/${sessionId}/transcript.md`,
-      `.agents/session/${sessionId}/memory-context.md`,
-      `.agents/session/${sessionId}/context-facts.json`,
-      `.agents/session/${sessionId}/context-facts.md`,
-      `.agents/session/${sessionId}/context-fetches.jsonl`,
+      `.agentify/session/${sessionId}/context.json`,
+      `.agentify/session/${sessionId}/checklist.json`,
+      `.agentify/session/${sessionId}/launches.jsonl`,
+      `.agentify/session/${sessionId}/turns.jsonl`,
+      `.agentify/session/${sessionId}/context-events.jsonl`,
+      `.agentify/session/${sessionId}/handoff.json`,
+      `.agentify/session/${sessionId}/handoff.md`,
+      `.agentify/session/${sessionId}/bootstrap.md`,
+      `.agentify/session/${sessionId}/transcript.md`,
+      `.agentify/session/${sessionId}/memory-context.md`,
+      `.agentify/session/${sessionId}/context-facts.json`,
+      `.agentify/session/${sessionId}/context-facts.md`,
+      `.agentify/session/${sessionId}/context-fetches.jsonl`,
     ],
     metadata: {
       modules_indexed: index?.modules?.length || 0,
@@ -425,7 +425,7 @@ export async function forkSession(root, config, options = {}) {
 }
 
 export async function listSessions(root) {
-  const sessionsDir = path.join(root, ".agents", "session");
+  const sessionsDir = path.join(root, ".agentify", "session");
   if (!(await exists(sessionsDir))) return [];
 
   const entries = await fs.readdir(sessionsDir, { withFileTypes: true });

--- a/src/core/toolchain.js
+++ b/src/core/toolchain.js
@@ -151,7 +151,7 @@ async function buildSemanticDoctorReport(root, config) {
   const parseFailures = await discoverSemanticProjectParseFailures(root);
   const discoveredById = new Map(discoveredProjects.map((project) => [project.id, project]));
   const discoveredIds = new Set(discoveredById.keys());
-  const dbPath = `${root}/.agents/index.db`;
+  const dbPath = `${root}/.agentify/index.db`;
   const indexPresent = await exists(dbPath);
   const failures = [];
   const staleFingerprints = [];
@@ -168,7 +168,7 @@ async function buildSemanticDoctorReport(root, config) {
     failures.push({
       category: "missing-index",
       project_id: null,
-      message: "missing .agents/index.db; run `agentify scan` and `agentify semantic refresh`",
+      message: "missing .agentify/index.db; run `agentify scan` and `agentify semantic refresh`",
     });
   }
   for (const failure of parseFailures) {
@@ -374,7 +374,7 @@ export async function runDoctor(root, config, options = {}) {
   if (semanticReport) {
     renderSemanticDoctorReport(semanticReport);
   } else if (config.semantic?.tsjs?.enabled && root) {
-    const dbPath = `${root}/.agents/index.db`;
+    const dbPath = `${root}/.agentify/index.db`;
     if (await exists(dbPath)) {
       const db = openIndexDatabase(root, { readOnly: true });
       try {

--- a/src/core/validate.js
+++ b/src/core/validate.js
@@ -18,9 +18,8 @@ const ALLOWED_DOC_PATHS = [
   /^\.agentignore$/,
   /^\.guardrails$/,
   /^\.gitignore$/,
-  /^\.agentify\/work\//,
   /^docs\//,
-  /^\.agents\//,
+  /^\.agentify\//,
   /^\.codex(\/|$)/,
   /^\.claude(\/|$)/,
   /^\.gemini(\/|$)/,
@@ -38,7 +37,7 @@ export const FAILURE_CATEGORIES = {
 
 const REMEDIATION_HINTS = {
   [FAILURE_CATEGORIES.UNSAFE_PATH]:
-    "Only recognized Agentify paths (.agents/, docs/, generated AGENTIFY.md files, .agentify/work/, provider skill dirs, .guardrails, .agentignore, .gitignore) and code files with header-only changes are allowed. Run 'git checkout -- <path>' to revert.",
+    "Only recognized Agentify paths (.agentify/, docs/, generated AGENTIFY.md files, provider skill dirs, .guardrails, .agentignore, .gitignore) and code files with header-only changes are allowed. Run 'git checkout -- <path>' to revert.",
   [FAILURE_CATEGORIES.CODE_BODY_CHANGED]:
     "Agentify only modifies @agentify headers. If you edited this file intentionally, commit it separately before running agentify.",
   [FAILURE_CATEGORIES.FRESHNESS_STALE]:
@@ -81,13 +80,13 @@ export function validateHeaderOnlyChange(before, after, filePath, headerWindow =
 
 async function validateFreshness(root, failures, options = {}) {
   const targetRoot = options.artifactRoot || root;
-  const indexPath = path.join(targetRoot, ".agents", "index.db");
+  const indexPath = path.join(targetRoot, ".agentify", "index.db");
   if (!(await exists(indexPath))) {
     failures.push(
       createFailure(
         FAILURE_CATEGORIES.FRESHNESS_STALE,
-        ".agents/index.db",
-        "missing .agents/index.db"
+        ".agentify/index.db",
+        "missing .agentify/index.db"
       )
     );
     return;
@@ -100,7 +99,7 @@ async function validateFreshness(root, failures, options = {}) {
       failures.push(
         createFailure(
           FAILURE_CATEGORIES.FRESHNESS_STALE,
-          ".agents/index.db",
+          ".agentify/index.db",
           `stale index head_commit: expected ${headCommit}, found ${meta.head_commit || "unknown"}`
         )
       );
@@ -131,7 +130,7 @@ async function validateFreshness(root, failures, options = {}) {
           failures.push(
             createFailure(
               FAILURE_CATEGORIES.FRESHNESS_STALE,
-              ".agents/index.db",
+              ".agentify/index.db",
               `semantic project ${projectInfo.project_id} is ${projectInfo.status}`
             )
           );
@@ -140,7 +139,7 @@ async function validateFreshness(root, failures, options = {}) {
           failures.push(
             createFailure(
               FAILURE_CATEGORIES.FRESHNESS_STALE,
-              ".agents/index.db",
+              ".agentify/index.db",
               `semantic project ${projectInfo.project_id} has partial coverage`
             )
           );
@@ -210,7 +209,7 @@ export async function validateRepo(root, config, options = {}) {
   const targetRoot = options.artifactRoot || root;
   const allFiles = (await walkFiles(targetRoot, { respectIgnore: true })).map((file) => relative(targetRoot, file));
   const unsafeGeneratedFiles = allFiles
-    .filter((file) => file.startsWith(".agents/") || file.startsWith("docs/"))
+    .filter((file) => file.startsWith(".agentify/") || file.startsWith("docs/"))
     .filter((file) => !isAllowedPath(file));
   for (const file of unsafeGeneratedFiles) {
     failures.push(

--- a/src/main.js
+++ b/src/main.js
@@ -603,7 +603,7 @@ export async function runCli(argv, runtime = {}) {
             command: "init",
             root,
             dry_run: Boolean(config.dryRun),
-            wrote: config.dryRun ? [] : [".agentify.yaml", ".gitignore", ".agentignore", ".guardrails", ".agentify/work", ".agents", "docs/modules"],
+            wrote: config.dryRun ? [] : [".agentify.yaml", ".gitignore", ".agentignore", ".guardrails", ".agentify", ".agentify/runs", ".agentify/work", "docs/modules"],
             skill_install_hint: skillInstallHint,
           }, null, 2));
         } else {
@@ -1122,7 +1122,7 @@ export async function runCli(argv, runtime = {}) {
       }
 
       case "cache": {
-        const cacheRoot = path.join(root, ".agents", "cache");
+        const cacheRoot = path.join(root, ".agentify", "cache");
         if (subcommand === "gc") {
           const maxAge = args.maxAge || config.cache?.maxAgeDays || 7;
           const result = await garbageCollect(cacheRoot, maxAge);

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -238,7 +238,7 @@ test("runBootstrapCommand bootstraps a repo and persists provider", async () => 
     "brew:tree-sitter-cli",
     "npm:@openai/codex",
   ]);
-  await assert.doesNotReject(() => fs.access(path.join(root, ".agents")));
+  await assert.doesNotReject(() => fs.access(path.join(root, ".agentify")));
   await assert.doesNotReject(() => fs.access(path.join(root, "docs", "modules")));
   await assert.rejects(() => fs.access(path.join(root, ".codex", "skills")), { code: "ENOENT" });
 });

--- a/test/cleanup.test.js
+++ b/test/cleanup.test.js
@@ -15,19 +15,19 @@ async function setOldMtime(targetPath, daysAgo) {
 test("runClean prunes orphaned Agentify artifacts and stale folders", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-clean-"));
   await fs.mkdir(path.join(root, "docs", "modules"), { recursive: true });
-  await fs.mkdir(path.join(root, ".agents", "modules"), { recursive: true });
-  await fs.mkdir(path.join(root, ".agents", "runs"), { recursive: true });
-  await fs.mkdir(path.join(root, ".agents", "session", "broken"), { recursive: true });
+  await fs.mkdir(path.join(root, ".agentify", "modules"), { recursive: true });
+  await fs.mkdir(path.join(root, ".agentify", "runs"), { recursive: true });
+  await fs.mkdir(path.join(root, ".agentify", "session", "broken"), { recursive: true });
   await fs.mkdir(path.join(root, ".current_session", "ghost_old"), { recursive: true });
   await fs.mkdir(path.join(root, ".current_session", "ghost_keep"), { recursive: true });
   await fs.mkdir(path.join(root, "src", "payments"), { recursive: true });
   await fs.mkdir(path.join(root, "src", "dead"), { recursive: true });
 
-  await fs.writeFile(path.join(root, ".agents", "index.json"), JSON.stringify({
+  await fs.writeFile(path.join(root, ".agentify", "index.json"), JSON.stringify({
     modules: [
       {
         doc_path: "docs/modules/auth.md",
-        metadata_path: ".agents/modules/auth.json"
+        metadata_path: ".agentify/modules/auth.json"
       },
       {
         doc_path: "src/payments/AGENTIFY.md"
@@ -39,14 +39,14 @@ test("runClean prunes orphaned Agentify artifacts and stale folders", async () =
   await fs.writeFile(path.join(root, "AGENTIFY.md"), "# repo\n");
   await fs.writeFile(path.join(root, "src", "payments", "AGENTIFY.md"), "# payments\n");
   await fs.writeFile(path.join(root, "src", "dead", "AGENTIFY.md"), "# dead module\n");
-  await fs.writeFile(path.join(root, ".agents", "modules", "auth.json"), "{}\n");
-  await fs.writeFile(path.join(root, ".agents", "modules", "dead.json"), "{}\n");
-  await fs.writeFile(path.join(root, ".agents", "runs", "keep.json"), "{}\n");
-  await fs.writeFile(path.join(root, ".agents", "runs", "old.json"), "{}\n");
+  await fs.writeFile(path.join(root, ".agentify", "modules", "auth.json"), "{}\n");
+  await fs.writeFile(path.join(root, ".agentify", "modules", "dead.json"), "{}\n");
+  await fs.writeFile(path.join(root, ".agentify", "runs", "keep.json"), "{}\n");
+  await fs.writeFile(path.join(root, ".agentify", "runs", "old.json"), "{}\n");
   await fs.writeFile(path.join(root, ".current_session", "ghost_old", "ghost-report.json"), "{}\n");
   await fs.writeFile(path.join(root, ".current_session", "ghost_keep", "ghost-report.json"), "{}\n");
 
-  await setOldMtime(path.join(root, ".agents", "runs", "old.json"), 10);
+  await setOldMtime(path.join(root, ".agentify", "runs", "old.json"), 10);
   await setOldMtime(path.join(root, ".current_session", "ghost_old"), 10);
 
   const config = await loadConfig(root, { provider: "local" });
@@ -59,43 +59,43 @@ test("runClean prunes orphaned Agentify artifacts and stale folders", async () =
 
   assert.ok(result.removed_paths.includes("docs/modules/dead.md"));
   assert.ok(result.removed_paths.includes("src/dead/AGENTIFY.md"));
-  assert.ok(result.removed_paths.includes(".agents/modules/dead.json"));
-  assert.ok(result.removed_paths.includes(".agents/runs/old.json"));
+  assert.ok(result.removed_paths.includes(".agentify/modules/dead.json"));
+  assert.ok(result.removed_paths.includes(".agentify/runs/old.json"));
   assert.ok(result.removed_paths.includes(".current_session/ghost_old"));
-  assert.ok(result.removed_paths.includes(".agents/session/broken"));
+  assert.ok(result.removed_paths.includes(".agentify/session/broken"));
 
   assert.equal(await fs.stat(path.join(root, "docs", "modules", "dead.md")).then(() => true).catch(() => false), false);
   assert.equal(await fs.stat(path.join(root, "src", "dead", "AGENTIFY.md")).then(() => true).catch(() => false), false);
-  assert.equal(await fs.stat(path.join(root, ".agents", "modules", "dead.json")).then(() => true).catch(() => false), false);
-  assert.equal(await fs.stat(path.join(root, ".agents", "runs", "old.json")).then(() => true).catch(() => false), false);
+  assert.equal(await fs.stat(path.join(root, ".agentify", "modules", "dead.json")).then(() => true).catch(() => false), false);
+  assert.equal(await fs.stat(path.join(root, ".agentify", "runs", "old.json")).then(() => true).catch(() => false), false);
   assert.equal(await fs.stat(path.join(root, ".current_session", "ghost_old")).then(() => true).catch(() => false), false);
-  assert.equal(await fs.stat(path.join(root, ".agents", "session", "broken")).then(() => true).catch(() => false), false);
+  assert.equal(await fs.stat(path.join(root, ".agentify", "session", "broken")).then(() => true).catch(() => false), false);
 
   assert.equal(await fs.stat(path.join(root, "docs", "modules", "auth.md")).then(() => true), true);
   assert.equal(await fs.stat(path.join(root, "AGENTIFY.md")).then(() => true), true);
   assert.equal(await fs.stat(path.join(root, "src", "payments", "AGENTIFY.md")).then(() => true), true);
-  assert.equal(await fs.stat(path.join(root, ".agents", "modules", "auth.json")).then(() => true), true);
-  assert.ok(!result.removed_paths.includes(".agents/modules/auth.json"));
-  assert.equal(await fs.stat(path.join(root, ".agents", "runs", "keep.json")).then(() => true), true);
+  assert.equal(await fs.stat(path.join(root, ".agentify", "modules", "auth.json")).then(() => true), true);
+  assert.ok(!result.removed_paths.includes(".agentify/modules/auth.json"));
+  assert.equal(await fs.stat(path.join(root, ".agentify", "runs", "keep.json")).then(() => true), true);
   assert.equal(await fs.stat(path.join(root, ".current_session", "ghost_keep")).then(() => true), true);
 });
 
 test("runClean dry-run reports removals without deleting files", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-clean-dry-"));
   await fs.mkdir(path.join(root, "docs", "modules"), { recursive: true });
-  await fs.mkdir(path.join(root, ".agents", "modules"), { recursive: true });
-  await fs.mkdir(path.join(root, ".agents", "cache", "blobs", "aa"), { recursive: true });
+  await fs.mkdir(path.join(root, ".agentify", "modules"), { recursive: true });
+  await fs.mkdir(path.join(root, ".agentify", "cache", "blobs", "aa"), { recursive: true });
   await fs.mkdir(path.join(root, "src", "dead"), { recursive: true });
 
-  await fs.writeFile(path.join(root, ".agents", "index.json"), JSON.stringify({
+  await fs.writeFile(path.join(root, ".agentify", "index.json"), JSON.stringify({
     modules: []
   }, null, 2));
   await fs.writeFile(path.join(root, "docs", "modules", "dead.md"), "# dead\n");
   await fs.writeFile(path.join(root, "AGENTIFY.md"), "# repo\n");
   await fs.writeFile(path.join(root, "src", "dead", "AGENTIFY.md"), "# dead module\n");
-  await fs.writeFile(path.join(root, ".agents", "modules", "dead.json"), "{}\n");
-  await fs.writeFile(path.join(root, ".agents", "cache", "blobs", "aa", "aa.blob"), "blob\n");
-  await fs.writeFile(path.join(root, ".agents", "cache", "manifest.json"), JSON.stringify({
+  await fs.writeFile(path.join(root, ".agentify", "modules", "dead.json"), "{}\n");
+  await fs.writeFile(path.join(root, ".agentify", "cache", "blobs", "aa", "aa.blob"), "blob\n");
+  await fs.writeFile(path.join(root, ".agentify", "cache", "manifest.json"), JSON.stringify({
     modules: {
       stale: {
         blobs: ["aa"],
@@ -109,11 +109,11 @@ test("runClean dry-run reports removals without deleting files", async () => {
 
   assert.ok(result.removed_paths.includes("docs/modules/dead.md"));
   assert.ok(result.removed_paths.includes("src/dead/AGENTIFY.md"));
-  assert.ok(result.removed_paths.includes(".agents/modules/dead.json"));
+  assert.ok(result.removed_paths.includes(".agentify/modules/dead.json"));
   assert.equal(result.removed_cache_blobs, 1);
   assert.equal(await fs.stat(path.join(root, "docs", "modules", "dead.md")).then(() => true), true);
   assert.equal(await fs.stat(path.join(root, "AGENTIFY.md")).then(() => true), true);
   assert.equal(await fs.stat(path.join(root, "src", "dead", "AGENTIFY.md")).then(() => true), true);
-  assert.equal(await fs.stat(path.join(root, ".agents", "modules", "dead.json")).then(() => true), true);
-  assert.equal(await fs.stat(path.join(root, ".agents", "cache", "blobs", "aa", "aa.blob")).then(() => true), true);
+  assert.equal(await fs.stat(path.join(root, ".agentify", "modules", "dead.json")).then(() => true), true);
+  assert.equal(await fs.stat(path.join(root, ".agentify", "cache", "blobs", "aa", "aa.blob")).then(() => true), true);
 });

--- a/test/context-events.test.js
+++ b/test/context-events.test.js
@@ -61,7 +61,7 @@ test("appendContextEvent persists session events under ignored session artifacts
     now: "2026-05-04T01:00:00.000Z",
   });
 
-  assert.equal(result.path, path.join(root, ".agents", "session", "sess_context", "context-events.jsonl"));
+  assert.equal(result.path, path.join(root, ".agentify", "session", "sess_context", "context-events.jsonl"));
   const raw = await fs.readFile(result.path, "utf8");
   assert.equal(raw.trim().split(/\r?\n/).length, 1);
 

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -70,7 +70,7 @@ test("openIndexDatabase read-only fallback snapshots valid databases without ini
     closeIndexDatabase(writeDb);
   }
 
-  const dbPath = path.join(root, ".agents", "index.db");
+  const dbPath = path.join(root, ".agentify", "index.db");
   const sqlite = require("node:sqlite");
   const OriginalDatabaseSync = sqlite.DatabaseSync;
   const betterSqlitePath = require.resolve("better-sqlite3");
@@ -126,7 +126,7 @@ test("openIndexDatabase read-only fallback snapshots valid databases without ini
 
 test("openIndexDatabase read-only rejects blank index database instead of initializing a snapshot", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-db-readonly-"));
-  const dbDir = path.join(root, ".agents");
+  const dbDir = path.join(root, ".agentify");
   const dbPath = path.join(dbDir, "index.db");
   await fs.mkdir(dbDir, { recursive: true });
   await fs.writeFile(dbPath, "");
@@ -141,7 +141,7 @@ test("openIndexDatabase read-only rejects blank index database instead of initia
 
 test("openIndexDatabase read-only rejects corrupt index database instead of initializing a snapshot", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-db-readonly-"));
-  const dbDir = path.join(root, ".agents");
+  const dbDir = path.join(root, ".agentify");
   await fs.mkdir(dbDir, { recursive: true });
   await fs.writeFile(path.join(dbDir, "index.db"), "not sqlite", "utf8");
 

--- a/test/exec.test.js
+++ b/test/exec.test.js
@@ -116,7 +116,7 @@ test("runExec hook-friendly validation allows wrapped source edits", async () =>
 
   const output = await fs.readFile(path.join(root, "output.txt"), "utf8");
   const html = await fs.readFile(path.join(root, "agentify-report.html"), "utf8");
-  const telemetryPath = path.join(root, ".agents", "runs", `${result.executionTelemetry.run_id}-execution-telemetry.json`);
+  const telemetryPath = path.join(root, ".agentify", "runs", `${result.executionTelemetry.run_id}-execution-telemetry.json`);
   const telemetry = JSON.parse(await fs.readFile(telemetryPath, "utf8"));
   assert.match(output, /execution: changed_files=1/);
   assert.match(html, /execution telemetry/);
@@ -309,7 +309,7 @@ test("runExec skips refresh when only Agentify session artifacts change", async 
 
   const config = await loadConfig(root, { provider: "codex", dryRun: false, tokenReport: false, docs: true });
   const session = await forkSession(root, config, { name: "artifact-refresh" });
-  await execFileAsync("git", ["add", ".agents"], { cwd: root });
+  await execFileAsync("git", ["add", ".agentify"], { cwd: root });
   await execFileAsync("git", ["commit", "-m", "track session artifact baseline"], { cwd: root });
 
   const result = await runExec(

--- a/test/fs.test.js
+++ b/test/fs.test.js
@@ -29,14 +29,14 @@ test("walkFiles respects hard excludes and does not leak ignore cache across roo
   const rootA = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-fs-a-"));
   await fs.writeFile(path.join(rootA, ".agentignore"), "ignored.js\n", "utf8");
   await fs.mkdir(path.join(rootA, "docs"), { recursive: true });
-  await fs.mkdir(path.join(rootA, ".agents"), { recursive: true });
+  await fs.mkdir(path.join(rootA, ".agentify"), { recursive: true });
   await fs.mkdir(path.join(rootA, ".codex", "skills"), { recursive: true });
   await fs.mkdir(path.join(rootA, ".claude", "skills"), { recursive: true });
   await fs.mkdir(path.join(rootA, "src"), { recursive: true });
   await fs.mkdir(path.join(rootA, "packages", "app"), { recursive: true });
   await fs.writeFile(path.join(rootA, "ignored.js"), "export const ignored = true;\n", "utf8");
   await fs.writeFile(path.join(rootA, "docs", "manual.md"), "# generated\n", "utf8");
-  await fs.writeFile(path.join(rootA, ".agents", "index.json"), "{}\n", "utf8");
+  await fs.writeFile(path.join(rootA, ".agentify", "index.json"), "{}\n", "utf8");
   await fs.writeFile(path.join(rootA, ".codex", "skills", "helper.md"), "# hidden\n", "utf8");
   await fs.writeFile(path.join(rootA, ".claude", "skills", "helper.md"), "# hidden\n", "utf8");
   await fs.writeFile(path.join(rootA, "src", "index.ts"), "export const ok = true;\n", "utf8");
@@ -138,11 +138,11 @@ test("walkFiles excludes Agentify runtime artifacts even when ignore rules are a
   resetIgnoreCache();
 
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-fs-artifacts-"));
-  await fs.mkdir(path.join(root, ".agents", "session", "sess_test"), { recursive: true });
+  await fs.mkdir(path.join(root, ".agentify", "session", "sess_test"), { recursive: true });
   await fs.mkdir(path.join(root, ".current_session", "session"), { recursive: true });
   await fs.mkdir(path.join(root, "docs", "modules"), { recursive: true });
   await fs.mkdir(path.join(root, "src"), { recursive: true });
-  await fs.writeFile(path.join(root, ".agents", "session", "sess_test", "context.json"), "{}\n", "utf8");
+  await fs.writeFile(path.join(root, ".agentify", "session", "sess_test", "context.json"), "{}\n", "utf8");
   await fs.writeFile(path.join(root, ".current_session", "session", "transcript.md"), "secret\n", "utf8");
   await fs.writeFile(path.join(root, "docs", "repo-map.md"), "# generated\n", "utf8");
   await fs.writeFile(path.join(root, "AGENTIFY.md"), "# generated\n", "utf8");

--- a/test/handoff.test.js
+++ b/test/handoff.test.js
@@ -28,7 +28,7 @@ async function setupHandoffRepo() {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-handoff-"));
   await fs.mkdir(path.join(root, "src", "core"), { recursive: true });
   await fs.mkdir(path.join(root, "test"), { recursive: true });
-  await fs.writeFile(path.join(root, ".gitignore"), ".agents/\n", "utf8");
+  await fs.writeFile(path.join(root, ".gitignore"), ".agentify/\n", "utf8");
   await fs.writeFile(path.join(root, "package.json"), JSON.stringify({
     type: "module",
     scripts: { test: "node --test" },
@@ -139,7 +139,7 @@ test("writeHandoffBundle creates deterministic JSON and markdown with conflict h
     "utf8",
   );
 
-  const previousDir = path.join(root, ".agents", "session", "sess_previous");
+  const previousDir = path.join(root, ".agentify", "session", "sess_previous");
   await fs.mkdir(previousDir, { recursive: true });
   await fs.writeFile(path.join(previousDir, "session-manifest.json"), JSON.stringify({
     schema_version: "1.0",
@@ -158,8 +158,8 @@ test("writeHandoffBundle creates deterministic JSON and markdown with conflict h
   const second = await writeHandoffBundle(root, config, session.sessionId, "continue buildSessionPrompt handoff");
 
   assert.deepEqual(second.bundle, first.bundle);
-  assert.equal(first.relativeJsonPath, `.agents/session/${session.sessionId}/handoff.json`);
-  assert.equal(first.relativeMarkdownPath, `.agents/session/${session.sessionId}/handoff.md`);
+  assert.equal(first.relativeJsonPath, `.agentify/session/${session.sessionId}/handoff.json`);
+  assert.equal(first.relativeMarkdownPath, `.agentify/session/${session.sessionId}/handoff.md`);
   assert.ok(first.bundle.top_ranked_context.files.some((item) => item.path === "src/core/session.js"));
   assert.ok(first.bundle.touched_files.some((item) => item.path === "src/core/session.js"));
   assert.ok(first.bundle.touched_symbol_neighborhood.some((item) =>
@@ -201,6 +201,6 @@ test("runCli handoff writes the latest session bundle as JSON", async () => {
   const payload = JSON.parse(output[0]);
   assert.equal(payload.command, "handoff");
   assert.equal(payload.session_id, session.sessionId);
-  assert.equal(payload.json_path, `.agents/session/${session.sessionId}/handoff.json`);
-  assert.equal(payload.markdown_path, `.agents/session/${session.sessionId}/handoff.md`);
+  assert.equal(payload.json_path, `.agentify/session/${session.sessionId}/handoff.json`);
+  assert.equal(payload.markdown_path, `.agentify/session/${session.sessionId}/handoff.md`);
 });

--- a/test/lock-contention.test.js
+++ b/test/lock-contention.test.js
@@ -9,9 +9,9 @@ import { runCli } from "../src/main.js";
 async function setupBlockedRepo(prefix) {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
   await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
-  await fs.mkdir(path.join(root, ".agents"), { recursive: true });
+  await fs.mkdir(path.join(root, ".agentify"), { recursive: true });
   await fs.writeFile(
-    path.join(root, ".agents", ".lock"),
+    path.join(root, ".agentify", ".lock"),
     JSON.stringify({
       pid: process.pid,
       operation: "scan",
@@ -48,7 +48,7 @@ test("runCli scan exits non-zero and emits a blocked JSON payload when the lock 
 
   assert.equal(process.exitCode, 1, "scan should exit non-zero on lock contention");
 
-  const dbExists = await fs.access(path.join(root, ".agents", "index.db")).then(() => true).catch(() => false);
+  const dbExists = await fs.access(path.join(root, ".agentify", "index.db")).then(() => true).catch(() => false);
   assert.equal(dbExists, false, "scan must not write the index when blocked");
 
   const payloads = captured

--- a/test/lock.test.js
+++ b/test/lock.test.js
@@ -8,9 +8,9 @@ import { acquireLock } from "../src/core/lock.js";
 
 test("acquireLock refuses to steal a stale lock from a live owner on the same host", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-lock-live-"));
-  await fs.mkdir(path.join(root, ".agents"), { recursive: true });
+  await fs.mkdir(path.join(root, ".agentify"), { recursive: true });
   await fs.writeFile(
-    path.join(root, ".agents", ".lock"),
+    path.join(root, ".agentify", ".lock"),
     JSON.stringify({
       pid: process.pid,
       operation: "scan",
@@ -29,9 +29,9 @@ test("acquireLock refuses to steal a stale lock from a live owner on the same ho
 
 test("acquireLock reclaims a stale lock when the recorded owner is gone", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-lock-dead-"));
-  await fs.mkdir(path.join(root, ".agents"), { recursive: true });
+  await fs.mkdir(path.join(root, ".agentify"), { recursive: true });
   await fs.writeFile(
-    path.join(root, ".agents", ".lock"),
+    path.join(root, ".agentify", ".lock"),
     JSON.stringify({
       pid: 2147483647,
       operation: "scan",
@@ -44,9 +44,9 @@ test("acquireLock reclaims a stale lock when the recorded owner is gone", async 
   const result = await acquireLock(root, "doc");
 
   assert.equal(result.acquired, true);
-  const lockData = JSON.parse(await fs.readFile(path.join(root, ".agents", ".lock"), "utf8"));
+  const lockData = JSON.parse(await fs.readFile(path.join(root, ".agentify", ".lock"), "utf8"));
   assert.equal(lockData.pid, process.pid);
   assert.equal(lockData.operation, "doc");
   await result.release();
-  await assert.rejects(() => fs.access(path.join(root, ".agents", ".lock")));
+  await assert.rejects(() => fs.access(path.join(root, ".agentify", ".lock")));
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -736,7 +736,7 @@ test("runCli sess run builds routed context with a fake codex provider", async (
   const argv = JSON.parse(await fs.readFile(capturePath, "utf8"));
   const prompt = argv.at(-1);
   assert.deepEqual(argv.slice(0, 2), ["exec", prompt]);
-  assert.match(prompt, /Full routing: host shell -> \.agents\/index\.db/);
+  assert.match(prompt, /Full routing: host shell -> \.agentify\/index\.db/);
   assert.match(prompt, /Current task: Use routed context/);
   assert.match(prompt, /Automatic Session Memory/);
 });
@@ -773,7 +773,7 @@ test("runCli sess run without a task asks the provider to collect one", async ()
   assert.match(prompt, /ask the user what task/);
   assert.doesNotMatch(prompt, /Current task: Continue this session/);
 
-  const sessionsRoot = path.join(root, ".agents", "session");
+  const sessionsRoot = path.join(root, ".agentify", "session");
   const [sessionId] = await fs.readdir(sessionsRoot);
   const launches = await fs.readFile(path.join(sessionsRoot, sessionId, "launches.jsonl"), "utf8");
   assert.match(launches, /"task":""/);
@@ -854,7 +854,7 @@ test("runCli passes routed context prompt to codex sess run and compacts facts",
   assert.match(prompt, /Session bootstrap:/);
   assert.match(prompt, /agentify context fetch <path> --symbol X/);
 
-  const sessionsRoot = path.join(root, ".agents", "session");
+  const sessionsRoot = path.join(root, ".agentify", "session");
   const entries = await fs.readdir(sessionsRoot);
   assert.equal(entries.length, 1);
   const facts = JSON.parse(await fs.readFile(path.join(sessionsRoot, entries[0], "context-facts.json"), "utf8"));
@@ -980,7 +980,7 @@ test("runCli init writes baseline local work and guardrail files", async () => {
 
   const gitignore = await fs.readFile(path.join(root, ".gitignore"), "utf8");
   assert.match(gitignore, /# >>> agentify generated artifacts/);
-  assert.match(gitignore, /^\.agents\/$/m);
+  assert.match(gitignore, /^\.agentify\/$/m);
   assert.match(gitignore, /^docs\/modules\/$/m);
   assert.match(gitignore, /^agentify-report\.html$/m);
   assert.doesNotMatch(gitignore, /^\.agentify\.yaml$/m);
@@ -1010,6 +1010,8 @@ test("runCli init updates gitignore Agentify block without dropping user additio
     "",
     "# >>> agentify generated artifacts",
     ".agents/",
+    ".agentify/",
+    ".agentify/work/",
     "local.env",
     "# <<< agentify generated artifacts",
     "",
@@ -1025,6 +1027,8 @@ test("runCli init updates gitignore Agentify block without dropping user additio
   assert.match(gitignore, /^local\.env$/m);
   assert.match(gitignore, /^\.current_session\/$/m);
   assert.match(gitignore, /^agentify-report\.html$/m);
+  assert.doesNotMatch(gitignore, /^\.agents\/$/m);
+  assert.doesNotMatch(gitignore, /^\.agentify\/work\/$/m);
   assert.equal((gitignore.match(/^local\.env$/gm) || []).length, 1);
 });
 
@@ -1060,8 +1064,8 @@ test("runCli plan reports actionable guidance when the index is missing", async 
 test("runCli plan reports actionable guidance when the index is unreadable", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-plan-invalid-index-"));
   await runCli(["init", "--root", root]);
-  await fs.mkdir(path.join(root, ".agents"), { recursive: true });
-  await fs.writeFile(path.join(root, ".agents", "index.db"), "not sqlite", "utf8");
+  await fs.mkdir(path.join(root, ".agentify"), { recursive: true });
+  await fs.writeFile(path.join(root, ".agentify", "index.db"), "not sqlite", "utf8");
 
   await assert.rejects(
     () => runCli(["plan", "--root", root, "summarize setup"]),
@@ -1268,7 +1272,7 @@ test("runCli sync upgrades repo-owned Agentify assets and emits sync json", asyn
   assert.match(configText, /^semantic:/m);
   assert.match(configText, /^toolchain:/m);
   assert.match(gitignoreText, /# >>> agentify generated artifacts/);
-  assert.match(gitignoreText, /^\.agents\/$/m);
+  assert.match(gitignoreText, /^\.agentify\/$/m);
   assert.match(skillText, /Interview the user relentlessly/);
   assert.match(hookText, /agentify scan --json >\/dev\/null 2>&1 && agentify doc --provider local --json >\/dev\/null 2>&1 \|\| true/);
   await assert.doesNotReject(() => fs.access(path.join(root, ".agentignore")));

--- a/test/planner.test.js
+++ b/test/planner.test.js
@@ -194,8 +194,8 @@ test("planner uses a read-only index and warns providers away from nested Agenti
   const config = await loadConfig(root, { provider: "local", dryRun: false });
   await runScan(root, config);
 
-  const dbPath = path.join(root, ".agents", "index.db");
-  const dbDir = path.join(root, ".agents");
+  const dbPath = path.join(root, ".agentify", "index.db");
+  const dbDir = path.join(root, ".agentify");
   await fs.chmod(dbPath, 0o444);
   await fs.chmod(dbDir, 0o555);
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -29,8 +29,8 @@ test("querySearch reads an existing index when the database is read-only", async
   const config = await loadConfig(root, { provider: "local", dryRun: false });
   await runScan(root, config);
 
-  const dbPath = path.join(root, ".agents", "index.db");
-  const dbDir = path.join(root, ".agents");
+  const dbPath = path.join(root, ".agentify", "index.db");
+  const dbDir = path.join(root, ".agentify");
   await fs.chmod(dbPath, 0o444);
   await fs.chmod(dbDir, 0o555);
 

--- a/test/run-report.test.js
+++ b/test/run-report.test.js
@@ -17,7 +17,7 @@ test("createRunReporter persists output and HTML report", async (t) => {
 
   const reporter = createRunReporter(root);
   reporter.setCommand("up");
-  reporter.setScan({ wrote: [".agents/index.db"] });
+  reporter.setScan({ wrote: [".agentify/index.db"] });
   reporter.setDoc({
     modules_processed: 2,
     docs_written: 1,
@@ -84,7 +84,7 @@ test("createRunReporter persists output and HTML report", async (t) => {
   const output = await fs.readFile(path.join(root, "output.txt"), "utf8");
   const html = await fs.readFile(path.join(root, "agentify-report.html"), "utf8");
   const telemetry = JSON.parse(
-    await fs.readFile(path.join(root, ".agents", "runs", "test-execution-execution-telemetry.json"), "utf8")
+    await fs.readFile(path.join(root, ".agentify", "runs", "test-execution-execution-telemetry.json"), "utf8")
   );
 
   assert.match(output, /\[agentify\] tests: passed/);

--- a/test/sess-cli-security.test.js
+++ b/test/sess-cli-security.test.js
@@ -41,7 +41,7 @@ test("sess resume rejects path-like ids without touching the filesystem", async 
   await fs.writeFile(path.join(probeDir, "context.json"), JSON.stringify({}));
   await fs.writeFile(path.join(probeDir, "bootstrap.md"), "forged");
 
-  const escapeId = path.relative(path.join(root, ".agents", "session"), probeDir);
+  const escapeId = path.relative(path.join(root, ".agentify", "session"), probeDir);
 
   for (const malicious of [escapeId, "../escape", "a/../b", "/abs/path", "with space"]) {
     const result = await runCli(["sess", "resume", "--session", malicious, "--json"], root);

--- a/test/session-structured.test.js
+++ b/test/session-structured.test.js
@@ -197,7 +197,7 @@ test("forkSession compacts child context while preserving runtime artifact refs"
   assert.equal(child.manifest.metadata.bootstrap_truncated, true);
   assert.ok(Buffer.byteLength(JSON.stringify(child.context), "utf8") <= 4096);
   assert.match(resumed.bootstrap, /Session Context/);
-  assert.match(resumed.bootstrap, /Full routing: host shell -> \.agents\/index\.db/);
+  assert.match(resumed.bootstrap, /Full routing: host shell -> \.agentify\/index\.db/);
   assert.ok(child.context.cache_refs.turns.endsWith("turns.jsonl"));
   assert.ok(child.context.cache_refs.checklist.endsWith("checklist.json"));
   assert.equal(await fileExists(path.join(child.sessionDir, "bootstrap.md")), false);
@@ -227,7 +227,7 @@ test("maybePrepareChildSession creates child above context threshold without lau
   assert.match(result.resume_command, new RegExp(result.child_session_id));
 
   const childManifest = JSON.parse(await fs.readFile(
-    path.join(root, ".agents", "session", result.child_session_id, "session-manifest.json"),
+    path.join(root, ".agentify", "session", result.child_session_id, "session-manifest.json"),
     "utf8"
   ));
   assert.equal(childManifest.parent_id, parent.sessionId);

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -47,7 +47,7 @@ if [ "$1" = "search" ]; then
       Source: sess_memory.md
       Match:  0.98
 
-      Source transcript: .agents/session/sess_memory/transcript.md
+      Source transcript: .agentify/session/sess_memory/transcript.md
       We chose JSONL transcripts because they are append-friendly for durable memory capture.
 
   ────────────────────────────────────────────────────────
@@ -82,7 +82,7 @@ test("resolveSessionProvider supports legacy tool manifests", () => {
 test("forkSession enforces bootstrap and context size caps", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-caps-"));
   await fs.writeFile(path.join(root, "package.json"), "{}\n");
-  await fs.mkdir(path.join(root, ".agents"), { recursive: true });
+  await fs.mkdir(path.join(root, ".agentify"), { recursive: true });
   const db = openIndexDatabase(root);
   try {
     inTransaction(db, () => {
@@ -148,7 +148,7 @@ test("forkSession enforces bootstrap and context size caps", async () => {
   assert.ok(Buffer.byteLength(JSON.stringify(resumed.context), "utf8") <= 1024);
   assert.equal(result.manifest.metadata.bootstrap_truncated, true);
   assert.equal(result.manifest.metadata.context_truncated, true);
-  assert.match(resumed.bootstrap, /host shell -> \.agents\/index\.db/);
+  assert.match(resumed.bootstrap, /host shell -> \.agentify\/index\.db/);
   assert.ok((resumed.context.index_snapshot.truncated_module_ids || 0) > 0);
   assert.ok((resumed.context.checklist_summary.remaining_items || 0) > 0);
 });
@@ -341,7 +341,7 @@ test("loadAutomaticRunMemory rejects MemPalace stdout that reports a missing pal
   const binDir = path.join(root, "bin");
   await fs.mkdir(binDir, { recursive: true });
   await installMemPalaceShim(binDir, [
-    "  No palace found at /tmp/agentify-test/.agents/mempalace/palace",
+    "  No palace found at /tmp/agentify-test/.agentify/mempalace/palace",
     "  Run: mempalace init <dir> then mempalace mine <dir>",
     "",
   ].join("\n"));
@@ -469,7 +469,7 @@ test("resumeSession refuses path traversal ids before touching disk", async () =
   await fs.writeFile(path.join(probeDir, "context.json"), JSON.stringify({}));
   await fs.writeFile(path.join(probeDir, "bootstrap.md"), "forged");
 
-  const relativeAttack = path.relative(path.join(root, ".agents", "session"), probeDir);
+  const relativeAttack = path.relative(path.join(root, ".agentify", "session"), probeDir);
 
   for (const malicious of [relativeAttack, "../escape", "a/../b", "/abs", "with space"]) {
     await assert.rejects(

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -54,7 +54,7 @@ async function createInitializedRepoWithSourceEdit(prefix) {
 }
 
 async function readLatestRunReport(root, commandName) {
-  const runDir = path.join(root, ".agents", "runs");
+  const runDir = path.join(root, ".agentify", "runs");
   const runFiles = (await fs.readdir(runDir))
     .filter((file) => file.endsWith(`-${commandName}.json`))
     .sort();
@@ -74,7 +74,7 @@ test("scan and doc generate required artifacts", async () => {
   const result = await validateRepo(root, config);
 
   assert.equal(result.passed, true);
-  assert.equal(await fs.stat(path.join(root, ".agents", "index.db")).then(() => true), true);
+  assert.equal(await fs.stat(path.join(root, ".agentify", "index.db")).then(() => true), true);
   assert.equal(await fs.stat(path.join(root, "src", "auth", "AGENTIFY.md")).then(() => true), true);
   assert.equal(await fs.stat(path.join(root, "AGENTIFY.md")).then(() => true), true);
   const summary = await fs.readFile(path.join(root, "AGENTIFY.md"), "utf8");
@@ -291,12 +291,12 @@ test("runUpdate in ghost mode reuses a single artifact root", async () => {
   assert.equal(ghostRuns.length, 1);
 
   const artifactRoot = path.join(sessionRoot, ghostRuns[0]);
-  assert.equal(await fs.stat(path.join(artifactRoot, ".agents", "index.db")).then(() => true), true);
+  assert.equal(await fs.stat(path.join(artifactRoot, ".agentify", "index.db")).then(() => true), true);
   assert.equal(await fs.stat(path.join(artifactRoot, "AGENTIFY.md")).then(() => true), true);
   assert.equal(await fs.stat(path.join(artifactRoot, "ghost-report.json")).then(() => true), true);
   assert.equal(await fs.stat(path.join(artifactRoot, "output.txt")).then(() => true), true);
   assert.equal(await fs.stat(path.join(artifactRoot, "agentify-report.html")).then(() => true), true);
-  assert.equal(await fs.stat(path.join(root, ".agents", "index.db")).then(() => true).catch(() => false), false);
+  assert.equal(await fs.stat(path.join(root, ".agentify", "index.db")).then(() => true).catch(() => false), false);
   assert.equal(await fs.stat(path.join(root, "output.txt")).then(() => true).catch(() => false), false);
   assert.equal(await fs.stat(path.join(root, "agentify-report.html")).then(() => true).catch(() => false), false);
 });
@@ -443,7 +443,7 @@ test("passes", () => {
   const config = await loadConfig(root, { provider: "local", dryRun: false, tokenReport: false, docs: false });
   await runUpdate(root, config);
 
-  assert.equal(await fs.stat(path.join(root, ".agents", "index.db")).then(() => true), true);
+  assert.equal(await fs.stat(path.join(root, ".agentify", "index.db")).then(() => true), true);
   assert.equal(await fs.stat(path.join(root, "AGENTIFY.md")).then(() => true).catch(() => false), false);
   const source = await fs.readFile(path.join(root, "src", "auth", "index.ts"), "utf8");
   assert.doesNotMatch(source, /@agentify/);
@@ -489,7 +489,7 @@ test("runDoc reuses cached module artifacts when bounded content is unchanged", 
     mode: "deterministic-local"
   });
 
-  const runDir = path.join(root, ".agents", "runs");
+  const runDir = path.join(root, ".agentify", "runs");
   const runFiles = (await fs.readdir(runDir)).sort();
   const latestRun = JSON.parse(await fs.readFile(path.join(runDir, runFiles.at(-1)), "utf8"));
   assert.equal(latestRun.results.cached_manager_plan, true);
@@ -573,7 +573,7 @@ setInterval(() => {}, 1000);
     } finally {
       closeIndexDatabase(fallbackDb);
     }
-    assert.equal(await fs.stat(path.join(root, ".agents", ".lock")).then(() => true).catch(() => false), false);
+    assert.equal(await fs.stat(path.join(root, ".agentify", ".lock")).then(() => true).catch(() => false), false);
   } finally {
     if (previousPath === undefined) {
       delete process.env.PATH;


### PR DESCRIPTION
## Summary
- move runtime artifact paths from `.agents/*` to direct `.agentify/*` locations across production code, prompts, reports, and tests
- update init/sync/gitignore behavior so `.agentify/` is the generated runtime root while root policy files remain committed
- refresh docs and README command references for the new artifact layout

## Validation
- `pnpm test -- test/main.test.js test/db.test.js test/session.test.js test/session-structured.test.js test/context-events.test.js test/cleanup.test.js test/update.test.js test/run-report.test.js test/handoff.test.js test/fs.test.js test/lock.test.js test/lock-contention.test.js test/planner.test.js test/query.test.js test/bootstrap.test.js test/exec.test.js`
- `pnpm test`
- `rg -n "\.agents" src test docs README.md .gitignore` only reports the intentional legacy managed-gitignore cleanup fixture/pattern

Fixes #180