### PR TITLE
fix: escape agentignore metacharacters

### DIFF
--- a/src/core/fs.js
+++ b/src/core/fs.js
@@ -33,6 +33,28 @@ const HARD_EXCLUDES = [
 
 const ignorePatternCache = new Map();
 
+function escapeRegexLiteral(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function compileAgentignorePattern(pattern) {
+  let regexStr = "";
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    if (char === "*") {
+      if (pattern[index + 1] === "*") {
+        regexStr += ".*";
+        index += 1;
+      } else {
+        regexStr += "[^/]*";
+      }
+      continue;
+    }
+    regexStr += escapeRegexLiteral(char);
+  }
+  return new RegExp(`^${regexStr}$`);
+}
+
 async function loadAgentignore(root) {
   const ignorePath = path.join(root, ".agentignore");
   let stat = null;
@@ -68,14 +90,7 @@ async function loadAgentignore(root) {
   const patterns = raw
     .split(/\r?\n/)
     .filter((line) => line.trim() && !line.startsWith("#"))
-    .map((pattern) => {
-      const regexStr = pattern
-        .replace(/\./g, "\\.")
-        .replace(/\*\*/g, "{{GLOBSTAR}}")
-        .replace(/\*/g, "[^/]*")
-        .replace(/\{\{GLOBSTAR\}\}/g, ".*");
-      return new RegExp(`^${regexStr}$`);
-    });
+    .map((pattern) => compileAgentignorePattern(pattern));
   ignorePatternCache.set(root, { mtimeNs: stat.mtimeNs, size: stat.size, patterns });
   return patterns;
 }

--- a/test/fs.test.js
+++ b/test/fs.test.js
@@ -134,6 +134,22 @@ test("walkFiles treats unreadable .agentignore as an empty ignore list", async (
   assert.deepEqual(files, ["visible.js"]);
 });
 
+test("walkFiles treats .agentignore regex metacharacters as literal text", async () => {
+  resetIgnoreCache();
+
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-fs-metachar-"));
+  await fs.writeFile(path.join(root, ".agentignore"), "[abc\nliteral (draft)+?.js\n*.log\nsrc/**\n", "utf8");
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, "[abc"), "export const ignored = true;\n", "utf8");
+  await fs.writeFile(path.join(root, "literal (draft)+?.js"), "export const ignored = true;\n", "utf8");
+  await fs.writeFile(path.join(root, "debug.log"), "ignored\n", "utf8");
+  await fs.writeFile(path.join(root, "src", "hidden.js"), "export const ignored = true;\n", "utf8");
+  await fs.writeFile(path.join(root, "visible.js"), "export const visible = true;\n", "utf8");
+
+  const files = (await walkFiles(root, { respectIgnore: true })).map((file) => relative(root, file));
+  assert.deepEqual(files.sort(), [".agentignore", "visible.js"]);
+});
+
 test("walkFiles excludes Agentify runtime artifacts even when ignore rules are absent", async () => {
   resetIgnoreCache();
 

--- a/test/project-tests.test.js
+++ b/test/project-tests.test.js
@@ -101,6 +101,19 @@ test("detectTestCommand prefers pytest when tests directory is the only Python t
   });
 });
 
+test("detectTestCommand tolerates malformed .agentignore metacharacters during file discovery", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-test-agentignore-metachar-"));
+  await fs.writeFile(path.join(root, ".agentignore"), "[abc\n", "utf8");
+  await fs.writeFile(path.join(root, "example_test.py"), "def test_example():\n    assert True\n");
+
+  const result = await detectTestCommand(root);
+
+  assert.deepEqual(result, {
+    command: process.platform === "win32" ? "python" : "python3",
+    args: ["-m", "pytest"],
+  });
+});
+
 test("detectTestCommand uses Windows Gradle wrapper only when gradlew.bat exists", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-test-gradle-win-"));
   await fs.writeFile(path.join(root, "gradlew"), "");


### PR DESCRIPTION
## Summary
- escape regex metacharacters while compiling `.agentignore` patterns
- preserve existing `*` and `**` ignore matching behavior
- add direct `walkFiles` and downstream `detectTestCommand` regressions for malformed/literal metacharacters

## Tests
- `rtk node --test test/fs.test.js`
- `rtk node --test test/project-tests.test.js`
- `rtk npm test`

Closes #248