### PR TITLE
fix: reject unsafe config key paths

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -122,14 +122,38 @@ const DEFAULT_CONFIG = {
   },
 };
 
+const RESERVED_CONFIG_PATH_SEGMENTS = new Set(["__proto__", "prototype", "constructor"]);
+
+function assertSafeConfigPath(parts) {
+  const unsafe = parts.find((part) => RESERVED_CONFIG_PATH_SEGMENTS.has(part));
+  if (unsafe) {
+    throw new Error(`Unsafe config key "${unsafe}" is not allowed`);
+  }
+}
+
+function assertSafeConfigObject(value, pathParts = []) {
+  if (!value || typeof value !== "object") {
+    return;
+  }
+
+  for (const key of Object.keys(value)) {
+    const nextPath = [...pathParts, key];
+    assertSafeConfigPath(nextPath);
+    assertSafeConfigObject(value[key], nextPath);
+  }
+}
+
 function parseConfigFile(text) {
   const result = parseYaml(text);
-  return result && typeof result === "object" ? result : {};
+  const config = result && typeof result === "object" ? result : {};
+  assertSafeConfigObject(config);
+  return config;
 }
 
 function deepMerge(target, source) {
   const result = { ...target };
   for (const key of Object.keys(source)) {
+    assertSafeConfigPath([key]);
     if (
       source[key] &&
       typeof source[key] === "object" &&
@@ -173,6 +197,7 @@ function applyNestedFlags(config, flags) {
       .split(".")
       .filter(Boolean)
       .map((part) => part.replace(/-([a-z])/g, (_, char) => char.toUpperCase()));
+    assertSafeConfigPath(parts);
     setNested(result, parts, value);
   }
   return result;

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -30,6 +30,29 @@ test("loadConfig applies nested semantic flags", async () => {
   assert.equal(config.semantic.tsjs.workerConcurrency, 2);
 });
 
+test("loadConfig rejects prototype-polluting dotted flags", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-config-unsafe-flags-"));
+
+  try {
+    for (const [key, unsafeSegment] of [
+      ["__proto__.polluted", "__proto__"],
+      ["providerEnv.prototype.polluted", "prototype"],
+      ["providerEnv.constructor.prototype.polluted", "constructor"],
+    ]) {
+      await assert.rejects(
+        loadConfig(root, {
+          [key]: "flag-owned",
+        }),
+        new RegExp(`Unsafe config key "${unsafeSegment}" is not allowed`),
+      );
+    }
+
+    assert.equal({}.polluted, undefined);
+  } finally {
+    delete Object.prototype.polluted;
+  }
+});
+
 test("loadConfig keeps doctor --semantic from replacing semantic settings", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-config-doctor-semantic-"));
 
@@ -80,6 +103,27 @@ test("loadConfig provides provider env policy defaults", async () => {
     passthrough: [],
     extra: {},
   });
+});
+
+test("loadConfig rejects prototype-polluting file config keys", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-config-unsafe-yaml-"));
+  await fs.writeFile(
+    path.join(root, ".agentify.yaml"),
+    [
+      "providerEnv:",
+      "  __proto__:",
+      "    nestedPolluted: yaml-provider-env",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  await assert.rejects(
+    loadConfig(root),
+    /Unsafe config key "__proto__" is not allowed/,
+  );
+
+  assert.equal({}.nestedPolluted, undefined);
 });
 
 test("loadConfig provides context orchestration defaults", async () => {


### PR DESCRIPTION
## Summary
- Reject reserved prototype-related keys from parsed `.agentify.yaml` before merging
- Reject dotted CLI override paths containing `__proto__`, `prototype`, or `constructor`
- Add regression coverage for YAML and CLI prototype-pollution inputs

## Tests
- `npm test -- test/config.test.js`
- `npm test`

Closes #247