### PR TITLE
fix: guard stale lock release ownership

### DIFF
--- a/src/core/lock-file.js
+++ b/src/core/lock-file.js
@@ -1,0 +1,74 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import process from "node:process";
+
+export function createLockData(operation) {
+  return {
+    owner_id: randomUUID(),
+    pid: process.pid,
+    operation,
+    acquired_at: Date.now(),
+    host: os.hostname(),
+  };
+}
+
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+export function canReclaimLock(existing, staleMs) {
+  if (!existing || typeof existing.acquired_at !== "number") {
+    return false;
+  }
+
+  if (Date.now() - existing.acquired_at <= staleMs) {
+    return false;
+  }
+
+  return !(existing.host === os.hostname() && isProcessAlive(existing.pid));
+}
+
+function ownsLock(current, expected) {
+  if (!current || !expected) {
+    return false;
+  }
+
+  if (current.owner_id && expected.owner_id) {
+    return current.owner_id === expected.owner_id;
+  }
+
+  return current.pid === expected.pid
+    && current.operation === expected.operation
+    && current.acquired_at === expected.acquired_at
+    && current.host === expected.host;
+}
+
+export async function unlinkLockIfOwned(lockPath, expected) {
+  let current;
+  try {
+    current = JSON.parse(await fs.readFile(lockPath, "utf8"));
+  } catch {
+    return false;
+  }
+
+  if (!ownsLock(current, expected)) {
+    return false;
+  }
+
+  try {
+    await fs.unlink(lockPath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/core/lock.js
+++ b/src/core/lock.js
@@ -1,34 +1,9 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import process from "node:process";
+
+import { canReclaimLock, createLockData, unlinkLockIfOwned } from "./lock-file.js";
 
 const LOCK_STALE_MS = 300000;
-
-function isProcessAlive(pid) {
-  if (!Number.isInteger(pid) || pid <= 0) {
-    return false;
-  }
-
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return error?.code === "EPERM";
-  }
-}
-
-function canReclaimLock(existing) {
-  if (!existing || typeof existing.acquired_at !== "number") {
-    return false;
-  }
-
-  if (Date.now() - existing.acquired_at <= LOCK_STALE_MS) {
-    return false;
-  }
-
-  return !(existing.host === os.hostname() && isProcessAlive(existing.pid));
-}
 
 export async function acquireLock(root, operation) {
   const lockPath = path.join(root, ".agentify", ".lock");
@@ -39,25 +14,20 @@ export async function acquireLock(root, operation) {
     // directory may already exist
   }
 
-  const lockData = {
-    pid: process.pid,
-    operation,
-    acquired_at: Date.now(),
-    host: os.hostname(),
-  };
+  const lockData = createLockData(operation);
 
   try {
     const handle = await fs.open(lockPath, "wx");
     await handle.writeFile(JSON.stringify(lockData));
     await handle.close();
-    return { acquired: true, release: () => fs.unlink(lockPath).catch(() => {}) };
+    return { acquired: true, release: () => unlinkLockIfOwned(lockPath, lockData) };
   } catch (error) {
     if (error.code !== "EEXIST") throw error;
 
     try {
       const existing = JSON.parse(await fs.readFile(lockPath, "utf8"));
-      if (canReclaimLock(existing)) {
-        await fs.unlink(lockPath);
+      if (canReclaimLock(existing, LOCK_STALE_MS)) {
+        await unlinkLockIfOwned(lockPath, existing);
         return acquireLock(root, operation);
       }
       return {

--- a/src/core/session-memory.js
+++ b/src/core/session-memory.js
@@ -2,12 +2,12 @@ import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
 
 import { ensureDir, exists, readJson, relative, writeJson, writeText } from "./fs.js";
+import { canReclaimLock, createLockData, unlinkLockIfOwned } from "./lock-file.js";
 
 const execFileAsync = promisify(execFile);
 const SESSION_LOCK_STALE_MS = 300000;
@@ -963,31 +963,6 @@ export function getSessionArtifactPaths(root, sessionId) {
   };
 }
 
-function isProcessAlive(pid) {
-  if (!Number.isInteger(pid) || pid <= 0) {
-    return false;
-  }
-
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return error?.code === "EPERM";
-  }
-}
-
-function canReclaimSessionLock(existing) {
-  if (!existing || typeof existing.acquired_at !== "number") {
-    return false;
-  }
-
-  if (Date.now() - existing.acquired_at <= SESSION_LOCK_STALE_MS) {
-    return false;
-  }
-
-  return !(existing.host === os.hostname() && isProcessAlive(existing.pid));
-}
-
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -998,12 +973,7 @@ async function acquireSessionArtifactLock(paths, operation, options = {}) {
   const deadline = Date.now() + waitMs;
 
   for (;;) {
-    const lockData = {
-      pid: process.pid,
-      operation,
-      acquired_at: Date.now(),
-      host: os.hostname(),
-    };
+    const lockData = createLockData(operation);
 
     try {
       const handle = await fs.open(paths.lockPath, "wx");
@@ -1012,7 +982,7 @@ async function acquireSessionArtifactLock(paths, operation, options = {}) {
       } finally {
         await handle.close();
       }
-      return { release: () => fs.unlink(paths.lockPath).catch(() => {}) };
+      return { release: () => unlinkLockIfOwned(paths.lockPath, lockData) };
     } catch (error) {
       if (error.code !== "EEXIST") {
         throw error;
@@ -1033,12 +1003,8 @@ async function acquireSessionArtifactLock(paths, operation, options = {}) {
       continue;
     }
 
-    if (canReclaimSessionLock(existing)) {
-      await fs.unlink(paths.lockPath).catch((error) => {
-        if (error.code !== "ENOENT") {
-          throw error;
-        }
-      });
+    if (canReclaimLock(existing, SESSION_LOCK_STALE_MS)) {
+      await unlinkLockIfOwned(paths.lockPath, existing);
       continue;
     }
 

--- a/test/lock.test.js
+++ b/test/lock.test.js
@@ -50,3 +50,31 @@ test("acquireLock reclaims a stale lock when the recorded owner is gone", async 
   await result.release();
   await assert.rejects(() => fs.access(path.join(root, ".agentify", ".lock")));
 });
+
+test("acquireLock stale holder release does not remove a reclaimed successor lock", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-lock-stale-release-"));
+  await fs.mkdir(path.join(root, ".agentify"), { recursive: true });
+  const lockPath = path.join(root, ".agentify", ".lock");
+
+  const staleHolder = await acquireLock(root, "scan");
+  const stalePayload = JSON.parse(await fs.readFile(lockPath, "utf8"));
+  await fs.writeFile(
+    lockPath,
+    JSON.stringify({
+      ...stalePayload,
+      host: "stale-host-for-test",
+      acquired_at: Date.now() - 301000,
+    }),
+    "utf8",
+  );
+
+  const replacement = await acquireLock(root, "doc");
+  await staleHolder.release();
+
+  const current = JSON.parse(await fs.readFile(lockPath, "utf8"));
+  assert.equal(current.operation, "doc");
+  assert.notEqual(current.owner_id, stalePayload.owner_id);
+
+  await replacement.release();
+  await assert.rejects(() => fs.access(lockPath));
+});

--- a/test/session-structured.test.js
+++ b/test/session-structured.test.js
@@ -216,6 +216,35 @@ test("prepareSessionMemoryRun rejects a concurrent same-session run while the fi
   assert.match(context.rolling_summary, /first task/);
 });
 
+test("prepareSessionMemoryRun stale holder release does not remove a reclaimed successor lock", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-stale-release-"));
+  const sessionId = "sess_stale_release";
+  const config = { session: { emitMarkdownArtifacts: false } };
+  const paths = getSessionArtifactPaths(root, sessionId);
+
+  const stalePrepared = await prepareSessionMemoryRun(root, createSessionRecord(sessionId, "first task"), config);
+  const stalePayload = JSON.parse(await fs.readFile(paths.lockPath, "utf8"));
+  await fs.writeFile(
+    paths.lockPath,
+    JSON.stringify({
+      ...stalePayload,
+      host: "stale-host-for-test",
+      acquired_at: Date.now() - 301000,
+    }),
+    "utf8",
+  );
+
+  const replacementPrepared = await prepareSessionMemoryRun(root, createSessionRecord(sessionId, "second task"), config);
+  await stalePrepared.sessionArtifactLock.release();
+
+  const current = JSON.parse(await fs.readFile(paths.lockPath, "utf8"));
+  assert.equal(current.operation, "session-run");
+  assert.notEqual(current.owner_id, stalePayload.owner_id);
+
+  await replacementPrepared.sessionArtifactLock.release();
+  assert.equal(await fileExists(paths.lockPath), false);
+});
+
 test("forkSession inherits run_history and rolling_summary from parent", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-inherit-"));
   await fs.writeFile(path.join(root, "package.json"), "{}\n");


### PR DESCRIPTION
## Summary
- add shared lock ownership helpers with per-lock owner tokens
- guard shared and session artifact lock release/reclaim paths so stale holders cannot delete successor locks
- add regressions for shared .agentify/.lock and session artifact lock reclamation

## Validation
- node --test test/lock.test.js
- node --test test/session-structured.test.js
- node --test

Fixes #243