### PR TITLE
docs: add gamified session command page

### DIFF
--- a/index.html
+++ b/index.html
@@ -672,6 +672,7 @@
         <a href="#what">what</a>
         <a href="#why">why</a>
         <a href="#how">how</a>
+        <a href="pages/">commands</a>
         <a href="skill-catalog.html">skills</a>
         <a href="https://github.com/ixigo/agentify/blob/main/README.md">docs</a>
         <span class="pill">beta</span>
@@ -686,6 +687,7 @@
       <p class="lede">Agentify prepares your repository, routes the right context to the agent, validates state, and runs end-to-end workflows — so you spend less time prompting and more time shipping.</p>
       <div class="cta-row">
         <a class="cta cta-primary" href="https://github.com/ixigo/agentify">try the beta</a>
+        <a class="cta cta-secondary" href="pages/">browse commands</a>
         <a class="cta cta-secondary" href="skill-catalog.html">browse skills</a>
       </div>
       <div class="hero-meta">

--- a/pages/command-style.css
+++ b/pages/command-style.css
@@ -1,0 +1,684 @@
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap");
+
+:root {
+  color-scheme: dark light;
+  --bg: #0a0a0b;
+  --surface: #101012;
+  --surface-2: #15151a;
+  --ink: #ededed;
+  --muted: #8a8a93;
+  --faint: #555560;
+  --rule: #1f1f24;
+  --hair: #1a1a1e;
+  --accent: #7df9a0;
+  --accent-dim: rgba(125, 249, 160, 0.15);
+  --accent-strong: rgba(125, 249, 160, 0.4);
+  --hl: #15151a;
+  --code-bg: #050507;
+  --code-ink: #ededed;
+  --warn: #ffb86b;
+  --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  --max: 1080px;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #fafafa;
+    --surface: #ffffff;
+    --surface-2: #f5f5f7;
+    --ink: #0a0a0b;
+    --muted: #6a6a73;
+    --faint: #a0a0aa;
+    --rule: #e4e4ea;
+    --hair: #ececf0;
+    --accent: #00875f;
+    --accent-dim: rgba(0, 135, 95, 0.1);
+    --accent-strong: rgba(0, 135, 95, 0.3);
+    --hl: #f5f5f7;
+    --code-bg: #0a0a0b;
+    --code-ink: #ededed;
+    --warn: #b95900;
+  }
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  overflow-x: hidden;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 50% -10%, var(--accent-dim) 0%, transparent 45%),
+    var(--bg);
+  background-attachment: fixed;
+  font-family: var(--mono);
+  font-size: 14px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(var(--hair) 1px, transparent 1px),
+    linear-gradient(90deg, var(--hair) 1px, transparent 1px);
+  background-size: 64px 64px;
+  mask-image: radial-gradient(ellipse at center top, black 0%, transparent 75%);
+  opacity: 0.5;
+  z-index: 0;
+}
+
+nav, header, main, section.shell, footer { position: relative; z-index: 1; }
+
+.container {
+  width: min(var(--max), 100vw);
+  max-width: 100vw;
+  margin: 0 auto;
+  padding: 0 16px;
+}
+
+a {
+  color: var(--ink);
+  text-decoration: underline;
+  text-decoration-color: var(--rule);
+  text-underline-offset: 3px;
+}
+
+a:hover { color: var(--accent); text-decoration-color: var(--accent); }
+
+nav {
+  padding: 18px 0;
+  border-bottom: 1px solid var(--rule);
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+nav .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 18px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink);
+  font: 700 13px/1 var(--mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.brand::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  background: var(--accent);
+  border-radius: 50%;
+  box-shadow: 0 0 12px var(--accent);
+}
+
+.nav-links {
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  font-size: 12px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.nav-links a { text-decoration: none; color: var(--muted); }
+.nav-links a:hover { color: var(--accent); }
+
+.pill {
+  padding: 4px 8px;
+  color: var(--accent);
+  background: var(--accent-dim);
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+header {
+  padding: 84px 0 54px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.eyebrow, .section-label, .label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--accent);
+  background: var(--accent-dim);
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  font: 600 10px/1 var(--mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.eyebrow {
+  margin-bottom: 22px;
+  padding: 5px 11px;
+  border-color: var(--accent);
+}
+
+.section-label, .label {
+  margin-bottom: 14px;
+  padding: 3px 9px;
+}
+
+.eyebrow::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  background: var(--accent);
+  border-radius: 50%;
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 6px var(--accent); }
+  50% { opacity: 0.5; box-shadow: 0 0 0 var(--accent); }
+}
+
+h1 {
+  margin: 0 0 18px;
+  max-width: 18ch;
+  font: 600 clamp(2.4rem, 7vw, 4.4rem)/0.98 var(--sans);
+  letter-spacing: -0.04em;
+  color: var(--ink);
+}
+
+h2 {
+  margin: 0 0 12px;
+  max-width: 22ch;
+  font: 600 clamp(1.7rem, 4vw, 2.4rem)/1.05 var(--sans);
+  letter-spacing: -0.025em;
+  color: var(--ink);
+}
+
+h3 {
+  margin: 0 0 8px;
+  font: 600 1.05rem/1.25 var(--sans);
+  letter-spacing: -0.015em;
+  color: var(--ink);
+}
+
+.accent { color: var(--accent); }
+
+.lede, .section-lede {
+  margin: 0;
+  color: var(--muted);
+  font: 400 1rem/1.6 var(--sans);
+}
+
+.lede {
+  max-width: 63ch;
+  font-size: clamp(1rem, 1.5vw, 1.12rem);
+}
+
+.section-lede {
+  max-width: 66ch;
+  margin-bottom: 36px;
+}
+
+.hero-grid {
+  width: 100%;
+  max-width: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.75fr);
+  gap: 42px;
+  align-items: end;
+}
+
+.hero-grid > *,
+.terminal,
+.panel,
+.campaign,
+.move,
+.inventory-item,
+.command-card {
+  min-width: 0;
+}
+
+.hero-meta {
+  margin-top: 34px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 24px;
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.hero-meta span {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.hero-meta span::before {
+  content: "";
+  width: 4px;
+  height: 4px;
+  background: var(--accent);
+  transform: rotate(45deg);
+}
+
+code, .cmd, pre {
+  min-width: 0;
+  font-family: var(--mono);
+  letter-spacing: 0;
+}
+
+code {
+  padding: 1px 5px;
+  background: var(--hl);
+  border: 1px solid var(--hair);
+  border-radius: 2px;
+  color: var(--ink);
+  font-size: 0.92em;
+  overflow-wrap: anywhere;
+}
+
+pre {
+  margin: 0;
+  padding: 16px 18px;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  background: var(--code-bg);
+  color: var(--code-ink);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  font: 500 12px/1.7 var(--mono);
+}
+
+pre .c { color: var(--faint); }
+pre .a { color: var(--accent); }
+pre .w { color: var(--warn); }
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin-top: 28px;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 18px;
+  border-radius: 4px;
+  font: 600 12px/1 var(--mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: transform 100ms, box-shadow 100ms, border-color 100ms, background 100ms;
+}
+
+.cta-primary {
+  color: var(--bg);
+  background: var(--accent);
+  border: 1px solid var(--accent);
+}
+
+.cta-primary:hover {
+  color: var(--bg);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 28px var(--accent-strong);
+  text-decoration: none;
+}
+
+.cta-primary::after { content: "->"; transition: transform 120ms; }
+.cta-primary:hover::after { transform: translate(3px, 0); }
+
+.cta-secondary {
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--rule);
+}
+
+.cta-secondary:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  text-decoration: none;
+}
+
+section.shell {
+  padding: 72px 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+section.shell:last-of-type { border-bottom: none; }
+
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+}
+
+.terminal {
+  align-self: stretch;
+  padding: 18px;
+  overflow: hidden;
+  display: grid;
+  gap: 14px;
+  background:
+    linear-gradient(180deg, var(--surface-2), var(--surface));
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+}
+
+.terminal-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  color: var(--faint);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.campaign {
+  display: grid;
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.campaign-row {
+  display: grid;
+  grid-template-columns: 96px minmax(0, 1fr);
+  gap: 18px;
+  padding: 22px;
+  background: var(--surface);
+}
+
+.campaign-row .key {
+  color: var(--accent);
+  font: 700 11px/1 var(--mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.campaign-row p {
+  margin: 0;
+  color: var(--muted);
+  font: 400 13.5px/1.65 var(--sans);
+}
+
+.move-grid, .inventory-grid, .command-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.move, .inventory-item, .command-card {
+  padding: 20px;
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+}
+
+.move .tag, .inventory-item .tag, .command-card .tag {
+  display: inline-block;
+  margin-bottom: 12px;
+  color: var(--accent);
+  font: 600 10px/1 var(--mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.move p, .inventory-item p, .command-card p {
+  margin: 0 0 12px;
+  color: var(--muted);
+  font: 400 13px/1.6 var(--sans);
+  overflow-wrap: anywhere;
+}
+
+.move p:last-child, .inventory-item p:last-child, .command-card p:last-child { margin-bottom: 0; }
+
+.cmd {
+  display: block;
+  padding: 9px 11px;
+  overflow-x: auto;
+  background: var(--code-bg);
+  color: var(--accent);
+  border: 1px solid var(--rule);
+  border-radius: 3px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.cmd::before { content: "$ "; color: var(--faint); }
+
+.map {
+  padding: 24px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.node {
+  min-height: 116px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 16px;
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+}
+
+.node strong {
+  font: 600 0.98rem/1.2 var(--sans);
+  color: var(--ink);
+  letter-spacing: -0.01em;
+}
+
+.node span {
+  color: var(--muted);
+  font: 500 11px/1.4 var(--mono);
+}
+
+.node.active {
+  background:
+    linear-gradient(180deg, var(--accent-dim), transparent 65%),
+    var(--surface);
+  border-color: var(--accent);
+}
+
+.artifact-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.artifact {
+  padding: 18px;
+  background: var(--surface);
+}
+
+.artifact strong {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--ink);
+  font: 600 13px/1.3 var(--mono);
+  overflow-wrap: anywhere;
+}
+
+.artifact span {
+  color: var(--muted);
+  font: 400 12.5px/1.55 var(--sans);
+}
+
+.docs-strip {
+  margin-top: 16px;
+  padding: 20px 24px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 14px;
+  align-items: center;
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+}
+
+.docs-strip p {
+  margin: 0;
+  color: var(--muted);
+  font: 400 13px/1.5 var(--sans);
+}
+
+.doc-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  color: var(--ink);
+  background: var(--bg);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  font: 600 11px/1 var(--mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: all 100ms;
+}
+
+.doc-link:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-dim);
+  text-decoration: none;
+}
+
+.doc-link::before {
+  content: "->";
+  color: var(--accent);
+}
+
+footer {
+  padding: 28px 0 80px;
+  border-top: 1px solid var(--rule);
+  color: var(--faint);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+footer .container {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+footer a {
+  color: var(--faint);
+  text-decoration: none;
+}
+
+footer a:hover { color: var(--accent); }
+
+@media (max-width: 900px) {
+  .hero-grid,
+  .move-grid,
+  .inventory-grid,
+  .command-grid,
+  .docs-strip {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .map,
+  .artifact-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  header { padding: 60px 0 44px; }
+  section.shell { padding: 56px 0; }
+}
+
+@media (max-width: 620px) {
+  nav .container {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .nav-links {
+    width: 100%;
+    overflow-x: auto;
+    padding-bottom: 2px;
+  }
+
+  h1 {
+    max-width: 12ch;
+    font-size: clamp(2.05rem, 11vw, 2.7rem);
+  }
+
+  .lede {
+    font-size: 1rem;
+  }
+
+  .hero-meta {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .hero-grid,
+  .hero-grid > *,
+  .terminal {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .lede,
+  .section-lede {
+    max-width: calc(100vw - 64px);
+  }
+
+  .campaign-row,
+  .map,
+  .artifact-list {
+    grid-template-columns: 1fr;
+  }
+
+  .campaign-row {
+    gap: 10px;
+    padding: 18px;
+  }
+
+  .terminal,
+  .move,
+  .inventory-item,
+  .command-card {
+    padding: 16px;
+  }
+}

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Agentify · Command pages</title>
+  <meta name="description" content="Browse Agentify command workflows as focused, buildless command pages.">
+  <link rel="stylesheet" href="command-style.css">
+</head>
+<body>
+  <nav>
+    <div class="container">
+      <a class="brand" href="../index.html">Agentify</a>
+      <div class="nav-links">
+        <a href="../index.html">home</a>
+        <a href="session.html">session</a>
+        <a href="../skill-catalog.html">skills</a>
+        <a href="https://github.com/ixigo/agentify/blob/main/README.md">docs</a>
+        <span class="pill">commands</span>
+      </div>
+    </div>
+  </nav>
+
+  <header>
+    <div class="container hero-grid">
+      <div>
+        <span class="eyebrow">command atlas</span>
+        <h1>Pick a <span class="accent">workflow</span>, not a flag list.</h1>
+        <p class="lede">Agentify commands are grouped as playable routes: what the command does, when to use it, which subcommands matter, and what artifacts appear on disk.</p>
+        <div class="hero-meta">
+          <span>buildless html</span>
+          <span>same site theme</span>
+          <span>first page: <code>sess</code></span>
+        </div>
+      </div>
+      <aside class="terminal" aria-label="Command route preview">
+        <div class="terminal-top">
+          <span>route unlocked</span>
+          <span>01 / sessions</span>
+        </div>
+<pre><span class="c"># durable campaign state</span>
+<span class="a">agentify sess run --name "checkout-retries"</span>
+agentify sess resume --session &lt;id&gt;
+agentify sess fork --from &lt;id&gt;
+agentify sess list</pre>
+      </aside>
+    </div>
+  </header>
+
+  <main>
+    <section class="shell">
+      <div class="container">
+        <span class="section-label">available routes</span>
+        <h2>The first command page sets the <span class="accent">pattern.</span></h2>
+        <p class="section-lede">Each route keeps the technical surface visible while giving users a memorable mental model for when to run the command and what state it creates.</p>
+
+        <div class="command-grid">
+          <a class="command-card" href="session.html">
+            <span class="tag">durable work</span>
+            <h3>Session command</h3>
+            <p>Use <code>agentify sess</code> as a campaign save file: start, resume, fork, inspect, and hand off provider-backed work.</p>
+            <span class="cmd">agentify sess run --provider codex --name "payments-v2"</span>
+          </a>
+          <div class="command-card">
+            <span class="tag">next routes</span>
+            <h3>More command families</h3>
+            <p>Run, context, query, risk, skill, issue-killer, setup, planning, and maintenance pages are tracked by the follow-up issues under the parent command-page tracker.</p>
+            <span class="cmd">Parent: #202</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">
+      <span>Agentify command pages</span>
+      <span><a href="../index.html">home</a> · <a href="session.html">session</a></span>
+    </div>
+  </footer>
+</body>
+</html>

--- a/pages/session.html
+++ b/pages/session.html
@@ -1,0 +1,236 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Agentify · Session command</title>
+  <meta name="description" content="Learn the agentify sess workflow: run, resume, fork, list, and the durable session artifacts created under .agentify/session.">
+  <link rel="stylesheet" href="command-style.css">
+</head>
+<body>
+  <nav>
+    <div class="container">
+      <a class="brand" href="../index.html">Agentify</a>
+      <div class="nav-links">
+        <a href="../index.html">home</a>
+        <a href="./">commands</a>
+        <a href="#moves">moves</a>
+        <a href="#artifacts">artifacts</a>
+        <span class="pill">sess</span>
+      </div>
+    </div>
+  </nav>
+
+  <header>
+    <div class="container hero-grid">
+      <div>
+        <span class="eyebrow">agentify sess</span>
+        <h1>Your workstream has a <span class="accent">save file.</span></h1>
+        <p class="lede">Sessions turn a provider-backed task into durable campaign state. Start a run, resume later with the same context, fork from an earlier path, or hand the next agent a compact bundle.</p>
+        <div class="cta-row">
+          <a class="cta cta-primary" href="#moves">learn moves</a>
+          <a class="cta cta-secondary" href="./">command index</a>
+        </div>
+        <div class="hero-meta">
+          <span>state root <code>.agentify/session/&lt;id&gt;/</code></span>
+          <span>alias <code>agentify session</code></span>
+          <span>subcommands run · resume · fork · list</span>
+        </div>
+      </div>
+      <aside class="terminal" aria-label="Session command quick start">
+        <div class="terminal-top">
+          <span>campaign start</span>
+          <span>provider backed</span>
+        </div>
+<pre><span class="c"># Start a named workstream</span>
+<span class="a">agentify sess run --provider codex --name "checkout-retries"</span>
+
+<span class="c"># Continue from saved Agentify session context</span>
+agentify sess resume --session &lt;session-id&gt; "finish the implementation"
+
+<span class="c"># Write a cross-agent handoff bundle</span>
+agentify handoff --session &lt;session-id&gt; "handoff for the next agent"</pre>
+      </aside>
+    </div>
+  </header>
+
+  <main>
+    <section class="shell">
+      <div class="container">
+        <span class="section-label">mental model</span>
+        <h2>A session is a campaign <span class="accent">checkpoint.</span></h2>
+        <p class="section-lede">The command wraps provider launches with local state. Agentify records enough structure for the next launch to know where the work started, what context was selected, and what artifacts were generated.</p>
+
+        <div class="campaign">
+          <div class="campaign-row">
+            <div class="key">save file</div>
+            <p><code>agentify sess run</code> creates <code>.agentify/session/&lt;id&gt;/</code>, a manifest, bounded context, a checklist, and optional markdown bootstrap files before launching the provider.</p>
+          </div>
+          <div class="campaign-row">
+            <div class="key">load game</div>
+            <p><code>agentify sess resume</code> rehydrates an existing session by ID, rebuilds the provider prompt from saved bootstrap/context, and appends the new task to the same workstream.</p>
+          </div>
+          <div class="campaign-row">
+            <div class="key">new route</div>
+            <p><code>agentify sess fork</code> starts a child route from a parent session, carrying forward selected checklist and run history while keeping the new session path separate.</p>
+          </div>
+          <div class="campaign-row">
+            <div class="key">inventory</div>
+            <p><code>agentify sess list</code> shows known sessions with ID, provider, and creation time, so completions and handoffs can target the right run.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="shell" id="moves">
+      <div class="container">
+        <span class="section-label">moves</span>
+        <h2>The four session moves cover the <span class="accent">loop.</span></h2>
+        <p class="section-lede">Use these commands when one provider turn is not enough and you want Agentify-managed continuity instead of relying only on provider history.</p>
+
+        <div class="move-grid">
+          <div class="move">
+            <span class="tag">start</span>
+            <h3>Run a new session</h3>
+            <p>Creates a fresh session unless <code>--session</code> points at an existing one. Use <code>--name</code> for a readable label and <code>--provider</code> to pin the agent host.</p>
+            <span class="cmd">agentify sess run --provider codex --name "payments-v2"</span>
+          </div>
+          <div class="move">
+            <span class="tag">continue</span>
+            <h3>Resume by ID</h3>
+            <p>Loads <code>session-manifest.json</code>, <code>context.json</code>, and <code>bootstrap.md</code>. If no task is provided, the provider is instructed to continue from the latest repository state.</p>
+            <span class="cmd">agentify sess resume --session &lt;session-id&gt; "finish the tests"</span>
+          </div>
+          <div class="move">
+            <span class="tag">branch</span>
+            <h3>Fork from a parent</h3>
+            <p>Creates a separate child session from <code>--from</code>. This is useful when a workstream splits into an experiment, review path, or handoff branch.</p>
+            <span class="cmd">agentify sess fork --from &lt;session-id&gt; --name "payments-v2-review"</span>
+          </div>
+          <div class="move">
+            <span class="tag">inspect</span>
+            <h3>List saved sessions</h3>
+            <p>Prints recent session IDs, provider names, and creation timestamps. With JSON output enabled, the command returns the full manifest list.</p>
+            <span class="cmd">agentify sess list</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="shell">
+      <div class="container">
+        <span class="section-label">route map</span>
+        <h2>How a session moves through <span class="accent">state.</span></h2>
+        <p class="section-lede">The session flow is deliberately file-backed and local. Nothing becomes durable unless Agentify writes it into the session directory.</p>
+
+        <div class="map panel" aria-label="Session workflow map">
+          <div class="node active">
+            <strong>create</strong>
+            <span>manifest + context</span>
+          </div>
+          <div class="node">
+            <strong>launch</strong>
+            <span>provider prompt</span>
+          </div>
+          <div class="node">
+            <strong>record</strong>
+            <span>turns + transcript</span>
+          </div>
+          <div class="node">
+            <strong>compact</strong>
+            <span>context facts</span>
+          </div>
+          <div class="node">
+            <strong>resume</strong>
+            <span>same session id</span>
+          </div>
+          <div class="node">
+            <strong>fork</strong>
+            <span>child session id</span>
+          </div>
+          <div class="node">
+            <strong>handoff</strong>
+            <span>json + markdown</span>
+          </div>
+          <div class="node">
+            <strong>prepare child</strong>
+            <span>threshold based</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="shell" id="artifacts">
+      <div class="container">
+        <span class="section-label">inventory</span>
+        <h2>Artifacts under <span class="accent">.agentify/session/&lt;id&gt;/</span></h2>
+        <p class="section-lede">The manifest names the session and provider. The context files keep the launch bounded. Runtime records capture what happened after the provider starts.</p>
+
+        <div class="artifact-list">
+          <div class="artifact">
+            <strong>session-manifest.json</strong>
+            <span>Session ID, parent/fork IDs, provider, name, creation time, index snapshot, and cache refs.</span>
+          </div>
+          <div class="artifact">
+            <strong>context.json</strong>
+            <span>Fitted snapshot with module IDs, checklist summary, run history, rolling summary, and artifact refs.</span>
+          </div>
+          <div class="artifact">
+            <strong>checklist.json</strong>
+            <span>Structured task checklist carried from a parent session when the new run is forked.</span>
+          </div>
+          <div class="artifact">
+            <strong>bootstrap.md</strong>
+            <span>Markdown launch brief generated from the bounded context when markdown artifacts are enabled.</span>
+          </div>
+          <div class="artifact">
+            <strong>transcript.md</strong>
+            <span>Readable run transcript used by automatic session memory and future recall.</span>
+          </div>
+          <div class="artifact">
+            <strong>memory-context.md</strong>
+            <span>Automatic memory excerpt attached to the launch when prior session memory is available.</span>
+          </div>
+          <div class="artifact">
+            <strong>launches.jsonl</strong>
+            <span>Provider launch records, including the redacted command, provider, capture mode, and prompt metadata.</span>
+          </div>
+          <div class="artifact">
+            <strong>turns.jsonl</strong>
+            <span>Structured turn records used for replay, recall, and managed-context estimates.</span>
+          </div>
+          <div class="artifact">
+            <strong>context-events.jsonl</strong>
+            <span>Context fetch and routing events emitted during the session workflow.</span>
+          </div>
+          <div class="artifact">
+            <strong>context-facts.json</strong>
+            <span>Compacted structured facts extracted from session state when context compaction runs.</span>
+          </div>
+          <div class="artifact">
+            <strong>context-facts.md</strong>
+            <span>Markdown version of compacted context facts for humans and provider prompts.</span>
+          </div>
+          <div class="artifact">
+            <strong>handoff.json / handoff.md</strong>
+            <span>Cross-agent bundle written by <code>agentify handoff --session &lt;id&gt;</code>.</span>
+          </div>
+        </div>
+
+        <div class="docs-strip">
+          <p>Session IDs are validated before path resolution, and session directories are kept under <code>.agentify/session/</code>.</p>
+          <a class="doc-link" href="https://github.com/ixigo/agentify/blob/main/src/core/session.js">session source</a>
+          <a class="doc-link" href="https://github.com/ixigo/agentify/blob/main/README.md">readme</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">
+      <span>Agentify session command</span>
+      <span><a href="./">commands</a> · <a href="../index.html">home</a></span>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
Parent: #202
Closes #203

## Summary
- add a reusable static command-page stylesheet and command index under `pages/`
- add `pages/session.html` explaining `agentify sess run`, `resume`, `fork`, and `list` with session artifacts under `.agentify/session/<id>/`
- link the command-page area from the homepage navigation and hero CTA

## Verification
- `pnpm install --frozen-lockfile`
- `git diff --check`
- `node --test`
- headless Chrome screenshot checks for `pages/session.html` at desktop `1440x1100` and mobile `390x1200`

## Scope
This handles only the first child slice from the parent tracker: reusable command-page pattern plus the session command page.