### PR TITLE
fix: reject symlinked artifact paths

### DIFF
--- a/src/core/cache.js
+++ b/src/core/cache.js
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { ensureDir, exists, readJson, writeJson } from "./fs.js";
+import { assertNoSymlinkPath, exists, readJson, readText, statFile, writeJson, writeText } from "./fs.js";
 
 function blobHash(content) {
   return crypto.createHash("sha256").update(content).digest("hex");
@@ -15,13 +15,12 @@ export async function storeBlob(cacheRoot, content) {
   const hash = blobHash(content);
   const target = blobPath(cacheRoot, hash);
   if (await exists(target)) return hash;
-  await ensureDir(path.dirname(target));
-  await fs.writeFile(target, content, "utf8");
+  await writeText(target, content);
   return hash;
 }
 
 export async function readBlob(cacheRoot, hash) {
-  return fs.readFile(blobPath(cacheRoot, hash), "utf8");
+  return readText(blobPath(cacheRoot, hash));
 }
 
 export async function updateManifest(cacheRoot, moduleId, blobRefs) {
@@ -59,11 +58,13 @@ export async function garbageCollect(cacheRoot, maxAgeDays = 7, options = {}) {
   let removed = 0;
   const blobsRoot = path.join(cacheRoot, "blobs");
   if (await exists(blobsRoot)) {
+    await assertNoSymlinkPath(blobsRoot);
     const prefixes = await fs.readdir(blobsRoot);
     for (const prefix of prefixes) {
       const prefixDir = path.join(blobsRoot, prefix);
       let files;
       try {
+        await assertNoSymlinkPath(prefixDir);
         files = await fs.readdir(prefixDir);
       } catch {
         continue;
@@ -99,11 +100,13 @@ export async function cacheStatus(cacheRoot) {
   let totalSize = 0;
   const blobsRoot = path.join(cacheRoot, "blobs");
   if (await exists(blobsRoot)) {
+    await assertNoSymlinkPath(blobsRoot);
     const prefixes = await fs.readdir(blobsRoot);
     for (const prefix of prefixes) {
       const prefixDir = path.join(blobsRoot, prefix);
       let files;
       try {
+        await assertNoSymlinkPath(prefixDir);
         files = await fs.readdir(prefixDir);
       } catch {
         continue;
@@ -111,7 +114,7 @@ export async function cacheStatus(cacheRoot) {
       for (const file of files) {
         blobCount += 1;
         try {
-          const stat = await fs.stat(path.join(prefixDir, file));
+          const stat = await statFile(path.join(prefixDir, file));
           totalSize += stat.size;
         } catch {
           // skip unreadable blobs

--- a/src/core/context-events.js
+++ b/src/core/context-events.js
@@ -1,7 +1,6 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 
-import { ensureDir, exists } from "./fs.js";
+import { appendText, exists, readText } from "./fs.js";
 import { checkSchema, SCHEMA_VERSIONS } from "./schema.js";
 
 const CONTEXT_RUNTIME_ID_PATTERN = /^[A-Za-z0-9_.-]+$/;
@@ -66,8 +65,7 @@ export async function appendContextEvent(root, event, options = {}) {
     sessionId: options.sessionId,
     runId: options.runId || record.run_id,
   });
-  await ensureDir(path.dirname(targetPath));
-  await fs.appendFile(targetPath, `${JSON.stringify(record)}\n`, "utf8");
+  await appendText(targetPath, `${JSON.stringify(record)}\n`);
   return { path: targetPath, record };
 }
 
@@ -77,7 +75,7 @@ export async function readContextEvents(root, options = {}) {
     return [];
   }
 
-  const raw = await fs.readFile(targetPath, "utf8");
+  const raw = await readText(targetPath);
   return raw
     .split(/\r?\n/)
     .map((line) => line.trim())

--- a/src/core/fs.js
+++ b/src/core/fs.js
@@ -32,6 +32,16 @@ const HARD_EXCLUDES = [
 ];
 
 const ignorePatternCache = new Map();
+const ARTIFACT_PATH_MARKERS = new Set([
+  ".agentify",
+  ".current_session",
+  "docs",
+  "AGENTIFY.md",
+  "agentify-report.html",
+  "output.txt",
+  ".agentignore",
+  ".guardrails",
+]);
 
 async function loadAgentignore(root) {
   const ignorePath = path.join(root, ".agentignore");
@@ -144,16 +154,91 @@ export async function exists(targetPath) {
   }
 }
 
+export async function assertNoSymlinkPath(targetPath) {
+  const resolved = path.resolve(targetPath);
+  const { root } = path.parse(resolved);
+  const parts = resolved.slice(root.length).split(path.sep).filter(Boolean);
+  let startIndex = await findRepoRelativeStartIndex(resolved, root, parts);
+  if (startIndex === -1) {
+    startIndex = parts.findIndex((part) => ARTIFACT_PATH_MARKERS.has(part));
+  }
+  if (startIndex === -1) {
+    return;
+  }
+
+  let current = path.join(root, ...parts.slice(0, startIndex));
+
+  for (const part of parts.slice(startIndex)) {
+    current = path.join(current, part);
+    let stat;
+    try {
+      stat = await fs.lstat(current);
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        return;
+      }
+      throw error;
+    }
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Refusing to follow symlinked artifact path: ${current}`);
+    }
+  }
+}
+
+async function findRepoRelativeStartIndex(resolved, root, parts) {
+  let current = resolved;
+  try {
+    const stat = await fs.lstat(current);
+    if (!stat.isDirectory()) {
+      current = path.dirname(current);
+    }
+  } catch {
+    current = path.dirname(current);
+  }
+
+  let startIndex = -1;
+  while (current && current !== root) {
+    if (await hasRepoBoundaryMarker(current)) {
+      const relativeToBoundary = path.relative(current, resolved);
+      if (!relativeToBoundary || relativeToBoundary.startsWith("..") || path.isAbsolute(relativeToBoundary)) {
+        return startIndex;
+      }
+      const boundaryParts = current.slice(root.length).split(path.sep).filter(Boolean);
+      startIndex = Math.min(parts.length, boundaryParts.length + 1);
+    }
+    current = path.dirname(current);
+  }
+
+  return startIndex;
+}
+
+async function hasRepoBoundaryMarker(directory) {
+  for (const marker of [".git", "package.json"]) {
+    try {
+      await fs.lstat(path.join(directory, marker));
+      return true;
+    } catch (error) {
+      if (error.code !== "ENOENT" && error.code !== "ENOTDIR") {
+        throw error;
+      }
+    }
+  }
+  return false;
+}
+
 export async function ensureDir(targetPath) {
+  await assertNoSymlinkPath(targetPath);
   await fs.mkdir(targetPath, { recursive: true });
 }
 
 export async function readJson(targetPath) {
+  await assertNoSymlinkPath(targetPath);
   return JSON.parse(await fs.readFile(targetPath, "utf8"));
 }
 
 export async function writeJson(targetPath, value) {
   await ensureDir(path.dirname(targetPath));
+  await assertNoSymlinkPath(targetPath);
   const tmp = `${targetPath}.${randomUUID().slice(0, 8)}.tmp`;
   const content = `${JSON.stringify(value, null, 2)}\n`;
   await fs.writeFile(tmp, content, "utf8");
@@ -210,11 +295,24 @@ export function relative(root, targetPath) {
 
 export async function writeText(targetPath, text) {
   await ensureDir(path.dirname(targetPath));
+  await assertNoSymlinkPath(targetPath);
   const tmp = `${targetPath}.${randomUUID().slice(0, 8)}.tmp`;
   await fs.writeFile(tmp, text, "utf8");
   await fs.rename(tmp, targetPath);
 }
 
+export async function appendText(targetPath, text) {
+  await ensureDir(path.dirname(targetPath));
+  await assertNoSymlinkPath(targetPath);
+  await fs.appendFile(targetPath, text, "utf8");
+}
+
 export async function readText(targetPath) {
+  await assertNoSymlinkPath(targetPath);
   return fs.readFile(targetPath, "utf8");
+}
+
+export async function statFile(targetPath) {
+  await assertNoSymlinkPath(targetPath);
+  return fs.stat(targetPath);
 }

--- a/src/core/session-memory.js
+++ b/src/core/session-memory.js
@@ -7,7 +7,7 @@ import path from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
 
-import { ensureDir, exists, readJson, relative, writeJson, writeText } from "./fs.js";
+import { appendText, assertNoSymlinkPath, ensureDir, exists, readJson, readText, relative, statFile, writeJson, writeText } from "./fs.js";
 
 const execFileAsync = promisify(execFile);
 const SESSION_LOCK_STALE_MS = 300000;
@@ -377,6 +377,7 @@ async function listSessionTranscripts(root) {
   if (!(await exists(sessionsDir))) {
     return [];
   }
+  await assertNoSymlinkPath(sessionsDir);
 
   const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
   const transcripts = [];
@@ -389,7 +390,7 @@ async function listSessionTranscripts(root) {
     if (!(await exists(transcriptPath))) {
       continue;
     }
-    const stat = await fs.stat(transcriptPath);
+    const stat = await statFile(transcriptPath);
     transcripts.push({
       sessionId: entry.name,
       transcriptPath,
@@ -407,6 +408,7 @@ async function listStructuredSessionTurns(root) {
   if (!(await exists(sessionsDir))) {
     return [];
   }
+  await assertNoSymlinkPath(sessionsDir);
 
   const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
   const results = [];
@@ -419,7 +421,7 @@ async function listStructuredSessionTurns(root) {
     if (!(await exists(turnsPath))) {
       continue;
     }
-    const stat = await fs.stat(turnsPath);
+    const stat = await statFile(turnsPath);
     results.push({
       sessionId: entry.name,
       turnsPath,
@@ -457,7 +459,7 @@ async function writeMemPalaceSessionExports(exportDir, transcripts) {
   await ensureDir(exportDir);
 
   for (const item of transcripts) {
-    const transcript = await fs.readFile(item.transcriptPath, "utf8");
+    const transcript = await readText(item.transcriptPath);
     const exportPath = path.join(exportDir, `${item.sessionId}.md`);
     await writeText(exportPath, [
       "# Agentify Transcript Export",
@@ -477,7 +479,7 @@ async function syncMemPalaceSessionExports(root, transcripts) {
   let cachedState = null;
   if (await exists(syncStatePath)) {
     try {
-      cachedState = JSON.parse(await fs.readFile(syncStatePath, "utf8"));
+      cachedState = JSON.parse(await readText(syncStatePath));
     } catch {
       cachedState = null;
     }
@@ -512,6 +514,7 @@ async function movePathIfExists(from, to) {
     return false;
   }
   await ensureDir(path.dirname(to));
+  await assertNoSymlinkPath(to);
   await fs.rename(from, to);
   return true;
 }
@@ -757,7 +760,7 @@ async function createTranscriptSearchBackend(root, query, config, sharedInventor
       const matches = [];
 
       for (const item of transcripts) {
-        const transcript = await fs.readFile(item.transcriptPath, "utf8");
+        const transcript = await readText(item.transcriptPath);
         const passages = buildPassages(parseTranscriptTurns(transcript));
         for (const passage of passages) {
           const score = scorePassage(query, tokens, passage);
@@ -883,7 +886,7 @@ async function createLineageBackend(root, manifest, config) {
         let turns = [];
         let sourcePath = null;
         if (await exists(transcriptPath)) {
-          const transcript = await fs.readFile(transcriptPath, "utf8");
+          const transcript = await readText(transcriptPath);
           turns = parseTranscriptTurns(transcript);
           sourcePath = transcriptPath;
         } else if (await exists(turnsPath)) {
@@ -1006,6 +1009,7 @@ async function acquireSessionArtifactLock(paths, operation, options = {}) {
     };
 
     try {
+      await assertNoSymlinkPath(paths.lockPath);
       const handle = await fs.open(paths.lockPath, "wx");
       try {
         await handle.writeFile(JSON.stringify(lockData));
@@ -1021,7 +1025,7 @@ async function acquireSessionArtifactLock(paths, operation, options = {}) {
 
     let existing = null;
     try {
-      existing = JSON.parse(await fs.readFile(paths.lockPath, "utf8"));
+      existing = JSON.parse(await readText(paths.lockPath));
     } catch (error) {
       if (error.code === "ENOENT") {
         continue;
@@ -1066,7 +1070,7 @@ async function safeFileBytes(filePath) {
     return 0;
   }
   try {
-    const stat = await fs.stat(filePath);
+    const stat = await statFile(filePath);
     return stat.isFile() ? stat.size : 0;
   } catch {
     return 0;
@@ -1115,7 +1119,7 @@ async function readJsonlTurns(targetPath) {
   if (!(await exists(targetPath))) {
     return [];
   }
-  const raw = await fs.readFile(targetPath, "utf8");
+  const raw = await readText(targetPath);
   const turns = [];
   for (const line of raw.split(/\r?\n/)) {
     const trimmed = line.trim();
@@ -1150,7 +1154,7 @@ async function readStructuredTurnsAsText(turnsPath) {
 
 async function appendTurnsRecord(turnsPath, record) {
   await ensureDir(path.dirname(turnsPath));
-  await fs.appendFile(turnsPath, `${JSON.stringify(redactSensitiveValue(record))}\n`, "utf8");
+  await appendText(turnsPath, `${JSON.stringify(redactSensitiveValue(record))}\n`);
 }
 
 function clampRunHistoryEntry(entry, summaryMaxBytes) {
@@ -1191,7 +1195,7 @@ async function readJsonLines(filePath) {
   if (!(await exists(filePath))) {
     return [];
   }
-  const raw = await fs.readFile(filePath, "utf8");
+  const raw = await readText(filePath);
   const rows = [];
   for (const line of raw.split(/\r?\n/)) {
     const trimmed = line.trim();
@@ -1395,7 +1399,7 @@ export async function prepareSessionMemoryRun(root, sessionRecord, config) {
         ""
       );
 
-      await fs.appendFile(paths.transcriptPath, `${transcriptLines.filter(Boolean).join("\n")}\n`, "utf8");
+      await appendText(paths.transcriptPath, `${transcriptLines.filter(Boolean).join("\n")}\n`);
     }
     return { startedAt, paths, emitMarkdown, sessionArtifactLock: lock };
   } catch (error) {
@@ -1468,7 +1472,7 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
         `Ended: ${endedAt}`,
         ""
       ].filter(Boolean).join("\n");
-      await fs.appendFile(prepared.paths.transcriptPath, transcriptTail, "utf8");
+      await appendText(prepared.paths.transcriptPath, transcriptTail);
     }
 
     const managedContext = await buildEstimatedManagedContext(root, sessionRecord, prepared.paths, config);
@@ -1501,7 +1505,7 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
       interactive_capture_error: outcome?.interactiveCaptureError || null,
       managed_context: managedContext,
     };
-    await fs.appendFile(prepared.paths.launchesPath, `${JSON.stringify(launchRecord)}\n`, "utf8");
+    await appendText(prepared.paths.launchesPath, `${JSON.stringify(launchRecord)}\n`);
 
     await appendRunSummaryUnlocked(root, sessionRecord.sessionId, {
       started_at: prepared.startedAt,

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { ensureDir, exists, readJson, writeJson, writeText } from "./fs.js";
+import { assertNoSymlinkPath, ensureDir, exists, readJson, readText, writeJson, writeText } from "./fs.js";
 import { getHeadCommit } from "./git.js";
 import { closeIndexDatabase, openIndexDatabase } from "./db/connection.js";
 import { loadModules } from "./db/structural-store.js";
@@ -427,6 +427,7 @@ export async function forkSession(root, config, options = {}) {
 export async function listSessions(root) {
   const sessionsDir = path.join(root, ".agentify", "session");
   if (!(await exists(sessionsDir))) return [];
+  await assertNoSymlinkPath(sessionsDir);
 
   const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
   const sessions = [];
@@ -457,7 +458,7 @@ export async function resumeSession(root, sessionId) {
   const context = await readJson(path.join(sessionDir, "context.json"));
   const bootstrapPath = path.join(sessionDir, "bootstrap.md");
   const bootstrap = (await exists(bootstrapPath))
-    ? await fs.readFile(bootstrapPath, "utf8")
+    ? await readText(bootstrapPath)
     : synthesizeBootstrapFromContext(manifest, context);
 
   return { manifest, context, bootstrap };
@@ -479,7 +480,7 @@ export async function maybePrepareChildSession(root, config, parentSessionId, op
     return null;
   }
 
-  const contextText = await fs.readFile(contextPath, "utf8");
+  const contextText = await readText(contextPath);
   const contextBytes = bytes(contextText);
   if (contextBytes <= thresholdKb * 1024) {
     return null;

--- a/test/fs.test.js
+++ b/test/fs.test.js
@@ -5,7 +5,17 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 
-import { resetIgnoreCache, walkFiles, relative } from "../src/core/fs.js";
+import {
+  appendText,
+  ensureDir,
+  readJson,
+  readText,
+  relative,
+  resetIgnoreCache,
+  walkFiles,
+  writeJson,
+  writeText,
+} from "../src/core/fs.js";
 
 async function runGit(root, args) {
   await new Promise((resolve, reject) => {
@@ -153,4 +163,69 @@ test("walkFiles excludes Agentify runtime artifacts even when ignore rules are a
   const files = (await walkFiles(root, { respectIgnore: true })).map((file) => relative(root, file)).sort();
 
   assert.deepEqual(files, ["src/index.js"]);
+});
+
+test("filesystem helpers reject symlinked artifact directories and files", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-fs-symlink-"));
+  const outside = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-fs-outside-"));
+
+  await fs.symlink(outside, path.join(root, "docs"), "dir");
+  await assert.rejects(
+    ensureDir(path.join(root, "docs", "modules")),
+    /Refusing to follow symlinked artifact path: .*docs/,
+  );
+  await assert.rejects(
+    writeText(path.join(root, "docs", "repo-map.md"), "# Repo Map\n"),
+    /Refusing to follow symlinked artifact path: .*docs/,
+  );
+  await assert.rejects(
+    writeJson(path.join(root, "docs", "repo-map.json"), { ok: true }),
+    /Refusing to follow symlinked artifact path: .*docs/,
+  );
+  assert.equal(await fs.access(path.join(outside, "repo-map.md")).then(() => true, () => false), false);
+
+  await fs.rm(path.join(root, "docs"), { force: true });
+  await fs.mkdir(path.join(root, ".agentify", "session", "sess_safe"), { recursive: true });
+  await fs.writeFile(path.join(outside, "transcript.md"), "outside secret\n", "utf8");
+  await fs.symlink(
+    path.join(outside, "transcript.md"),
+    path.join(root, ".agentify", "session", "sess_safe", "transcript.md"),
+  );
+  await assert.rejects(
+    readText(path.join(root, ".agentify", "session", "sess_safe", "transcript.md")),
+    /Refusing to follow symlinked artifact path: .*transcript\.md/,
+  );
+  await assert.rejects(
+    appendText(path.join(root, ".agentify", "session", "sess_safe", "transcript.md"), "new\n"),
+    /Refusing to follow symlinked artifact path: .*transcript\.md/,
+  );
+  assert.equal(await fs.readFile(path.join(outside, "transcript.md"), "utf8"), "outside secret\n");
+
+  await fs.writeFile(path.join(outside, "context.json"), "{\"secret\":true}\n", "utf8");
+  await fs.symlink(
+    path.join(outside, "context.json"),
+    path.join(root, ".agentify", "session", "sess_safe", "context.json"),
+  );
+  await assert.rejects(
+    readJson(path.join(root, ".agentify", "session", "sess_safe", "context.json")),
+    /Refusing to follow symlinked artifact path: .*context\.json/,
+  );
+
+  await fs.writeFile(path.join(outside, "AGENTIFY.md"), "outside guide\n", "utf8");
+  await fs.symlink(path.join(outside, "AGENTIFY.md"), path.join(root, "AGENTIFY.md"));
+  await assert.rejects(
+    writeText(path.join(root, "AGENTIFY.md"), "# AGENTIFY.md\n"),
+    /Refusing to follow symlinked artifact path: .*AGENTIFY\.md/,
+  );
+  assert.equal(await fs.readFile(path.join(outside, "AGENTIFY.md"), "utf8"), "outside guide\n");
+
+  await fs.rm(path.join(root, "AGENTIFY.md"), { force: true });
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(root, "packages"), { recursive: true });
+  await fs.mkdir(path.join(outside, "module"), { recursive: true });
+  await fs.symlink(path.join(outside, "module"), path.join(root, "packages", "app"), "dir");
+  await assert.rejects(
+    writeText(path.join(root, "packages", "app", "AGENTIFY.md"), "# Module\n"),
+    /Refusing to follow symlinked artifact path: .*app/,
+  );
 });

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -281,6 +281,33 @@ test("loadAutomaticSessionMemory searches older sessions when the direct parent 
   }
 });
 
+test("loadAutomaticRunMemory rejects symlinked session transcripts", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-symlink-transcript-"));
+  const outside = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-outside-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex" });
+  const session = await forkSession(root, config, { name: "symlinked-transcript" });
+  const paths = getSessionArtifactPaths(root, session.sessionId);
+  await fs.writeFile(path.join(outside, "transcript.md"), [
+    "# Agentify Session Run",
+    "",
+    "> Current task",
+    "outside",
+    "",
+    "> Provider response",
+    "outside secret",
+    "",
+  ].join("\n"), "utf8");
+  await fs.symlink(path.join(outside, "transcript.md"), paths.transcriptPath);
+
+  await assert.rejects(
+    loadAutomaticRunMemory(root, "outside secret", config),
+    /Refusing to follow symlinked artifact path: .*transcript\.md/,
+  );
+});
+
 test("loadAutomaticRunMemory uses MemPalace automatically when the CLI is available", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-run-memory-"));
   await fs.writeFile(path.join(root, "package.json"), "{}\n");


### PR DESCRIPTION
## Summary
- Add centralized symlink rejection for repo/artifact paths before guarded reads, writes, appends, mkdirs, stats, and renames.
- Route session memory, context events, and cache artifact access through the guarded helpers.
- Cover symlinked docs, AGENTIFY.md, session transcript/context, and automatic memory recall regressions.

## Validation
- npm test -- test/fs.test.js test/session.test.js test/context-events.test.js
- npm test

Closes #244