### PR TITLE
fix: clean up codex provider temp directories

### DIFF
--- a/src/core/provider.js
+++ b/src/core/provider.js
@@ -413,33 +413,48 @@ async function runCodexExec({ root, prompt, schema, model, timeoutMs }) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-codex-"));
   const schemaPath = path.join(tempDir, "schema.json");
   const outputPath = path.join(tempDir, "result.json");
-  await fs.writeFile(schemaPath, `${JSON.stringify(schema, null, 2)}\n`, "utf8");
+  let providerError = null;
 
-  const args = [
-    "exec",
-    "--skip-git-repo-check",
-    "--json",
-    "--sandbox",
-    "workspace-write",
-    "--cd",
-    root,
-    "--output-schema",
-    schemaPath,
-    "--output-last-message",
-    outputPath
-  ];
+  try {
+    await fs.writeFile(schemaPath, `${JSON.stringify(schema, null, 2)}\n`, "utf8");
 
-  if (model) {
-    args.push("--model", model);
+    const args = [
+      "exec",
+      "--skip-git-repo-check",
+      "--json",
+      "--sandbox",
+      "workspace-write",
+      "--cd",
+      root,
+      "--output-schema",
+      schemaPath,
+      "--output-last-message",
+      outputPath
+    ];
+
+    if (model) {
+      args.push("--model", model);
+    }
+
+    args.push(prompt);
+
+    const { stdout } = await runChild("codex", args, { cwd: root, timeoutMs });
+
+    const output = JSON.parse(await fs.readFile(outputPath, "utf8"));
+    const usage = parseCodexJsonl(stdout);
+    return { output, usage };
+  } catch (error) {
+    providerError = error;
+    throw error;
+  } finally {
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch (cleanupError) {
+      if (!providerError) {
+        throw cleanupError;
+      }
+    }
   }
-
-  args.push(prompt);
-
-  const { stdout } = await runChild("codex", args, { cwd: root, timeoutMs });
-
-  const output = JSON.parse(await fs.readFile(outputPath, "utf8"));
-  const usage = parseCodexJsonl(stdout);
-  return { output, usage };
 }
 
 async function runClaudeExec({ root, prompt, schema, model, timeoutMs }) {

--- a/test/provider.test.js
+++ b/test/provider.test.js
@@ -44,6 +44,124 @@ test("runChild closes provider stdin when prompt is passed through argv", async 
   assert.equal(result.stdout, "stdin closed");
 });
 
+async function assertPathMissing(targetPath) {
+  await assert.rejects(
+    () => fs.access(targetPath),
+    (error) => error?.code === "ENOENT",
+  );
+}
+
+function restoreEnvValue(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+test("codex provider removes its temp directory after successful execution", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-provider-codex-root-"));
+  const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-provider-codex-bin-"));
+  const codexPath = path.join(binDir, "codex");
+  const tempDirRecordPath = path.join(root, "codex-temp-dir.txt");
+
+  await fs.writeFile(codexPath, `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+
+const outputPath = process.argv[process.argv.indexOf("--output-last-message") + 1];
+fs.writeFileSync(path.join(process.cwd(), "codex-temp-dir.txt"), path.dirname(outputPath));
+fs.writeFileSync(outputPath, JSON.stringify({
+  repo_summary: "Codex fixture",
+  shared_conventions: [],
+  module_focus: [{ module_id: "auth", focus: "Keep auth simple." }]
+}));
+process.stdout.write(JSON.stringify({
+  type: "turn.completed",
+  usage: { input_tokens: 4, output_tokens: 2 }
+}) + "\\n");
+`, "utf8");
+  await fs.chmod(codexPath, 0o755);
+
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${binDir}${path.delimiter}${previousPath || ""}`;
+
+  try {
+    const provider = createProvider("codex");
+    const result = await provider.buildManagerPlan({
+      repoName: "agentify-fixture",
+      root,
+      defaultStack: "ts",
+      stacks: [{ name: "ts", confidence: 1 }],
+      entrypoints: [],
+      modules: [{ id: "auth", rootPath: "src/auth" }],
+      sampleFiles: [],
+    });
+
+    assert.equal(result.plan.repo_summary, "Codex fixture");
+    assert.deepEqual(result.tokenUsage, {
+      input_tokens: 4,
+      output_tokens: 2,
+      total_tokens: 6
+    });
+    const tempDir = await fs.readFile(tempDirRecordPath, "utf8");
+    assert.match(tempDir, /agentify-codex-/);
+    await assertPathMissing(tempDir);
+  } finally {
+    restoreEnvValue("PATH", previousPath);
+  }
+});
+
+test("codex provider removes its temp directory after failed execution", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-provider-codex-root-"));
+  const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-provider-codex-bin-"));
+  const codexPath = path.join(binDir, "codex");
+  const tempDirRecordPath = path.join(root, "codex-temp-dir.txt");
+
+  await fs.writeFile(codexPath, `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+
+const outputPath = process.argv[process.argv.indexOf("--output-last-message") + 1];
+fs.writeFileSync(path.join(process.cwd(), "codex-temp-dir.txt"), path.dirname(outputPath));
+process.stderr.write("codex fixture failed");
+process.exit(7);
+`, "utf8");
+  await fs.chmod(codexPath, 0o755);
+
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${binDir}${path.delimiter}${previousPath || ""}`;
+
+  try {
+    const provider = createProvider("codex");
+    await assert.rejects(
+      () => provider.buildManagerPlan({
+        repoName: "agentify-fixture",
+        root,
+        defaultStack: "ts",
+        stacks: [{ name: "ts", confidence: 1 }],
+        entrypoints: [],
+        modules: [{ id: "auth", rootPath: "src/auth" }],
+        sampleFiles: [],
+      }),
+      (error) => {
+        assert.equal(error instanceof ProviderExecutionError, true);
+        assert.equal(error.provider, "codex");
+        assert.equal(error.phase, "manager planning");
+        assert.match(error.message, /failed with code 7/);
+        assert.match(error.message, /codex fixture failed/);
+        return true;
+      },
+    );
+
+    const tempDir = await fs.readFile(tempDirRecordPath, "utf8");
+    assert.match(tempDir, /agentify-codex-/);
+    await assertPathMissing(tempDir);
+  } finally {
+    restoreEnvValue("PATH", previousPath);
+  }
+});
+
 test("external provider manager planning surfaces unavailable provider failures", async () => {
   const provider = createProvider("codex");
   const previousPath = process.env.PATH;


### PR DESCRIPTION
## Summary
- remove per-run `agentify-codex-*` temp directories after Codex provider success and failure
- preserve the original provider error if cleanup also fails on an error path
- add fake-Codex regression tests for successful and failing provider execution cleanup

Closes #176

## Verification
- `node --test test/provider.test.js`
- `git diff --check`
- `npm test` (302 passed, 1 failed: existing README CLI reference command-index assertion in `test/main.test.js`)
