### PR TITLE
docs: add risk command page

### DIFF
--- a/pages/command-style.css
+++ b/pages/command-style.css
@@ -392,6 +392,7 @@ section.shell:last-of-type { border-bottom: none; }
 .terminal-top {
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 16px;
   color: var(--faint);
   font-size: 11px;
@@ -459,6 +460,129 @@ section.shell:last-of-type { border-bottom: none; }
 }
 
 .move p:last-child, .inventory-item p:last-child, .command-card p:last-child { margin-bottom: 0; }
+
+.level-grid {
+  margin-top: 12px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.level-card {
+  min-width: 0;
+  padding: 18px;
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+}
+
+.level-card .tag {
+  display: inline-block;
+  margin-bottom: 12px;
+  color: var(--accent);
+  font: 600 10px/1 var(--mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.level-card p {
+  margin: 0;
+  color: var(--muted);
+  font: 400 13px/1.6 var(--sans);
+}
+
+.level-card.danger {
+  border-color: color-mix(in srgb, var(--warn) 55%, var(--rule));
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--warn) 12%, transparent), transparent 68%),
+    var(--surface);
+}
+
+.level-card.danger .tag {
+  color: var(--warn);
+}
+
+.risk-meter {
+  margin-bottom: 12px;
+  padding: 20px;
+}
+
+.meter-scale {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr auto;
+  margin-bottom: 8px;
+  color: var(--faint);
+  font: 600 10px/1 var(--mono);
+  letter-spacing: 0.08em;
+}
+
+.meter-scale span:nth-child(2),
+.meter-scale span:nth-child(3) {
+  justify-self: center;
+}
+
+.meter-scale span:last-child {
+  justify-self: end;
+}
+
+.meter-track {
+  display: grid;
+  grid-template-columns: 1fr 34fr 35fr 31fr;
+  min-height: 54px;
+  overflow: hidden;
+  background: var(--code-bg);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+}
+
+.meter-segment {
+  min-width: 0;
+  padding: 16px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink);
+  border-right: 1px solid var(--rule);
+  font: 700 10px/1 var(--mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.meter-segment:last-child {
+  border-right: 0;
+}
+
+.meter-segment.none { color: var(--faint); }
+.meter-segment.low { background: var(--accent-dim); color: var(--accent); }
+.meter-segment.medium { background: color-mix(in srgb, var(--warn) 14%, transparent); color: var(--warn); }
+.meter-segment.high { background: color-mix(in srgb, var(--warn) 28%, transparent); color: var(--warn); }
+
+.warning-panel {
+  padding: 20px;
+  display: grid;
+  grid-template-columns: minmax(0, 0.85fr) minmax(320px, 1.15fr);
+  gap: 18px;
+  align-items: stretch;
+}
+
+.warning-panel > div {
+  min-width: 0;
+}
+
+.warning-panel .tag {
+  display: inline-block;
+  margin-bottom: 12px;
+  color: var(--warn);
+  font: 600 10px/1 var(--mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.warning-panel p {
+  margin: 0;
+  color: var(--muted);
+  font: 400 13px/1.65 var(--sans);
+}
 
 .cmd {
   display: block;
@@ -613,6 +737,8 @@ footer a:hover { color: var(--accent); }
   .move-grid,
   .inventory-grid,
   .command-grid,
+  .level-grid,
+  .warning-panel,
   .docs-strip {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -627,6 +753,17 @@ footer a:hover { color: var(--accent); }
 }
 
 @media (max-width: 620px) {
+  .container {
+    width: min(390px, 100%);
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  header .container > *,
+  section.shell .container > * {
+    max-width: min(358px, 100%);
+  }
+
   nav .container {
     align-items: flex-start;
     flex-direction: column;
@@ -641,6 +778,12 @@ footer a:hover { color: var(--accent); }
   h1 {
     max-width: 12ch;
     font-size: clamp(2.05rem, 11vw, 2.7rem);
+  }
+
+  h2 {
+    max-width: 100%;
+    font-size: clamp(1.45rem, 8vw, 1.9rem);
+    overflow-wrap: anywhere;
   }
 
   .lede {
@@ -661,7 +804,12 @@ footer a:hover { color: var(--accent); }
 
   .lede,
   .section-lede {
-    max-width: calc(100vw - 64px);
+    max-width: 31ch;
+    overflow-wrap: anywhere;
+  }
+
+  .terminal-top {
+    justify-content: flex-start;
   }
 
   .campaign-row,
@@ -678,7 +826,28 @@ footer a:hover { color: var(--accent); }
   .terminal,
   .move,
   .inventory-item,
-  .command-card {
+  .command-card,
+  .level-card,
+  .warning-panel {
     padding: 16px;
+  }
+
+  .meter-track {
+    grid-template-columns: 1fr;
+  }
+
+  .meter-segment {
+    min-height: 42px;
+    border-right: 0;
+    border-bottom: 1px solid var(--rule);
+  }
+
+  .meter-segment:last-child {
+    border-bottom: 0;
+  }
+
+  pre {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
   }
 }

--- a/pages/index.html
+++ b/pages/index.html
@@ -61,10 +61,16 @@ agentify sess list</pre>
             <p>Use <code>agentify sess</code> as a campaign save file: start, resume, fork, inspect, and hand off provider-backed work.</p>
             <span class="cmd">agentify sess run --provider codex --name "payments-v2"</span>
           </a>
+          <a class="command-card" href="risk.html">
+            <span class="tag">blast radius</span>
+            <h3>Risk command</h3>
+            <p>Use <code>agentify risk</code> as a mission danger board: score changed files, inspect impacted code, and pick regression tests.</p>
+            <span class="cmd">agentify risk --since origin/main</span>
+          </a>
           <div class="command-card">
             <span class="tag">next routes</span>
             <h3>More command families</h3>
-            <p>Run, context, query, risk, skill, issue-killer, setup, planning, and maintenance pages are tracked by the follow-up issues under the parent command-page tracker.</p>
+            <p>Run, context, query, skill, issue-killer, setup, planning, and maintenance pages are tracked by the follow-up issues under the parent command-page tracker.</p>
             <span class="cmd">Parent: #202</span>
           </div>
         </div>

--- a/pages/risk.html
+++ b/pages/risk.html
@@ -1,0 +1,219 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Agentify · Risk command</title>
+  <meta name="description" content="Learn the agentify risk workflow: score PR blast radius, inspect impacted code, and pick regression tests from the Agentify index.">
+  <link rel="stylesheet" href="command-style.css">
+</head>
+<body>
+  <nav>
+    <div class="container">
+      <a class="brand" href="../index.html">Agentify</a>
+      <div class="nav-links">
+        <a href="../index.html">home</a>
+        <a href="./">commands</a>
+        <a href="#score">score</a>
+        <a href="#report">report</a>
+        <a href="#tests">tests</a>
+        <span class="pill">risk</span>
+      </div>
+    </div>
+  </nav>
+
+  <header>
+    <div class="container hero-grid">
+      <div>
+        <span class="eyebrow">agentify risk</span>
+        <h1>Run the <span class="accent">danger board</span> before the PR.</h1>
+        <p class="lede">Risk turns the current diff into a blast-radius score, a list of likely impacted code, and a short regression-test queue. Treat it like a mission meter: it points at danger, but it does not guarantee safety.</p>
+        <div class="cta-row">
+          <a class="cta cta-primary" href="#moves">choose input</a>
+          <a class="cta cta-secondary" href="#report">read output</a>
+        </div>
+        <div class="hero-meta">
+          <span>score range <code>0..100</code></span>
+          <span>source <code>.agentify/index.db</code></span>
+          <span>modes worktree diff or <code>--since</code></span>
+        </div>
+      </div>
+      <aside class="terminal" aria-label="Risk command quick start">
+        <div class="terminal-top">
+          <span>mission check</span>
+          <span>blast radius</span>
+        </div>
+<pre><span class="c"># Score the current worktree diff</span>
+<span class="a">agentify risk</span>
+
+<span class="c"># Score everything changed since the PR base</span>
+agentify risk --since origin/main
+
+<span class="c"># Send the full report to automation</span>
+agentify risk --since origin/main --json</pre>
+      </aside>
+    </div>
+  </header>
+
+  <main>
+    <section class="shell" id="moves">
+      <div class="container">
+        <span class="section-label">mission input</span>
+        <h2>Pick the board that matches the <span class="accent">review moment.</span></h2>
+        <p class="section-lede">The command always needs an Agentify index. Run it after <code>agentify scan</code> or <code>agentify up</code> so files, modules, symbols, imports, and test commands are available.</p>
+
+        <div class="move-grid">
+          <div class="move">
+            <span class="tag">local edit check</span>
+            <h3>Current worktree diff</h3>
+            <p>Use the default mode while you are still editing. Agentify reads the changed files in the current checkout and scores the blast radius against the indexed graph.</p>
+            <span class="cmd">agentify risk</span>
+          </div>
+          <div class="move">
+            <span class="tag">pr base check</span>
+            <h3>Since a commit or ref</h3>
+            <p>Use <code>--since &lt;commit&gt;</code> for a branch review. It scores files changed since the chosen ref, such as the PR base branch or a known release point.</p>
+            <span class="cmd">agentify risk --since origin/main</span>
+          </div>
+          <div class="move">
+            <span class="tag">automation</span>
+            <h3>Machine-readable output</h3>
+            <p>Add <code>--json</code> when a script, CI job, or follow-up agent needs every field instead of the compact terminal report.</p>
+            <span class="cmd">agentify risk --since origin/main --json</span>
+          </div>
+          <div class="move">
+            <span class="tag">follow the trail</span>
+            <h3>Inspect with query</h3>
+            <p>When the report names an unexpected module, file, or symbol, use the query command page to inspect owners, dependencies, definitions, references, callers, and impact paths.</p>
+            <span class="cmd">agentify query impacts --file src/auth/useAuth.ts</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="shell" id="score">
+      <div class="container">
+        <span class="section-label">score model</span>
+        <h2>The meter is bounded, indexed, and <span class="accent">explainable.</span></h2>
+        <p class="section-lede">Risk combines changed-file contribution, dependency fan-out, semantic relationships, impacted files, and impacted modules into a score capped at 100.</p>
+
+        <div class="risk-meter panel" aria-label="Risk score levels">
+          <div class="meter-scale">
+            <span>0</span>
+            <span>35</span>
+            <span>70</span>
+            <span>100</span>
+          </div>
+          <div class="meter-track">
+            <div class="meter-segment none">none</div>
+            <div class="meter-segment low">low</div>
+            <div class="meter-segment medium">medium</div>
+            <div class="meter-segment high">high</div>
+          </div>
+        </div>
+
+        <div class="level-grid">
+          <div class="level-card">
+            <span class="tag">0</span>
+            <h3>None</h3>
+            <p>No changed-file contribution is present in the report. This is not a proof that nothing matters outside the index.</p>
+          </div>
+          <div class="level-card">
+            <span class="tag">1-34</span>
+            <h3>Low</h3>
+            <p>The changed files look relatively isolated or test-focused according to the indexed graph and semantic facts.</p>
+          </div>
+          <div class="level-card">
+            <span class="tag">35-69</span>
+            <h3>Medium</h3>
+            <p>The diff reaches enough dependency, semantic, or module surface area that focused regression tests should be planned.</p>
+          </div>
+          <div class="level-card danger">
+            <span class="tag">70-100</span>
+            <h3>High</h3>
+            <p>The diff likely touches shared code, fan-out, or multiple modules. Run the recommended tests and inspect the impact path before review.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="shell" id="report">
+      <div class="container">
+        <span class="section-label">report sections</span>
+        <h2>Read the board from top to <span class="accent">fallback.</span></h2>
+        <p class="section-lede">The human report is intentionally short. The JSON report keeps the same sections with the full file, module, symbol, and test payloads.</p>
+
+        <div class="campaign">
+          <div class="campaign-row">
+            <div class="key">score</div>
+            <p><code>Risk: &lt;score&gt;/100 (&lt;level&gt;)</code> is the headline. Reasons call out signals such as the highest changed-file contribution, dependency fan-out, semantic centrality, module count, or semantic surfaces.</p>
+          </div>
+          <div class="campaign-row">
+            <div class="key">changed</div>
+            <p>Changed files include the path, git status, owning module when known, and per-file scoring details in JSON. The terminal view lists each file and its rounded contribution.</p>
+          </div>
+          <div class="campaign-row">
+            <div class="key">impact</div>
+            <p>Impacted modules, files, and symbols come from the indexed import graph plus semantic TypeScript/JavaScript facts. The graph only covers what Agentify indexed.</p>
+          </div>
+          <div class="campaign-row">
+            <div class="key">tests</div>
+            <p>Prioritized test commands are ranked from indexed package scripts and test-file relationships. A high priority means "run this first", not "run only this".</p>
+          </div>
+          <div class="campaign-row">
+            <div class="key">json</div>
+            <p><code>--json</code> returns <code>schema_version</code>, <code>changed_files</code>, <code>risk</code>, <code>impacted</code>, <code>prioritized_test_commands</code>, and <code>notes</code> for scripts or agents.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="shell" id="tests">
+      <div class="container">
+        <span class="section-label">coverage warning</span>
+        <h2>No indexed test does not mean <span class="accent">safe.</span></h2>
+        <p class="section-lede">If Agentify cannot match an indexed test command to the impacted modules, the report emits a note instead of pretending the mission is clear.</p>
+
+        <div class="warning-panel panel">
+          <div>
+            <span class="tag">possible note</span>
+            <h3>No indexed test command covers the impacted modules.</h3>
+            <p>That note means the index did not find a test command for the impacted area. Rebuild the index after adding package test scripts, then rerun risk and choose any missing manual checks yourself.</p>
+          </div>
+          <aside class="terminal" aria-label="Risk no coverage example">
+            <div class="terminal-top">
+              <span>fallback</span>
+              <span>not safe</span>
+            </div>
+<pre>Risk: 44/100 (medium)
+
+Changed files:
+- src/payments/settle.ts [M] score 28
+
+Impacted modules:
+- payments (3 file(s), score 16)
+
+Prioritized tests:
+- none
+
+Note: No indexed test command covers the impacted modules. Run agentify scan after adding package test scripts.</pre>
+          </aside>
+        </div>
+
+        <div class="docs-strip">
+          <p>Need to explain an impact path? Open the query route for owner, deps, refs, callers, and file impact inspection.</p>
+          <a class="doc-link" href="query.html">query page</a>
+          <a class="doc-link" href="https://github.com/ixigo/agentify/blob/main/src/core/risk.js">risk source</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">
+      <span>Agentify risk command</span>
+      <span><a href="./">commands</a> · <a href="../index.html">home</a></span>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add a buildless, gamified command page for agentify risk
- Document default diff mode, --since usage, --json output, score thresholds, report sections, and no-coverage notes
- Link the command index to the risk page and add responsive shared styles for the risk meter and warning board

## Verification
- git diff --check
- node -e static HTML smoke for pages/risk.html and pages/index.html
- env npm_config_cache=/tmp/agentify-npm-cache node --test
- Headless Chrome screenshots for pages/risk.html at 1440px desktop and 390px mobile

Closes #207