### PR TITLE
fix: restrict runtime artifact permissions

### DIFF
--- a/src/core/afk.js
+++ b/src/core/afk.js
@@ -4,7 +4,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import YAML from "yaml";
 
-import { ensureDir, exists, readText, relative, writeText } from "./fs.js";
+import { ensureDir, ensurePrivateDir, exists, readText, relative, writePrivateText, writeText } from "./fs.js";
 import { getChangedFiles } from "./git.js";
 import { runProjectTests } from "./project-tests.js";
 import { buildProviderTemplateCommand } from "./provider-command.js";
@@ -411,7 +411,7 @@ export async function runAfkCreate(root, config, args) {
   });
   const sessionId = buildSessionId(slug);
   const capturePath = path.join(root, ".agentify", "session", sessionId, "interactive.log");
-  await ensureDir(path.dirname(capturePath));
+  await ensurePrivateDir(path.dirname(capturePath));
 
   const result = await runExec(root, config, agentCommand, {
     commandName: "afk-create",
@@ -441,7 +441,7 @@ export async function runAfkCreate(root, config, args) {
   const runCommand = `agentify afk run ${relative(root, planPath)}`;
   const savedPlanMarkdown = appendAfkExecutionHandoff(plan.markdown, runCommand);
   await writeText(planPath, `${savedPlanMarkdown}\n`);
-  await writeText(path.join(root, ".agentify", "session", sessionId, "afk-create.json"), `${JSON.stringify({
+  await writePrivateText(path.join(root, ".agentify", "session", sessionId, "afk-create.json"), `${JSON.stringify({
     schema_version: "1.0",
     type: "agentify-afk-create",
     session_id: sessionId,

--- a/src/core/commands.js
+++ b/src/core/commands.js
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 
-import { ensureDir, exists, writeJson, writeText } from "./fs.js";
+import { ensureDir, ensurePrivateDir, exists, writeJson, writePrivateJson, writeText } from "./fs.js";
 import { getHeadCommit } from "./git.js";
 import { stripLeadingAgentifyHeader, updateFileHeader } from "./headers.js";
 import { ensureAgentifyGitignore } from "./gitignore.js";
@@ -156,7 +156,7 @@ ${index.modules.map(moduleLink).join("\n")}
 
 async function writeRunReport(root, report) {
   const runPath = path.join(root, ".agentify", "runs", `${report.run_id}.json`);
-  await writeJson(runPath, report);
+  await writePrivateJson(runPath, report);
   return runPath;
 }
 
@@ -228,7 +228,7 @@ export async function ensureBaselineArtifacts(root, config) {
     return;
   }
   await ensureDir(path.join(root, ".agentify"));
-  await ensureDir(path.join(root, ".agentify", "runs"));
+  await ensurePrivateDir(path.join(root, ".agentify", "runs"));
   await ensureDir(path.join(root, ".agentify", "work"));
   await ensureDir(path.join(root, "docs", "modules"));
   await writeTextIfMissing(path.join(root, ".agentignore"), renderDefaultAgentignore());

--- a/src/core/context-events.js
+++ b/src/core/context-events.js
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-import { ensureDir, exists } from "./fs.js";
+import { appendPrivateText, ensureDir, exists } from "./fs.js";
 import { checkSchema, SCHEMA_VERSIONS } from "./schema.js";
 
 const CONTEXT_RUNTIME_ID_PATTERN = /^[A-Za-z0-9_.-]+$/;
@@ -66,8 +66,12 @@ export async function appendContextEvent(root, event, options = {}) {
     sessionId: options.sessionId,
     runId: options.runId || record.run_id,
   });
-  await ensureDir(path.dirname(targetPath));
-  await fs.appendFile(targetPath, `${JSON.stringify(record)}\n`, "utf8");
+  if (options.sessionId) {
+    await appendPrivateText(targetPath, `${JSON.stringify(record)}\n`);
+  } else {
+    await ensureDir(path.dirname(targetPath));
+    await fs.appendFile(targetPath, `${JSON.stringify(record)}\n`, "utf8");
+  }
   return { path: targetPath, record };
 }
 

--- a/src/core/fs.js
+++ b/src/core/fs.js
@@ -3,6 +3,9 @@ import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 
+export const PRIVATE_DIR_MODE = 0o700;
+export const PRIVATE_FILE_MODE = 0o600;
+
 const SKIP_DIRS = new Set([
   ".git",
   "node_modules",
@@ -148,16 +151,38 @@ export async function ensureDir(targetPath) {
   await fs.mkdir(targetPath, { recursive: true });
 }
 
+export async function ensurePrivateDir(targetPath) {
+  await fs.mkdir(targetPath, { recursive: true, mode: PRIVATE_DIR_MODE });
+  await fs.chmod(targetPath, PRIVATE_DIR_MODE);
+}
+
 export async function readJson(targetPath) {
   return JSON.parse(await fs.readFile(targetPath, "utf8"));
 }
 
-export async function writeJson(targetPath, value) {
-  await ensureDir(path.dirname(targetPath));
+async function atomicWriteText(targetPath, text, options = {}) {
+  const ensureParent = options.private && options.privateDir !== false ? ensurePrivateDir : ensureDir;
+  await ensureParent(path.dirname(targetPath));
   const tmp = `${targetPath}.${randomUUID().slice(0, 8)}.tmp`;
-  const content = `${JSON.stringify(value, null, 2)}\n`;
-  await fs.writeFile(tmp, content, "utf8");
+  const writeOptions = options.private
+    ? { encoding: "utf8", mode: PRIVATE_FILE_MODE }
+    : "utf8";
+  await fs.writeFile(tmp, text, writeOptions);
+  if (options.private) {
+    await fs.chmod(tmp, PRIVATE_FILE_MODE);
+  }
   await fs.rename(tmp, targetPath);
+  if (options.private) {
+    await fs.chmod(targetPath, PRIVATE_FILE_MODE);
+  }
+}
+
+export async function writeJson(targetPath, value) {
+  await atomicWriteText(targetPath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export async function writePrivateJson(targetPath, value) {
+  await atomicWriteText(targetPath, `${JSON.stringify(value, null, 2)}\n`, { private: true });
 }
 
 export async function walkFiles(root, { respectIgnore = false } = {}) {
@@ -209,10 +234,24 @@ export function relative(root, targetPath) {
 }
 
 export async function writeText(targetPath, text) {
-  await ensureDir(path.dirname(targetPath));
-  const tmp = `${targetPath}.${randomUUID().slice(0, 8)}.tmp`;
-  await fs.writeFile(tmp, text, "utf8");
-  await fs.rename(tmp, targetPath);
+  await atomicWriteText(targetPath, text);
+}
+
+export async function writePrivateText(targetPath, text, options = {}) {
+  await atomicWriteText(targetPath, text, { private: true, ...options });
+}
+
+export async function appendPrivateText(targetPath, text) {
+  await ensurePrivateDir(path.dirname(targetPath));
+  try {
+    await fs.chmod(targetPath, PRIVATE_FILE_MODE);
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+  await fs.appendFile(targetPath, text, { encoding: "utf8", mode: PRIVATE_FILE_MODE });
+  await fs.chmod(targetPath, PRIVATE_FILE_MODE);
 }
 
 export async function readText(targetPath) {

--- a/src/core/handoff.js
+++ b/src/core/handoff.js
@@ -4,7 +4,7 @@ import path from "node:path";
 import { buildExecutionPlan } from "./planner.js";
 import { closeIndexDatabase, openIndexDatabase } from "./db/connection.js";
 import { loadSymbols } from "./db/structural-store.js";
-import { ensureDir, exists, readJson, relative, writeJson, writeText } from "./fs.js";
+import { ensurePrivateDir, exists, readJson, relative, writePrivateJson, writePrivateText } from "./fs.js";
 import { getChangedFiles, getChangedFilesSince, getHeadCommit } from "./git.js";
 import { getSessionArtifactPaths } from "./session-memory.js";
 import { listSessions, resumeSession } from "./session.js";
@@ -375,9 +375,9 @@ export async function buildHandoffBundle(root, config, sessionId, task = "") {
 export async function writeHandoffBundle(root, config, sessionId, task = "") {
   const paths = getSessionArtifactPaths(root, sessionId);
   const bundle = await buildHandoffBundle(root, config, sessionId, task);
-  await ensureDir(paths.sessionDir);
-  await writeJson(paths.handoffJsonPath, bundle);
-  await writeText(paths.handoffMarkdownPath, renderHandoffMarkdown(bundle));
+  await ensurePrivateDir(paths.sessionDir);
+  await writePrivateJson(paths.handoffJsonPath, bundle);
+  await writePrivateText(paths.handoffMarkdownPath, renderHandoffMarkdown(bundle));
   return {
     bundle,
     jsonPath: paths.handoffJsonPath,

--- a/src/core/run-report.js
+++ b/src/core/run-report.js
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import { writeJson, writeText } from "./fs.js";
+import { writePrivateJson, writePrivateText } from "./fs.js";
 import { redactSensitiveText } from "./session-memory.js";
 import * as ui from "./ui.js";
 
@@ -1269,10 +1269,10 @@ export function createRunReporter(root) {
       let telemetryJsonPath = null;
       if (summary.execution) {
         telemetryJsonPath = path.join(root, ".agentify", "runs", `${summary.execution.run_id}-execution-telemetry.json`);
-        await writeJson(telemetryJsonPath, summary.execution);
+        await writePrivateJson(telemetryJsonPath, summary.execution);
       }
-      await writeText(outputPath, events.join(""));
-      await writeText(htmlPath, renderHtmlReport(summary));
+      await writePrivateText(outputPath, events.join(""), { privateDir: false });
+      await writePrivateText(htmlPath, renderHtmlReport(summary), { privateDir: false });
 
       loader.clear();
       ui.box("Run Complete", [

--- a/src/core/session-memory.js
+++ b/src/core/session-memory.js
@@ -7,7 +7,18 @@ import path from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
 
-import { ensureDir, exists, readJson, relative, writeJson, writeText } from "./fs.js";
+import {
+  appendPrivateText,
+  ensureDir,
+  ensurePrivateDir,
+  exists,
+  PRIVATE_FILE_MODE,
+  readJson,
+  relative,
+  writePrivateJson,
+  writePrivateText,
+  writeText,
+} from "./fs.js";
 
 const execFileAsync = promisify(execFile);
 const SESSION_LOCK_STALE_MS = 300000;
@@ -993,7 +1004,7 @@ function sleep(ms) {
 }
 
 async function acquireSessionArtifactLock(paths, operation, options = {}) {
-  await ensureDir(paths.sessionDir);
+  await ensurePrivateDir(paths.sessionDir);
   const waitMs = Math.max(0, Number(options.waitMs) || 0);
   const deadline = Date.now() + waitMs;
 
@@ -1006,7 +1017,7 @@ async function acquireSessionArtifactLock(paths, operation, options = {}) {
     };
 
     try {
-      const handle = await fs.open(paths.lockPath, "wx");
+      const handle = await fs.open(paths.lockPath, "wx", PRIVATE_FILE_MODE);
       try {
         await handle.writeFile(JSON.stringify(lockData));
       } finally {
@@ -1149,8 +1160,7 @@ async function readStructuredTurnsAsText(turnsPath) {
 }
 
 async function appendTurnsRecord(turnsPath, record) {
-  await ensureDir(path.dirname(turnsPath));
-  await fs.appendFile(turnsPath, `${JSON.stringify(redactSensitiveValue(record))}\n`, "utf8");
+  await appendPrivateText(turnsPath, `${JSON.stringify(redactSensitiveValue(record))}\n`);
 }
 
 function clampRunHistoryEntry(entry, summaryMaxBytes) {
@@ -1264,10 +1274,10 @@ async function compactSessionContextUnlocked(root, sessionId, config = {}, paths
   };
 
   context.context_facts = facts;
-  await writeJson(paths.contextPath, context);
-  await writeJson(paths.contextFactsPath, facts);
+  await writePrivateJson(paths.contextPath, context);
+  await writePrivateJson(paths.contextFactsPath, facts);
   if (config?.session?.emitMarkdownArtifacts !== false) {
-    await writeText(paths.contextFactsMarkdownPath, renderContextFactsMarkdown(facts));
+    await writePrivateText(paths.contextFactsMarkdownPath, renderContextFactsMarkdown(facts));
   }
   return {
     session_id: sessionId,
@@ -1299,7 +1309,7 @@ async function appendRunSummaryUnlocked(root, sessionId, entry, config, paths = 
   const next = [...previous, clampRunHistoryEntry(entry, summaryBytes)].slice(-historyLimit);
   context.run_history = next;
   context.rolling_summary = clipToBytes(buildRollingSummary(next), Math.max(summaryBytes * 2, 512));
-  await writeJson(paths.contextPath, context);
+  await writePrivateJson(paths.contextPath, context);
   return { run_history: next, rolling_summary: context.rolling_summary };
 }
 
@@ -1341,7 +1351,7 @@ export async function prepareSessionMemoryRun(root, sessionRecord, config) {
   const startedAt = new Date().toISOString();
   const paths = getSessionArtifactPaths(root, sessionRecord.sessionId);
   const lock = await acquireSessionArtifactLock(paths, "session-run");
-  await ensureDir(paths.sessionDir);
+  await ensurePrivateDir(paths.sessionDir);
   const emitMarkdown = config?.session?.emitMarkdownArtifacts !== false;
 
   try {
@@ -1368,7 +1378,7 @@ export async function prepareSessionMemoryRun(root, sessionRecord, config) {
 
     if (emitMarkdown) {
       const memoryMarkdown = redactSensitiveText(sessionRecord.memoryContext?.markdown || buildNoMemoryMarkdown());
-      await writeText(paths.memoryContextPath, `${memoryMarkdown.trim()}\n`);
+      await writePrivateText(paths.memoryContextPath, `${memoryMarkdown.trim()}\n`);
 
       const transcriptLines = [];
       if (await exists(paths.transcriptPath)) {
@@ -1395,7 +1405,7 @@ export async function prepareSessionMemoryRun(root, sessionRecord, config) {
         ""
       );
 
-      await fs.appendFile(paths.transcriptPath, `${transcriptLines.filter(Boolean).join("\n")}\n`, "utf8");
+      await appendPrivateText(paths.transcriptPath, `${transcriptLines.filter(Boolean).join("\n")}\n`);
     }
     return { startedAt, paths, emitMarkdown, sessionArtifactLock: lock };
   } catch (error) {
@@ -1468,7 +1478,7 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
         `Ended: ${endedAt}`,
         ""
       ].filter(Boolean).join("\n");
-      await fs.appendFile(prepared.paths.transcriptPath, transcriptTail, "utf8");
+      await appendPrivateText(prepared.paths.transcriptPath, transcriptTail);
     }
 
     const managedContext = await buildEstimatedManagedContext(root, sessionRecord, prepared.paths, config);
@@ -1501,7 +1511,7 @@ export async function finalizeSessionMemoryRun(root, sessionRecord, prepared, ou
       interactive_capture_error: outcome?.interactiveCaptureError || null,
       managed_context: managedContext,
     };
-    await fs.appendFile(prepared.paths.launchesPath, `${JSON.stringify(launchRecord)}\n`, "utf8");
+    await appendPrivateText(prepared.paths.launchesPath, `${JSON.stringify(launchRecord)}\n`);
 
     await appendRunSummaryUnlocked(root, sessionRecord.sessionId, {
       started_at: prepared.startedAt,

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { ensureDir, exists, readJson, writeJson, writeText } from "./fs.js";
+import { ensurePrivateDir, exists, readJson, writePrivateJson, writePrivateText } from "./fs.js";
 import { getHeadCommit } from "./git.js";
 import { closeIndexDatabase, openIndexDatabase } from "./db/connection.js";
 import { loadModules } from "./db/structural-store.js";
@@ -301,7 +301,7 @@ ${clipToBytes(baseStartHere, attempt.startHereBytes) || "- Inspect the session c
 export async function forkSession(root, config, options = {}) {
   const sessionId = generateSessionId();
   const sessionDir = path.join(root, ".agentify", "session", sessionId);
-  await ensureDir(sessionDir);
+  await ensurePrivateDir(sessionDir);
 
   const headCommit = await getHeadCommit(root);
   let index = null;
@@ -414,11 +414,11 @@ export async function forkSession(root, config, options = {}) {
   manifest.metadata.context_truncated = contextResult.truncated;
   manifest.metadata.bootstrap_truncated = bootstrapResult.truncated;
 
-  await writeJson(path.join(sessionDir, "session-manifest.json"), manifest);
-  await writeJson(path.join(sessionDir, "checklist.json"), parentChecklist);
-  await writeJson(path.join(sessionDir, "context.json"), context);
+  await writePrivateJson(path.join(sessionDir, "session-manifest.json"), manifest);
+  await writePrivateJson(path.join(sessionDir, "checklist.json"), parentChecklist);
+  await writePrivateJson(path.join(sessionDir, "context.json"), context);
   if (emitMarkdown) {
-    await writeText(path.join(sessionDir, "bootstrap.md"), bootstrap);
+    await writePrivateText(path.join(sessionDir, "bootstrap.md"), bootstrap);
   }
 
   return { sessionId, sessionDir, manifest, context, bootstrap };
@@ -499,7 +499,7 @@ export async function maybePrepareChildSession(root, config, parentSessionId, op
     threshold_bytes: thresholdKb * 1024,
     resume_command: `agentify sess resume --session ${child.sessionId}`,
   };
-  await writeJson(parentManifestPath, parentManifest);
+  await writePrivateJson(parentManifestPath, parentManifest);
 
   return {
     parent_session_id: parentSessionId,

--- a/test/context-events.test.js
+++ b/test/context-events.test.js
@@ -13,6 +13,17 @@ import {
 } from "../src/core/context-events.js";
 import { SCHEMA_VERSIONS } from "../src/core/schema.js";
 
+async function modeOf(targetPath) {
+  return (await fs.stat(targetPath)).mode & 0o777;
+}
+
+function withUmask(t, mask) {
+  const previous = process.umask(mask);
+  t.after(() => {
+    process.umask(previous);
+  });
+}
+
 test("createContextEventRecord normalizes the context event schema", () => {
   const record = createContextEventRecord({
     runId: "run_1",
@@ -45,7 +56,10 @@ test("context event schema rejects incompatible major versions", () => {
   assert.match(result.reason, /Major version mismatch/);
 });
 
-test("appendContextEvent persists session events under ignored session artifacts", async () => {
+test("appendContextEvent persists session events under ignored session artifacts", async (t) => {
+  if (process.platform !== "win32") {
+    withUmask(t, 0o000);
+  }
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-context-events-session-"));
 
   const result = await appendContextEvent(root, {
@@ -69,6 +83,10 @@ test("appendContextEvent persists session events under ignored session artifacts
   assert.equal(events.length, 1);
   assert.equal(events[0].event_type, "compact");
   assert.equal(events[0].run_id, "run_2");
+  if (process.platform !== "win32") {
+    assert.equal(await modeOf(path.dirname(result.path)), 0o700);
+    assert.equal(await modeOf(result.path), 0o600);
+  }
 });
 
 test("appendContextEvent persists run events under ignored Agentify work artifacts", async () => {

--- a/test/fs.test.js
+++ b/test/fs.test.js
@@ -5,7 +5,17 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 
-import { resetIgnoreCache, walkFiles, relative } from "../src/core/fs.js";
+import {
+  appendPrivateText,
+  ensurePrivateDir,
+  PRIVATE_DIR_MODE,
+  PRIVATE_FILE_MODE,
+  resetIgnoreCache,
+  walkFiles,
+  relative,
+  writePrivateJson,
+  writePrivateText,
+} from "../src/core/fs.js";
 
 async function runGit(root, args) {
   await new Promise((resolve, reject) => {
@@ -22,6 +32,40 @@ async function runGit(root, args) {
     });
   });
 }
+
+async function modeOf(targetPath) {
+  return (await fs.stat(targetPath)).mode & 0o777;
+}
+
+function withUmask(t, mask) {
+  const previous = process.umask(mask);
+  t.after(() => {
+    process.umask(previous);
+  });
+}
+
+test("private fs helpers create restrictive directories and files independent of umask", async (t) => {
+  if (process.platform === "win32") {
+    return;
+  }
+  withUmask(t, 0o000);
+
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-fs-private-"));
+  const dir = path.join(root, ".agentify", "session", "sess_private");
+  const jsonPath = path.join(dir, "context.json");
+  const textPath = path.join(dir, "transcript.md");
+  const appendPath = path.join(dir, "turns.jsonl");
+
+  await ensurePrivateDir(dir);
+  await writePrivateJson(jsonPath, { ok: true });
+  await writePrivateText(textPath, "secret\n");
+  await appendPrivateText(appendPath, "{\"ok\":true}\n");
+
+  assert.equal(await modeOf(dir), PRIVATE_DIR_MODE);
+  assert.equal(await modeOf(jsonPath), PRIVATE_FILE_MODE);
+  assert.equal(await modeOf(textPath), PRIVATE_FILE_MODE);
+  assert.equal(await modeOf(appendPath), PRIVATE_FILE_MODE);
+});
 
 test("walkFiles respects hard excludes and does not leak ignore cache across roots", async () => {
   resetIgnoreCache();

--- a/test/run-report.test.js
+++ b/test/run-report.test.js
@@ -7,7 +7,21 @@ import path from "node:path";
 import { createRunReporter } from "../src/core/run-report.js";
 import { setSilent } from "../src/core/ui.js";
 
+async function modeOf(targetPath) {
+  return (await fs.stat(targetPath)).mode & 0o777;
+}
+
+function withUmask(t, mask) {
+  const previous = process.umask(mask);
+  t.after(() => {
+    process.umask(previous);
+  });
+}
+
 test("createRunReporter persists output and HTML report", async (t) => {
+  if (process.platform !== "win32") {
+    withUmask(t, 0o000);
+  }
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-run-report-"));
   const sentinelPrompt = "AGENTIFY_SENTINEL_PROMPT_SHOULD_NOT_PERSIST";
   const previousSilent = false;
@@ -107,6 +121,12 @@ test("createRunReporter persists output and HTML report", async (t) => {
   assert.doesNotMatch(telemetryJson, new RegExp(sentinelPrompt));
   assert.equal(telemetry.capture.transcript_available, true);
   assert.deepEqual(telemetry.changed_paths, ["src/core/exec.js", "src/core/run-report.js"]);
+  if (process.platform !== "win32") {
+    assert.equal(await modeOf(path.join(root, "output.txt")), 0o600);
+    assert.equal(await modeOf(path.join(root, "agentify-report.html")), 0o600);
+    assert.equal(await modeOf(path.join(root, ".agentify", "runs")), 0o700);
+    assert.equal(await modeOf(path.join(root, ".agentify", "runs", "test-execution-execution-telemetry.json")), 0o600);
+  }
 });
 
 test("createRunReporter shows test output truncation metadata in HTML", async (t) => {

--- a/test/session-structured.test.js
+++ b/test/session-structured.test.js
@@ -58,6 +58,17 @@ function createSessionRecord(sessionId, task) {
   };
 }
 
+async function modeOf(targetPath) {
+  return (await fs.stat(targetPath)).mode & 0o777;
+}
+
+function withUmask(t, mask) {
+  const previous = process.umask(mask);
+  t.after(() => {
+    process.umask(previous);
+  });
+}
+
 test("forkSession initializes structured run_history and rolling_summary in context.json", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-structured-"));
   await fs.writeFile(path.join(root, "package.json"), "{}\n");
@@ -73,6 +84,44 @@ test("forkSession initializes structured run_history and rolling_summary in cont
   assert.ok(result.manifest.cache_refs.some((item) => item.endsWith("context-events.jsonl")));
   assert.ok(result.manifest.metadata.runtime_artifacts.includes("context-events.jsonl"));
   assert.ok(result.manifest.metadata.optional_markdown_artifacts.includes("bootstrap.md"));
+});
+
+test("session memory run artifacts use restrictive permissions", async (t) => {
+  if (process.platform === "win32") {
+    return;
+  }
+  withUmask(t, 0o000);
+
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-memory-perms-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex" });
+  const created = await forkSession(root, config, { name: "memory-perms" });
+  const record = createSessionRecord(created.sessionId, "permission-sensitive task");
+  const prepared = await prepareSessionMemoryRun(root, record, config);
+
+  await finalizeSessionMemoryRun(root, record, prepared, {
+    phase: "complete",
+    exitCode: 0,
+    stdout: "done",
+    stderr: "",
+    validation: { passed: true },
+  }, config);
+
+  const paths = getSessionArtifactPaths(root, created.sessionId);
+  assert.equal(await modeOf(paths.sessionDir), 0o700);
+  for (const artifactPath of [
+    paths.turnsPath,
+    paths.transcriptPath,
+    paths.memoryContextPath,
+    paths.launchesPath,
+    paths.contextPath,
+    paths.contextFactsPath,
+    paths.contextFactsMarkdownPath,
+  ]) {
+    assert.equal(await modeOf(artifactPath), 0o600, path.basename(artifactPath));
+  }
 });
 
 test("resumeSession synthesizes bootstrap from context when markdown artifacts are disabled", async () => {

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -61,6 +61,17 @@ exit 1
   return scriptPath;
 }
 
+async function modeOf(targetPath) {
+  return (await fs.stat(targetPath)).mode & 0o777;
+}
+
+function withUmask(t, mask) {
+  const previous = process.umask(mask);
+  t.after(() => {
+    process.umask(previous);
+  });
+}
+
 test("forkSession writes provider in manifest and bootstrap", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-"));
   await fs.writeFile(path.join(root, "package.json"), "{}\n");
@@ -72,6 +83,25 @@ test("forkSession writes provider in manifest and bootstrap", async () => {
 
   assert.equal(result.manifest.provider, "codex");
   assert.match(resumed.bootstrap, /Provider: codex/);
+});
+
+test("forkSession writes session artifacts with restrictive permissions", async (t) => {
+  if (process.platform === "win32") {
+    return;
+  }
+  withUmask(t, 0o000);
+
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-session-perms-"));
+  await fs.writeFile(path.join(root, "package.json"), "{}\n");
+  await initGitRepo(root);
+
+  const config = await loadConfig(root, { provider: "codex" });
+  const created = await forkSession(root, config, { name: "permissions" });
+
+  assert.equal(await modeOf(created.sessionDir), 0o700);
+  for (const artifact of ["session-manifest.json", "checklist.json", "context.json", "bootstrap.md"]) {
+    assert.equal(await modeOf(path.join(created.sessionDir, artifact)), 0o600, artifact);
+  }
 });
 
 test("resolveSessionProvider supports legacy tool manifests", () => {

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -62,7 +62,21 @@ async function readLatestRunReport(root, commandName) {
   return JSON.parse(await fs.readFile(path.join(runDir, runFiles.at(-1)), "utf8"));
 }
 
-test("scan and doc generate required artifacts", async () => {
+async function modeOf(targetPath) {
+  return (await fs.stat(targetPath)).mode & 0o777;
+}
+
+function withUmask(t, mask) {
+  const previous = process.umask(mask);
+  t.after(() => {
+    process.umask(previous);
+  });
+}
+
+test("scan and doc generate required artifacts", async (t) => {
+  if (process.platform !== "win32") {
+    withUmask(t, 0o000);
+  }
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-update-"));
   await fs.writeFile(path.join(root, "package.json"), "{}\n");
   await fs.mkdir(path.join(root, "src", "auth"), { recursive: true });
@@ -80,6 +94,12 @@ test("scan and doc generate required artifacts", async () => {
   const summary = await fs.readFile(path.join(root, "AGENTIFY.md"), "utf8");
   assert.match(summary, /# AGENTIFY\.md/);
   assert.match(summary, /## Run Metrics/);
+  if (process.platform !== "win32") {
+    const runDir = path.join(root, ".agentify", "runs");
+    const runFiles = await fs.readdir(runDir);
+    assert.equal(await modeOf(runDir), 0o700);
+    assert.equal(await modeOf(path.join(runDir, runFiles[0])), 0o600);
+  }
 });
 
 test("validateRepo allows tracked header-only code changes", async () => {


### PR DESCRIPTION
## Summary
- Add private filesystem helpers for runtime artifacts using `0700` directories and `0600` files.
- Route sensitive session, handoff, context-event, AFK, run-report, telemetry, and persisted run JSON writes through the private helpers.
- Keep shareable generated docs on the existing default write path while making root `output.txt` and `agentify-report.html` private files.

## Tests
- `rtk npm test -- test/fs.test.js test/session.test.js test/session-structured.test.js test/run-report.test.js test/context-events.test.js test/update.test.js`
- `rtk npm test`

Closes #249