### PR TITLE
fix: redact project test output in run reports

### DIFF
--- a/src/core/project-tests.js
+++ b/src/core/project-tests.js
@@ -4,6 +4,7 @@ import path from "node:path";
 import { createBoundedCaptureBuffer, DEFAULT_CAPTURE_MAX_KB, normalizeCaptureMaxBytes } from "./capture-buffer.js";
 import { detectStacks } from "./detect.js";
 import { exists, readJson, relative, walkFiles } from "./fs.js";
+import { redactSensitiveText } from "./session-memory.js";
 
 const DEFAULT_TEST_TIMEOUT_MS = 10 * 60 * 1000;
 const FORCE_KILL_TIMEOUT_MS = 1000;
@@ -423,11 +424,13 @@ export async function runProjectTests(root, reporter, options = {}) {
   if (outcome.stderrTruncated) {
     reporter.log(`tests: stderr truncated to ${outcome.outputMaxBytes} bytes from ${outcome.stderrBytes} bytes; configure tests.outputMaxKb to adjust`);
   }
-  if (outcome.stdout) {
-    reporter.appendSection("[tests stdout]", outcome.stdout);
+  const stdout = redactSensitiveText(outcome.stdout);
+  const stderr = redactSensitiveText(outcome.stderr);
+  if (stdout) {
+    reporter.appendSection("[tests stdout]", stdout);
   }
-  if (outcome.stderr) {
-    reporter.appendSection("[tests stderr]", outcome.stderr);
+  if (stderr) {
+    reporter.appendSection("[tests stderr]", stderr);
   }
   if (outcome.timedOut) {
     reporter.log(`tests: timed out after ${outcome.timeoutMs}ms; terminated subprocess`);
@@ -437,8 +440,8 @@ export async function runProjectTests(root, reporter, options = {}) {
     status: outcome.code === 0 && !outcome.timedOut ? "passed" : "failed",
     passed: outcome.code === 0 && !outcome.timedOut,
     command: `${testCommand.command} ${testCommand.args.join(" ")}`,
-    stdout: outcome.stdout,
-    stderr: outcome.stderr,
+    stdout,
+    stderr,
     stdout_truncated: outcome.stdoutTruncated,
     stderr_truncated: outcome.stderrTruncated,
     stdout_bytes: outcome.stdoutBytes,

--- a/src/core/run-report.js
+++ b/src/core/run-report.js
@@ -1,6 +1,7 @@
 import path from "node:path";
 
 import { writeJson, writeText } from "./fs.js";
+import { redactSensitiveText } from "./session-memory.js";
 import * as ui from "./ui.js";
 
 function escapeHtml(value) {
@@ -13,6 +14,21 @@ function escapeHtml(value) {
 
 function sanitizeForJsString(value) {
   return String(value).replaceAll("\\", "\\\\").replaceAll("`", "\\`").replaceAll("${", "\\${");
+}
+
+function redactTestsSummary(result) {
+  if (!result || typeof result !== "object") {
+    return result;
+  }
+
+  const safeResult = { ...result };
+  if (Object.hasOwn(safeResult, "stdout")) {
+    safeResult.stdout = redactSensitiveText(safeResult.stdout);
+  }
+  if (Object.hasOwn(safeResult, "stderr")) {
+    safeResult.stderr = redactSensitiveText(safeResult.stderr);
+  }
+  return safeResult;
 }
 
 function normalizeExecutionTelemetry(value) {
@@ -1186,7 +1202,8 @@ export function createRunReporter(root) {
       if (!text) {
         return;
       }
-      const block = `${title}\n${text.endsWith("\n") ? text : `${text}\n`}`;
+      const safeText = redactSensitiveText(text);
+      const block = `${title}\n${safeText.endsWith("\n") ? safeText : `${safeText}\n`}`;
       record(block);
     },
     setCommand(command) {
@@ -1204,7 +1221,7 @@ export function createRunReporter(root) {
       summary.validation = result;
     },
     setTests(result) {
-      summary.tests = result;
+      summary.tests = redactTestsSummary(result);
     },
     setExecution(result) {
       loader.clear();

--- a/test/project-tests.test.js
+++ b/test/project-tests.test.js
@@ -307,6 +307,36 @@ test("runProjectTests bounds captured stdout and stderr and reports truncation",
   assert.equal(Buffer.byteLength(reporter.sections.find((section) => section.title === "[tests stderr]").body, "utf8"), 1024);
 });
 
+test("runProjectTests redacts secrets from captured stdout and stderr before reporting", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-test-output-redaction-"));
+  const scriptPath = path.join(root, "emit-secret-output.js");
+  const stdoutSecret = "sk-live-secret12345";
+  const stderrSecret = "eyJhbGciOiJIUzI1NiJ9.secret";
+
+  await fs.writeFile(scriptPath, `
+    process.stdout.write("stdout context OPENAI_API_KEY=${stdoutSecret}\\n");
+    process.stderr.write("stderr context Authorization: Bearer ${stderrSecret}\\n");
+  `);
+  await fs.writeFile(path.join(root, "package.json"), JSON.stringify({
+    name: "agentify-output-redaction",
+    scripts: { test: "node emit-secret-output.js" },
+  }, null, 2));
+
+  const reporter = createReporter();
+  const result = await runProjectTests(root, reporter);
+  const sections = reporter.sections.map((section) => section.body).join("\n");
+
+  assert.equal(result.status, "passed");
+  assert.doesNotMatch(result.stdout, new RegExp(stdoutSecret));
+  assert.doesNotMatch(result.stderr, new RegExp(stderrSecret));
+  assert.doesNotMatch(sections, new RegExp(stdoutSecret));
+  assert.doesNotMatch(sections, new RegExp(stderrSecret));
+  assert.match(result.stdout, /stdout context OPENAI_API_KEY=\[REDACTED\]/);
+  assert.match(result.stderr, /stderr context Authorization: Bearer \[REDACTED\]/);
+  assert.match(sections, /\[REDACTED\]/);
+  assert.deepEqual(reporter.tests, result);
+});
+
 test("runProjectTests times out a hanging test command", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-test-timeout-"));
   const scriptPath = path.join(root, "hang.js");

--- a/test/run-report.test.js
+++ b/test/run-report.test.js
@@ -135,6 +135,45 @@ test("createRunReporter shows test output truncation metadata in HTML", async (t
   assert.match(html, /tests\.outputMaxKb/);
 });
 
+test("createRunReporter redacts test stdout and stderr in persisted artifacts", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-run-report-redaction-"));
+  const previousSilent = false;
+  setSilent(true);
+  t.after(() => {
+    setSilent(previousSilent);
+  });
+
+  const stdoutSecret = "sk-live-secret12345";
+  const stderrSecret = "eyJhbGciOiJIUzI1NiJ9.secret";
+  const reporter = createRunReporter(root);
+  reporter.setCommand("up");
+  reporter.setValidation({ passed: true, failures: [] });
+  reporter.appendSection("[tests stdout]", `stdout context OPENAI_API_KEY=${stdoutSecret}`);
+  reporter.appendSection("[tests stderr]", `stderr context Authorization: Bearer ${stderrSecret}`);
+  reporter.setTests({
+    status: "passed",
+    passed: true,
+    command: "pnpm test",
+    stdout: `stdout context OPENAI_API_KEY=${stdoutSecret}`,
+    stderr: `stderr context Authorization: Bearer ${stderrSecret}`,
+    exit_code: 0,
+  });
+
+  await reporter.finalize();
+
+  const output = await fs.readFile(path.join(root, "output.txt"), "utf8");
+  const html = await fs.readFile(path.join(root, "agentify-report.html"), "utf8");
+
+  assert.doesNotMatch(output, new RegExp(stdoutSecret));
+  assert.doesNotMatch(output, new RegExp(stderrSecret));
+  assert.doesNotMatch(html, new RegExp(stdoutSecret));
+  assert.doesNotMatch(html, new RegExp(stderrSecret));
+  assert.match(output, /stdout context OPENAI_API_KEY=\[REDACTED\]/);
+  assert.match(output, /stderr context Authorization: Bearer \[REDACTED\]/);
+  assert.match(html, /stdout context OPENAI_API_KEY=\[REDACTED\]/);
+  assert.match(html, /stderr context Authorization: Bearer \[REDACTED\]/);
+});
+
 test("createRunReporter uses live loader milestones on interactive stderr", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-run-report-loader-"));
   const chunks = [];


### PR DESCRIPTION
## Summary
- Redact project test stdout/stderr before returning test summaries or appending run-report sections.
- Redact direct run reporter test payloads before persisting output.txt and agentify-report.html.
- Add regressions covering project-test output and persisted report artifacts.

Closes #175

## Verification
- pnpm test -- test/project-tests.test.js
- pnpm test -- test/run-report.test.js
- pnpm test -- test/exec.test.js
- pnpm test (fails only in existing README CLI reference check: README is missing command index)