### PR TITLE
feat: add Azure DevOps provider skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,10 @@ Skills are opt-in. Install only if you need them:
 ```bash
 agentify skill install all --provider codex --scope project
 agentify skill install caveman --provider codex --scope project   # terse output mode
+agentify skill install ado-autopilot --provider codex --scope project
 ```
+
+Azure DevOps skills use Azure CLI plus the Azure DevOps extension. Verify with `az extension show --name azure-devops`, `az account show`, and `az devops configure --list`.
 
 </details>
 

--- a/docs/DETAILED_README.md
+++ b/docs/DETAILED_README.md
@@ -368,6 +368,8 @@ Built-in skill bundles live under the repository-level [`skills/`](../skills/) d
 
 Built-in skills:
 
+- `ado-autopilot` (aliases: `azure-devops-autopilot`, `ado`)
+- `azure-devops-triage` (alias: `ado-triage`)
 - `copy-mode`
 - `copy-pr`
 - `grill-me`
@@ -377,6 +379,22 @@ Built-in skills:
 - `worktree-autopilot` (aliases: `worktree-verifier`, `god-mode`)
 - `pr-creator`
 - `commit-creator`
+
+Azure DevOps skills require Azure CLI plus the Azure DevOps extension:
+
+```bash
+command -v az
+az extension show --name azure-devops
+az account show
+az devops configure --list
+```
+
+Examples:
+
+```bash
+agentify skill install ado-autopilot --provider codex --scope project
+agentify skill install azure-devops-triage --provider codex --scope project
+```
 
 Use `--scope project` when you want the repository to carry its own provider skill setup under directories like `.codex/skills/`. Use `--scope user` when you want skills installed globally for your local account.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -313,7 +313,11 @@ Project scope writes repo-local provider instructions, for example `.codex/skill
 ```bash
 agentify skill install all --provider codex --scope project
 agentify skill install gh-autopilot --provider codex --scope project
+agentify skill install ado-autopilot --provider codex --scope project
+agentify skill install azure-devops-triage --provider codex --scope project
 ```
+
+Azure DevOps skills require `az`, the `azure-devops` extension, a valid `az account show`, and configured organization/project defaults from `az devops configure --list`.
 
 User scope keeps the install local to one developer machine:
 

--- a/skill-catalog.html
+++ b/skill-catalog.html
@@ -643,11 +643,13 @@
       { id: "kb", title: "Knowledge & content", desc: "Notes, articles, compact prose.",
         skills: ["obsidian-vault", "edit-article", "scaffold-exercises", "caveman", "caveman-compress"] },
       { id: "ext", title: "External platforms", desc: "Jira, ADO, GitLab — non-GitHub source of truth.",
-        skills: ["jira", "pr-convention-learner"] }
+        skills: ["ado-autopilot", "azure-devops-triage", "jira", "pr-convention-learner"] }
     ];
 
     const needs = {
+      "ado-autopilot": "<code>az</code>, Azure DevOps extension, org/project defaults",
       "auto-pilot": "git repo, project commands, edit + validation perms",
+      "azure-devops-triage": "<code>az boards</code> access + work item ID/URL",
       "caveman-compress": "text or memory artifact",
       "caveman": "level: lite / full / ultra / wenyan",
       "commit-creator": "git, completed changes, stage + commit perms",
@@ -689,6 +691,20 @@
         helps: "Reduces handholding for routine implementation; keeps changes scoped to repository evidence.",
         invoke: "implement &lt;goal&gt; — agent reads repo, plans, edits, validates, commits.",
         tags: ["autonomous", "validation"] },
+      { name: "ado-autopilot",
+        short: "Azure Boards and Azure Repos orchestration via <code>az</code>.",
+        when: "Azure DevOps work item or PR context should drive execution, review, or PR creation.",
+        why: "ADO work needs org/project/repo detection and auth checks before mutations are safe.",
+        helps: "Resolves work items and PRs, checks CLI context, then hands code changes to worktree automation.",
+        invoke: "ado &lt;work-item|PR-url&gt; — resolves context, builds checklist, routes implementation.",
+        tags: ["ado", "az-cli"] },
+      { name: "azure-devops-triage",
+        short: "Inspect and prepare Azure Boards work items.",
+        when: "ADO work items need field, tag, state, or readiness triage before implementation.",
+        why: "Azure Boards process templates vary, so state changes need conservative recommendations.",
+        helps: "Reads standard System fields, comments, and tags; recommends updates without assuming a template.",
+        invoke: "ado-triage &lt;id|url&gt; — summarizes readiness and recommended changes.",
+        tags: ["ado", "triage"] },
       { name: "caveman-compress",
         short: "Memory compression placeholder. Experimental.",
         when: "Only when experimenting with compacting memory or long notes into terse agent-readable form.",

--- a/skills/ado-autopilot/SKILL.md
+++ b/skills/ado-autopilot/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: ado-autopilot
+description: >
+  Orchestrate Azure Boards work items and Azure Repos pull requests with az CLI.
+  Use when the user provides an Azure DevOps work item or PR URL/ID, asks to pick
+  up Azure Boards work, or wants Azure Repos PR creation/review handling. Resolve
+  Azure DevOps context first, then hand code changes to worktree-autopilot.
+---
+
+# ADO Autopilot
+
+Run Azure DevOps work-item and PR workflows end-to-end with explicit CLI context,
+readiness checks, and conservative mutation rules.
+
+## Workflow
+
+1. Confirm local repository and Azure DevOps tooling are ready:
+   - `git rev-parse --is-inside-work-tree`
+   - `command -v az`
+   - `az extension show --name azure-devops`
+   - `az account show`
+   - `az devops configure --list`
+2. Resolve organization, project, and repository from:
+   - explicit Azure DevOps URL fields
+   - `az devops configure --list` defaults
+   - Azure Repos git remotes such as `https://dev.azure.com/{org}/{project}/_git/{repo}`
+3. Detect the requested Azure DevOps object:
+   - Azure Boards work item URL or numeric ID
+   - Azure Repos pull request URL or numeric ID
+   - `latest` or `first` active work item assigned to or created by the authenticated user when identity is available
+4. Fetch canonical details before deciding:
+   - work item: `az boards work-item show --id <id>`
+   - PR: `az repos pr show --id <id>`
+5. Convert the resolved context into an execution checklist.
+6. Keep Azure DevOps orchestration in this skill. If code changes are needed,
+   invoke `worktree-autopilot` with the resolved work item or PR context.
+7. Validate, commit, push, and create a draft PR only when the user asked for that
+   workflow or the surrounding task requires delivery.
+
+## Work Item Resolution
+
+Use explicit IDs or URLs first. For shorthand selection, keep the default scope
+to the authenticated user when the CLI can determine identity.
+
+```bash
+az boards work-item show --id <id>
+az boards query --wiql "SELECT [System.Id], [System.Title], [System.State] FROM WorkItems WHERE [System.AssignedTo] = @Me ORDER BY [System.ChangedDate] DESC"
+```
+
+If `@Me` or identity resolution is not available, stop and ask for a work item ID
+or URL instead of broadening scope silently. Inspect returned `System.State`
+values before treating an item as active because terminal states vary by process
+template.
+
+Read these standard fields when present:
+
+- `System.Id`
+- `System.Title`
+- `System.State`
+- `System.WorkItemType`
+- `System.AssignedTo`
+- `System.CreatedBy`
+- `System.Tags`
+- `System.Description`
+
+## Pull Request Workflows
+
+Prefer normal Azure Repos CLI commands first:
+
+```bash
+az repos pr show --id <id>
+az repos pr list --status active
+az repos pr create --draft true --source-branch <branch> --target-branch <branch> --title <title> --description <body>
+```
+
+When `az repos pr` omits review-thread payloads, fall back to the Azure DevOps
+REST surface through `az devops invoke` and report the exact route used:
+
+```bash
+az devops invoke \
+  --area git \
+  --resource pullRequestThreads \
+  --route-parameters project=<project> repositoryId=<repo> pullRequestId=<id> \
+  --api-version 7.1
+```
+
+For richer review-comment resolution and convention learning, use the existing
+`pr-convention-learner` skill. For draft PR creation across hosts, reuse
+`pr-creator` command patterns instead of inventing a separate PR flow.
+
+## Failure Modes
+
+- Missing `az`: tell the user to install Azure CLI.
+- Missing Azure DevOps extension: run or suggest `az extension add --name azure-devops`.
+- Missing org/project defaults: ask for a URL or run `az devops configure --defaults organization=<url> project=<project>`.
+- Stale PAT/auth: surface errors such as `Access Denied: The Personal Access Token used has expired` and stop until auth is refreshed.
+- Remote/config mismatch: report both the Azure Repos remote-derived org/project and configured `az devops` defaults before mutating anything.
+- Missing PR review threads from CLI: use `az devops invoke` fallback and include the route in the response.
+
+## Guardrails
+
+- Do not close work items, complete PRs, bypass policies, or mutate state unless
+  the user clearly asks.
+- Do not store PATs or credentials in skill files, docs, prompts, or commits.
+- Do not assume all Azure Boards projects use Scrum, Agile, or CMMI-specific
+  states beyond standard `System.*` fields.
+- Keep implementation work isolated through `worktree-autopilot` after context
+  is resolved.

--- a/skills/ado-autopilot/agents/openai.yaml
+++ b/skills/ado-autopilot/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "ADO Autopilot"
+  short_description: "Orchestrate Azure Boards work items and Azure Repos PRs"
+  default_prompt: "Use $ado-autopilot to validate az Azure DevOps context, resolve the work item or PR, and invoke $worktree-autopilot if code changes are needed."

--- a/skills/azure-devops-triage/SKILL.md
+++ b/skills/azure-devops-triage/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: azure-devops-triage
+description: >
+  Triage Azure Boards work items by inspecting fields, comments, states, and tags
+  with az CLI. Use when the user wants to review, classify, update, or prepare
+  Azure DevOps work items for agent execution.
+---
+
+# Azure DevOps Triage
+
+Triage Azure Boards work items safely. Inspect first, recommend changes by
+default, and mutate only when the user explicitly asks.
+
+## Workflow
+
+1. Confirm prerequisites:
+   - `command -v az`
+   - `az extension show --name azure-devops`
+   - `az account show`
+   - `az devops configure --list`
+2. Resolve the target work item:
+   - explicit Azure Boards URL
+   - numeric work item ID
+   - `latest` or `first` active work item assigned to or created by the authenticated user when identity is available
+3. Fetch details:
+   - `az boards work-item show --id <id>`
+4. Inspect standard fields:
+   - `System.Title`
+   - `System.State`
+   - `System.WorkItemType`
+   - `System.AssignedTo`
+   - `System.CreatedBy`
+   - `System.Tags`
+   - `System.Description`
+5. Inspect discussion/comments where supported by the configured Azure DevOps CLI
+   version. If the CLI lacks a direct command, use `az devops invoke` against the
+   work item comments API and report the route used.
+6. Produce a triage summary with:
+   - current state and owner
+   - inferred type and priority signals from fields/tags
+   - missing information
+   - recommended state/tag/assignee changes
+   - whether the item is ready for implementation handoff
+7. If implementation is requested and the item is ready, hand the resolved
+   context to `ado-autopilot` or `worktree-autopilot`.
+
+## Conservative State Mapping
+
+Azure Boards process templates vary. Treat these as suggestions, not universal
+truth:
+
+- GitHub `open`: an active/nonterminal Azure Boards state such as `New`, `Active`, `To Do`, or `Committed`.
+- GitHub `ready`: use tags such as `agentify-ready` only if the project already uses them or the user asks.
+- GitHub `in progress`: recommend the nearest existing in-progress state after inspecting available field values.
+- GitHub `closed`: terminal states vary; do not close or resolve work items unless explicitly requested.
+
+Prefer tags for lightweight classification only when that matches the existing
+project convention. Preserve existing tags and append new tags intentionally.
+
+## Useful Commands
+
+```bash
+az boards work-item show --id <id>
+az boards work-item update --id <id> --fields System.Tags="tag1; tag2"
+az boards work-item update --id <id> --state "<state>"
+az boards query --wiql "SELECT [System.Id], [System.Title], [System.State] FROM WorkItems WHERE [System.AssignedTo] = @Me ORDER BY [System.ChangedDate] DESC"
+```
+
+Only run update commands after the user has clearly approved the exact mutation.
+
+## Failure Modes
+
+- Missing Azure DevOps extension: install with `az extension add --name azure-devops`.
+- Missing organization/project defaults: request a work item URL or configure defaults with `az devops configure`.
+- Stale PAT/auth: report the exact Azure CLI error and stop.
+- Unknown process template: inspect current fields and recommend, do not assume.
+
+## Output Format
+
+- `Work item`
+- `Current fields`
+- `Discussion signals`
+- `Readiness`
+- `Recommended changes`
+- `Next action`

--- a/skills/azure-devops-triage/agents/openai.yaml
+++ b/skills/azure-devops-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Azure DevOps Triage"
+  short_description: "Inspect and prepare Azure Boards work items safely"
+  default_prompt: "Use $azure-devops-triage to inspect the Azure Boards work item, summarize state and tags, and recommend conservative updates without mutating unless I ask."

--- a/src/core/skills.js
+++ b/src/core/skills.js
@@ -12,10 +12,22 @@ export const SKILL_INSTALL_PROVIDERS = SKILL_INSTALL_PROVIDER_NAMES;
 
 const BUILTIN_SKILLS = [
   {
+    name: "ado-autopilot",
+    aliases: ["azure-devops-autopilot", "ado"],
+    description:
+      "Orchestrate Azure Boards work items and Azure Repos PR workflows via az CLI, and hand implementation work off to worktree-autopilot after context is resolved.",
+  },
+  {
     name: "auto-pilot",
     aliases: [],
     description:
       "Execute a task end-to-end with minimal user interaction by deriving requirements from the repository first, then implementing, validating, and committing autonomously.",
+  },
+  {
+    name: "azure-devops-triage",
+    aliases: ["ado-triage"],
+    description:
+      "Triage Azure Boards work items by inspecting standard System fields, comments, states, and tags, then recommending conservative updates without assuming a process template.",
   },
   {
     name: "caveman",

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1124,7 +1124,7 @@ test("runCli supports skill install all for codex project scope", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-skill-all-codex-"));
   await runCli(["skill", "install", "all", "--root", root, "--provider", "codex", "--scope", "project"]);
 
-  for (const skillName of ["grill-me", "improve-codebase-architecture", "gh-autopilot", "copy-mode", "worktree-autopilot", "pr-creator", "commit-creator"]) {
+  for (const skillName of ["grill-me", "improve-codebase-architecture", "gh-autopilot", "ado-autopilot", "azure-devops-triage", "copy-mode", "worktree-autopilot", "pr-creator", "commit-creator"]) {
     await assert.doesNotReject(() =>
       fs.access(path.join(root, ".codex", "skills", skillName, "SKILL.md"))
     );

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -66,6 +66,8 @@ test("listBuiltinSkills exposes built-in catalog and alias", async () => {
   assert.deepEqual(resolveBuiltinSkill("worktree-verifier").name, "worktree-autopilot");
   assert.deepEqual(resolveBuiltinSkill("gh-issue-autopilot").name, "gh-autopilot");
   assert.deepEqual(resolveBuiltinSkill("gh-issue-killer").name, "issue-killer");
+  assert.deepEqual(resolveBuiltinSkill("azure-devops-autopilot").name, "ado-autopilot");
+  assert.deepEqual(resolveBuiltinSkill("ado-triage").name, "azure-devops-triage");
   assert.deepEqual(resolveBuiltinSkill("jira").name, "jira");
 });
 
@@ -137,6 +139,34 @@ test("installBuiltinSkill copies gh autopilot skill bundle into project scope", 
   assert.equal(result.results[0].status, "installed");
   assert.equal(await exists(skillPath), true);
   assert.equal(await exists(uiPath), true);
+});
+
+test("installBuiltinSkill copies Azure DevOps skill bundles into project scope", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-skill-ado-"));
+  const autopilot = await installBuiltinSkill(root, {
+    name: "azure-devops-autopilot",
+    provider: "codex",
+    scope: "project",
+  });
+  const triage = await installBuiltinSkill(root, {
+    name: "ado-triage",
+    provider: "codex",
+    scope: "project",
+  });
+
+  const autopilotPath = path.join(root, ".codex", "skills", "ado-autopilot", "SKILL.md");
+  const autopilotUiPath = path.join(root, ".codex", "skills", "ado-autopilot", "agents", "openai.yaml");
+  const triagePath = path.join(root, ".codex", "skills", "azure-devops-triage", "SKILL.md");
+  const triageUiPath = path.join(root, ".codex", "skills", "azure-devops-triage", "agents", "openai.yaml");
+
+  assert.equal(autopilot.skill.name, "ado-autopilot");
+  assert.equal(triage.skill.name, "azure-devops-triage");
+  assert.equal(autopilot.results[0].status, "installed");
+  assert.equal(triage.results[0].status, "installed");
+  assert.equal(await exists(autopilotPath), true);
+  assert.equal(await exists(autopilotUiPath), true);
+  assert.equal(await exists(triagePath), true);
+  assert.equal(await exists(triageUiPath), true);
 });
 
 test("installBuiltinSkill copies pr creator skill bundle into project scope", async () => {


### PR DESCRIPTION
Closes #240

## Summary
- add ado-autopilot and azure-devops-triage built-in skill bundles with Codex prompt metadata
- register Azure DevOps skill aliases for list/install discovery
- document Azure CLI prerequisites and update the static skill catalog

## Verification
- npm test -- test/skills.test.js
- npm test
- node src/cli.js skill list --json
- node src/cli.js skill install azure-devops-autopilot --provider codex --scope project --root <tmp> --json
- node src/cli.js skill install ado-triage --provider codex --scope project --root <tmp> --json