### PR TITLE
fix: block repo-config test env inheritance

### DIFF
--- a/docs/DETAILED_README.md
+++ b/docs/DETAILED_README.md
@@ -194,10 +194,12 @@ Configure overrides in `.agentify.yaml` under the `tests.env` key:
 tests:
   timeoutMs: 600000       # wall-clock timeout for the detected test command
   env:
-    inherit: false        # set to true to forward the entire host environment (legacy behavior, not recommended)
+    inherit: false        # repo config cannot enable full host-environment inheritance
     passthrough: []       # list of additional env var names to forward from the host shell
     extra: {}             # explicit key/value map injected into the test subprocess
 ```
+
+Tracked `.agentify.yaml` files cannot opt project tests into full host-environment inheritance. If you intentionally need host variables, prefer named `tests.env.passthrough` entries. Full-environment inheritance is reserved for explicit runtime opt-in outside repo-controlled config.
 
 For example, a project whose tests need `MY_TEST_DB_URL` from the shell and a fixed `NODE_ENV` should declare:
 

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -146,6 +146,26 @@ function deepMerge(target, source) {
   return result;
 }
 
+function sanitizeRepoConfig(config) {
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    return {};
+  }
+
+  const sanitized = { ...config };
+  const tests = sanitized.tests;
+  const env = tests && typeof tests === "object" && !Array.isArray(tests) ? tests.env : null;
+  if (env && typeof env === "object" && !Array.isArray(env) && env.inherit === true) {
+    sanitized.tests = {
+      ...tests,
+      env: {
+        ...env,
+        inherit: false,
+      },
+    };
+  }
+  return sanitized;
+}
+
 function applyNestedFlags(config, flags) {
   const result = { ...config };
 
@@ -199,7 +219,7 @@ export async function loadConfig(root, flags = {}) {
     }
   }
 
-  const merged = deepMerge(DEFAULT_CONFIG, fileConfig);
+  const merged = deepMerge(DEFAULT_CONFIG, sanitizeRepoConfig(fileConfig));
   return normalizeConfig(applyNestedFlags(merged, flags));
 }
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -70,6 +70,50 @@ test("loadConfig provides project test timeout defaults", async () => {
   assert.equal(config.tests.timeoutMs, 600000);
 });
 
+test("loadConfig ignores repo-configured project test full-env inheritance", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-config-test-env-inherit-"));
+  await fs.writeFile(
+    path.join(root, ".agentify.yaml"),
+    [
+      "tests:",
+      "  env:",
+      "    inherit: true",
+      "    passthrough:",
+      "      - MY_TEST_VAR",
+      "    extra:",
+      "      NODE_ENV: test",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const config = await loadConfig(root);
+
+  assert.equal(config.tests.env.inherit, false);
+  assert.deepEqual(config.tests.env.passthrough, ["MY_TEST_VAR"]);
+  assert.deepEqual(config.tests.env.extra, { NODE_ENV: "test" });
+});
+
+test("loadConfig allows explicit flag opt-in for project test full-env inheritance", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-config-test-env-flag-"));
+  await fs.writeFile(
+    path.join(root, ".agentify.yaml"),
+    [
+      "tests:",
+      "  env:",
+      "    inherit: true",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const config = await loadConfig(root, {
+    "tests.env.inherit": true,
+  });
+
+  assert.equal(config.tests.env.inherit, true);
+});
+
 test("loadConfig provides provider env policy defaults", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-config-provider-env-"));
 

--- a/test/project-tests.test.js
+++ b/test/project-tests.test.js
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import { loadConfig } from "../src/core/config.js";
 import { buildTestEnv, detectTestCommand, runProjectTests } from "../src/core/project-tests.js";
 
 function createReporter() {
@@ -222,6 +223,54 @@ test("runProjectTests does not leak host secrets to the test subprocess by defau
     assert.equal(result.status, "passed", `expected passed, got ${result.status}: ${result.stderr}`);
     const captured = JSON.parse(await fs.readFile(outputPath, "utf8"));
     assert.equal(captured.sentinel, null, "host secret leaked into the test subprocess");
+    assert.equal(captured.extra, "explicit-value", "configured extra env was not forwarded");
+  } finally {
+    if (previous === undefined) {
+      delete process.env.SENTINEL_SECRET;
+    } else {
+      process.env.SENTINEL_SECRET = previous;
+    }
+  }
+});
+
+test("runProjectTests ignores repo-configured full-env inheritance", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-test-env-repo-inherit-"));
+  const outputPath = path.join(root, "captured-env.txt");
+  await fs.writeFile(path.join(root, "capture.js"), `
+    const fs = require("node:fs");
+    fs.writeFileSync(process.env.CAPTURE_OUT, JSON.stringify({
+      sentinel: process.env.SENTINEL_SECRET ?? null,
+      extra: process.env.AGENTIFY_EXTRA ?? null,
+    }));
+  `);
+  await fs.writeFile(path.join(root, "package.json"), JSON.stringify({
+    name: "agentify-env-repo-inherit",
+    scripts: { test: "node capture.js" },
+  }, null, 2));
+  await fs.writeFile(
+    path.join(root, ".agentify.yaml"),
+    [
+      "tests:",
+      "  env:",
+      "    inherit: true",
+      "    extra:",
+      `      CAPTURE_OUT: ${JSON.stringify(outputPath)}`,
+      "      AGENTIFY_EXTRA: explicit-value",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const previous = process.env.SENTINEL_SECRET;
+  process.env.SENTINEL_SECRET = "repo-config-should-not-leak";
+  try {
+    const reporter = createReporter();
+    const config = await loadConfig(root);
+    const result = await runProjectTests(root, reporter, { config });
+
+    assert.equal(result.status, "passed", `expected passed, got ${result.status}: ${result.stderr}`);
+    const captured = JSON.parse(await fs.readFile(outputPath, "utf8"));
+    assert.equal(captured.sentinel, null, "repo-configured inherit leaked a host secret");
     assert.equal(captured.extra, "explicit-value", "configured extra env was not forwarded");
   } finally {
     if (previous === undefined) {


### PR DESCRIPTION
## Summary
- block tracked `.agentify.yaml` from enabling `tests.env.inherit: true` for project-test subprocesses
- keep targeted `tests.env.passthrough` and `tests.env.extra` behavior intact
- document the safer repo-config path and add regression coverage for repo-config and explicit runtime opt-in

Closes #250

## Tests
- `node --test test/config.test.js test/project-tests.test.js`
- `npm test`