### PR TITLE
feat: migrate shared worktree cache artifacts

### DIFF
--- a/src/core/cache.js
+++ b/src/core/cache.js
@@ -122,3 +122,32 @@ export async function cacheStatus(cacheRoot) {
 
   return { entries: moduleCount, blobs: blobCount, totalSize };
 }
+
+export async function hasSharedStoreLocks(locksRoot) {
+  if (!locksRoot || !(await exists(locksRoot))) {
+    return false;
+  }
+  const entries = await fs.readdir(locksRoot);
+  return entries.length > 0;
+}
+
+export async function cleanCache(cacheRoot, options = {}) {
+  const dryRun = Boolean(options.dryRun);
+  if (!(await exists(cacheRoot))) {
+    return { removed: 0, removed_paths: [], dry_run: dryRun };
+  }
+
+  const entries = await fs.readdir(cacheRoot);
+  const removedPaths = entries.map((entry) => path.join(cacheRoot, entry));
+  if (!dryRun) {
+    for (const target of removedPaths) {
+      await fs.rm(target, { recursive: true, force: true });
+    }
+  }
+
+  return {
+    removed: removedPaths.length,
+    removed_paths: removedPaths,
+    dry_run: dryRun,
+  };
+}

--- a/src/core/cli-fast-paths.js
+++ b/src/core/cli-fast-paths.js
@@ -120,6 +120,7 @@ export async function printHelp() {
     `    ${d("$")} agentify link --auto`,
     `    ${d("$")} agentify link --from ../canonical-worktree`,
     `    ${d("$")} agentify worktree status`,
+    `    ${d("$")} agentify cache clean --shared --dry-run`,
     `    ${d("$")} agentify this --provider codex`,
     `    ${d("$")} agentify up --provider codex`,
     `    ${d("$")} agentify sync`,

--- a/src/core/completion.js
+++ b/src/core/completion.js
@@ -224,6 +224,15 @@ const COMMANDS = [
         flags: [flag("--max-age", { valueKind: "number", description: "Maximum age in days" })],
       }),
       subcommand("status", "Show cache status"),
+      subcommand("clean", "Remove cache contents from the selected store", {
+        flags: [
+          flag("--local", { description: "Clean only the current worktree cache" }),
+          flag("--shared", { description: "Clean only the shared project-store cache" }),
+          flag("--all", { description: "Clean local and shared cache stores" }),
+          flag("--dry-run", { description: "Report planned removals only" }),
+          flag("--yes", { description: "Confirm --all without prompting" }),
+        ],
+      }),
     ],
   }),
   command("completion", "Generate shell completion scripts", {

--- a/src/core/link.js
+++ b/src/core/link.js
@@ -21,6 +21,7 @@ import {
 } from "./project-store.js";
 
 const execFileAsync = promisify(execFile);
+const MIGRATABLE_SHARED_ARTIFACTS = ["index.db", "cache", "semantic", "context"];
 
 async function runGit(targetPath, args) {
   try {
@@ -95,6 +96,98 @@ function createStoreMetadata({ identity, existing }) {
     created_by_agentify_version: base.created_by_agentify_version || VERSION,
     last_used_by_agentify_version: VERSION,
   };
+}
+
+function normalizeMigrationMode(raw) {
+  const value = raw === true || raw === undefined || raw === null
+    ? "auto"
+    : String(raw).trim().toLowerCase();
+  if (value === "auto" || value === "local-to-shared" || value === "none") {
+    return value;
+  }
+  throw new Error("--migrate must be one of: auto, local-to-shared, none");
+}
+
+async function copyArtifact(source, target) {
+  const stat = await fs.stat(source);
+  await ensureDir(path.dirname(target));
+  if (stat.isDirectory()) {
+    await fs.cp(source, target, { recursive: true, force: true });
+  } else if (stat.isFile()) {
+    await fs.copyFile(source, target);
+  }
+}
+
+async function planSharedArtifactMigration({ root, projectStore, mode, dryRun }) {
+  const localPaths = resolveLocalAgentifyPaths(root);
+  const localRoot = localPaths.runtimeRoot;
+  const result = {
+    mode,
+    dry_run: Boolean(dryRun),
+    migrated: [],
+    skipped: [],
+    warnings: [],
+  };
+
+  if (mode === "none") {
+    result.skipped.push({ reason: "migration_disabled" });
+    return result;
+  }
+
+  const candidates = [];
+  for (const name of MIGRATABLE_SHARED_ARTIFACTS) {
+    const source = path.join(localRoot, name);
+    const target = path.join(projectStore, name);
+    const sourceExists = await exists(source);
+    const targetExists = await exists(target);
+    candidates.push({ name, source, target, sourceExists, targetExists });
+  }
+
+  const sharedHasArtifacts = candidates.some((candidate) => candidate.targetExists);
+  const forceLocalToShared = mode === "local-to-shared";
+
+  if (sharedHasArtifacts && !forceLocalToShared) {
+    if (candidates.some((candidate) => candidate.sourceExists)) {
+      result.warnings.push("Shared store already has reusable artifacts; keeping shared artifacts. Use --migrate=local-to-shared to overwrite them from this worktree.");
+    }
+    for (const candidate of candidates) {
+      if (candidate.sourceExists) {
+        result.skipped.push({
+          artifact: candidate.name,
+          source: candidate.source,
+          target: candidate.target,
+          reason: candidate.targetExists ? "shared_exists" : "shared_store_not_empty",
+        });
+      }
+    }
+    return result;
+  }
+
+  for (const candidate of candidates) {
+    if (!candidate.sourceExists) {
+      continue;
+    }
+    if (candidate.targetExists && !forceLocalToShared) {
+      result.skipped.push({
+        artifact: candidate.name,
+        source: candidate.source,
+        target: candidate.target,
+        reason: "shared_exists",
+      });
+      continue;
+    }
+    if (!dryRun) {
+      await copyArtifact(candidate.source, candidate.target);
+    }
+    result.migrated.push({
+      artifact: candidate.name,
+      source: candidate.source,
+      target: candidate.target,
+      action: dryRun ? "would_copy" : "copied",
+    });
+  }
+
+  return result;
 }
 
 async function linkFromCanonical(root, options) {
@@ -189,6 +282,13 @@ async function linkAuto(root, options) {
     await options.prepareTarget(resolvedRoot);
   }
 
+  const migration = await planSharedArtifactMigration({
+    root: resolvedRoot,
+    projectStore,
+    mode: normalizeMigrationMode(options.migrate),
+    dryRun: options.dryRun,
+  });
+
   const payload = createAutoLinkPayload({ identity, projectStore });
   let changed = true;
   let existingPayload = null;
@@ -243,6 +343,7 @@ async function linkAuto(root, options) {
     repo_key: identity.repoKey,
     shared_artifacts: describeSharedArtifacts(),
     local_artifacts: describeLocalArtifacts(),
+    migration,
     linked: true,
     changed: changed && !options.dryRun,
     dry_run: Boolean(options.dryRun),

--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,7 @@ import { buildExecutionPlan, renderPlanExplanation } from "./core/planner.js";
 import { forkSession, listSessions, maybePrepareChildSession, resolveSessionProvider, resumeSession, validateSessionId } from "./core/session.js";
 import { compactSessionContext, loadAutomaticRunMemory, loadAutomaticSessionMemory } from "./core/session-memory.js";
 import { runDoctor } from "./core/toolchain.js";
-import { garbageCollect, cacheStatus } from "./core/cache.js";
+import { cleanCache, garbageCollect, cacheStatus, hasSharedStoreLocks } from "./core/cache.js";
 import { runClean } from "./core/cleanup.js";
 import { runAfk } from "./core/afk.js";
 import { generateCompletionScript, printCompletionValues } from "./core/completion.js";
@@ -36,7 +36,7 @@ import { buildRtkProviderInstruction, detectRtk, formatRtkUnavailableMessage, re
 import { buildSkillInstallHint, installAllBuiltinSkills, installBuiltinSkill, listBuiltinSkills } from "./core/skills.js";
 import { runBootstrapCommand } from "./core/bootstrap.js";
 import { VERSION, printHelp } from "./core/cli-fast-paths.js";
-import { resolveAgentifyPaths } from "./core/project-store.js";
+import { resolveAgentifyPaths, resolveLocalAgentifyPaths } from "./core/project-store.js";
 import {
   CONTEXT_MODE_DEFAULT,
   normalizeContextMode,
@@ -61,6 +61,22 @@ function renderAutoLinkSummary(result) {
   log("Local artifacts:");
   for (const name of result.local_artifacts || []) {
     log(`  - ${name}`);
+  }
+  if (result.migration) {
+    log("");
+    if (result.migration.migrated?.length > 0) {
+      log("Migrated reusable artifacts:");
+      for (const item of result.migration.migrated) {
+        log(`  - ${item.artifact}: ${item.source} -> ${item.target}`);
+      }
+    } else if (result.migration.mode === "none") {
+      log("Migration: skipped (--migrate=none)");
+    } else {
+      log("Migration: no reusable local artifacts copied");
+    }
+    for (const warning of result.migration.warnings || []) {
+      log(`Warning: ${warning}`);
+    }
   }
 }
 
@@ -89,6 +105,45 @@ function renderLinkStatus(result) {
     log(`Store created:   ${result.store_meta.created_at || "?"}`);
     log(`Store last used: ${result.store_meta.last_used_at || "?"}`);
   }
+}
+
+function buildCacheStatus(paths, status) {
+  return {
+    ...status,
+    store: paths.mode === "shared" ? "shared" : "local",
+    cache_root: paths.cacheRoot,
+    runtime_root: paths.runtimeRoot,
+    project_store: paths.projectStore,
+  };
+}
+
+function cacheCleanTargets(root, agentifyPaths, args) {
+  const localPaths = resolveLocalAgentifyPaths(root);
+  const wantsLocal = args.local === true;
+  const wantsShared = args.shared === true;
+  const wantsAll = args.all === true;
+  const selectedCount = [wantsLocal, wantsShared, wantsAll].filter(Boolean).length;
+  if (selectedCount !== 1) {
+    throw new Error("cache clean requires exactly one of --local, --shared, or --all");
+  }
+  if ((wantsShared || wantsAll) && agentifyPaths.mode !== "shared") {
+    throw new Error("cache clean --shared requires a linked or shared Agentify project store");
+  }
+  if (wantsAll && !args.dryRun && args.yes !== true) {
+    throw new Error("cache clean --all requires --yes unless --dry-run is used");
+  }
+
+  const targets = [];
+  if (wantsLocal || wantsAll) {
+    targets.push({ store: "local", cacheRoot: localPaths.cacheRoot, shared: false });
+  }
+  if (wantsShared || wantsAll) {
+    const alreadyIncluded = targets.some((target) => target.cacheRoot === agentifyPaths.cacheRoot);
+    if (!alreadyIncluded) {
+      targets.push({ store: "shared", cacheRoot: agentifyPaths.cacheRoot, shared: true });
+    }
+  }
+  return targets;
 }
 
 function parseValue(raw) {
@@ -615,6 +670,7 @@ export async function runCli(argv, runtime = {}) {
           auto: args.auto === true,
           status: args.status === true,
           force: args.force === true,
+          migrate: args.migrate,
           dryRun: config.dryRun,
           config,
           prepareTarget: (targetRoot) => ensureLinkTargetPolicy(targetRoot, config),
@@ -646,6 +702,7 @@ export async function runCli(argv, runtime = {}) {
           const result = await linkProject(root, {
             auto: true,
             force: args.force === true,
+            migrate: args.migrate,
             dryRun: config.dryRun,
             config,
             prepareTarget: (targetRoot) => ensureLinkTargetPolicy(targetRoot, config),
@@ -1209,14 +1266,46 @@ export async function runCli(argv, runtime = {}) {
           const result = await garbageCollect(cacheRoot, maxAge);
           success(`Garbage collected ${result.removed} blob(s).`);
         } else if (subcommand === "status") {
-          const status = await cacheStatus(cacheRoot);
+          const status = buildCacheStatus(config._agentifyPaths, await cacheStatus(cacheRoot));
           if (config.json) {
             console.log(JSON.stringify(status, null, 2));
           } else {
+            log(`Store: ${bold(status.store)}  Path: ${dim(status.cache_root)}`);
             log(`Blobs: ${bold(String(status.blobs))}  Size: ${bold(status.totalSize || "0 B")}`);
           }
+        } else if (subcommand === "clean") {
+          const targets = cacheCleanTargets(root, config._agentifyPaths, args);
+          const touchesShared = targets.some((target) => target.shared);
+          if (touchesShared && !config.dryRun && await hasSharedStoreLocks(config._agentifyPaths.locksRoot)) {
+            throw new Error(`Refusing to clean shared cache while shared store locks are present: ${config._agentifyPaths.locksRoot}`);
+          }
+
+          const cleaned = [];
+          for (const target of targets) {
+            cleaned.push({
+              store: target.store,
+              cache_root: target.cacheRoot,
+              ...(await cleanCache(target.cacheRoot, { dryRun: config.dryRun })),
+            });
+          }
+          const result = {
+            command: "cache clean",
+            dry_run: Boolean(config.dryRun),
+            cleaned,
+          };
+          if (config.json) {
+            console.log(JSON.stringify(result, null, 2));
+          } else {
+            for (const item of cleaned) {
+              const verb = config.dryRun ? "would remove" : "removed";
+              log(`Cache clean ${item.store}: ${verb} ${item.removed} item(s) from ${dim(item.cache_root)}`);
+              for (const removedPath of item.removed_paths) {
+                log(`  - ${removedPath}`);
+              }
+            }
+          }
         } else {
-          throw new Error("cache requires a subcommand: gc or status");
+          throw new Error("cache requires a subcommand: gc, status, or clean");
         }
         return;
       }

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -106,6 +106,20 @@ async function captureConsoleLog(fn) {
   return output;
 }
 
+async function withEnv(name, value, fn) {
+  const previous = process.env[name];
+  process.env[name] = value;
+  try {
+    return await fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = previous;
+    }
+  }
+}
+
 async function runCliWithImportTrace(args) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-cli-import-trace-"));
   const loaderPath = path.join(tempDir, "trace-loader.mjs");
@@ -1469,6 +1483,149 @@ test("runCli scan reuses a linked shared index across git worktrees", async () =
       process.env.AGENTIFY_SHARED_STORE_PATH = previousSharedStorePath;
     }
   }
+});
+
+test("runCli link --auto migrates reusable local artifacts and preserves local-only state", async () => {
+  const parent = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-shared-migrate-"));
+  const root = path.join(parent, "primary");
+  const sharedBase = path.join(parent, "shared-store");
+  await fs.mkdir(root, { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await initGitRepo(root);
+
+  await fs.mkdir(path.join(root, ".agentify", "cache", "nested"), { recursive: true });
+  await fs.mkdir(path.join(root, ".agentify", "semantic"), { recursive: true });
+  await fs.mkdir(path.join(root, ".agentify", "context"), { recursive: true });
+  await fs.mkdir(path.join(root, ".agentify", "runs"), { recursive: true });
+  await fs.mkdir(path.join(root, ".agentify", "session"), { recursive: true });
+  await fs.mkdir(path.join(root, ".agentify", "work"), { recursive: true });
+  await fs.writeFile(path.join(root, ".agentify", "index.db"), "local index\n", "utf8");
+  await fs.writeFile(path.join(root, ".agentify", "cache", "nested", "blob.txt"), "local cache\n", "utf8");
+  await fs.writeFile(path.join(root, ".agentify", "semantic", "facts.json"), "{}\n", "utf8");
+  await fs.writeFile(path.join(root, ".agentify", "context", "ctx.json"), "{}\n", "utf8");
+  await fs.writeFile(path.join(root, ".agentify", "runs", "run.json"), "{}\n", "utf8");
+  await fs.writeFile(path.join(root, ".agentify", "session", "session.json"), "{}\n", "utf8");
+  await fs.writeFile(path.join(root, ".agentify", "work", "scratch.txt"), "scratch\n", "utf8");
+
+  const result = await withEnv("AGENTIFY_SHARED_STORE_PATH", sharedBase, async () => {
+    const output = await captureConsoleLog(() => runCli(["link", "--root", root, "--auto", "--json"]));
+    return JSON.parse(output.join("\n"));
+  });
+
+  assert.deepEqual(result.migration.migrated.map((item) => item.artifact).sort(), ["cache", "context", "index.db", "semantic"]);
+  await assert.doesNotReject(() => fs.access(path.join(result.project_store, "index.db")));
+  await assert.doesNotReject(() => fs.access(path.join(result.project_store, "cache", "nested", "blob.txt")));
+  await assert.doesNotReject(() => fs.access(path.join(result.project_store, "semantic", "facts.json")));
+  await assert.doesNotReject(() => fs.access(path.join(result.project_store, "context", "ctx.json")));
+  await assert.rejects(() => fs.access(path.join(result.project_store, "runs", "run.json")), { code: "ENOENT" });
+  await assert.rejects(() => fs.access(path.join(result.project_store, "session", "session.json")), { code: "ENOENT" });
+  await assert.rejects(() => fs.access(path.join(result.project_store, "work", "scratch.txt")), { code: "ENOENT" });
+
+  await assert.doesNotReject(() => fs.access(path.join(root, ".agentify", "index.db")));
+  await assert.doesNotReject(() => fs.access(path.join(root, ".agentify", "runs", "run.json")));
+});
+
+test("runCli link --auto keeps existing shared artifacts unless local-to-shared migration is forced", async () => {
+  const parent = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-shared-migrate-force-"));
+  const root = path.join(parent, "primary");
+  const sharedBase = path.join(parent, "shared-store");
+  await fs.mkdir(path.join(root, ".agentify"), { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await initGitRepo(root);
+  await fs.writeFile(path.join(root, ".agentify", "index.db"), "local-v1\n", "utf8");
+
+  const initial = await withEnv("AGENTIFY_SHARED_STORE_PATH", sharedBase, async () => {
+    const output = await captureConsoleLog(() => runCli(["link", "--root", root, "--auto", "--migrate=none", "--json"]));
+    return JSON.parse(output.join("\n"));
+  });
+  await fs.writeFile(path.join(initial.project_store, "index.db"), "shared-v1\n", "utf8");
+  await fs.writeFile(path.join(root, ".agentify", "index.db"), "local-v2\n", "utf8");
+
+  const skipped = await withEnv("AGENTIFY_SHARED_STORE_PATH", sharedBase, async () => {
+    const output = await captureConsoleLog(() => runCli(["link", "--root", root, "--auto", "--json"]));
+    return JSON.parse(output.join("\n"));
+  });
+  assert.equal(await fs.readFile(path.join(initial.project_store, "index.db"), "utf8"), "shared-v1\n");
+  assert.ok(skipped.migration.warnings.some((warning) => warning.includes("Shared store already has reusable artifacts")));
+
+  await withEnv("AGENTIFY_SHARED_STORE_PATH", sharedBase, async () => {
+    await captureConsoleLog(() => runCli(["link", "--root", root, "--auto", "--migrate=local-to-shared", "--json"]));
+  });
+  assert.equal(await fs.readFile(path.join(initial.project_store, "index.db"), "utf8"), "local-v2\n");
+});
+
+test("runCli cache clean targets local, shared, and all stores without crossing boundaries", async () => {
+  const parent = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-cache-clean-stores-"));
+  const root = path.join(parent, "primary");
+  const sharedBase = path.join(parent, "shared-store");
+  await fs.mkdir(root, { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await initGitRepo(root);
+
+  const link = await withEnv("AGENTIFY_SHARED_STORE_PATH", sharedBase, async () => {
+    const output = await captureConsoleLog(() => runCli(["link", "--root", root, "--auto", "--migrate=none", "--json"]));
+    return JSON.parse(output.join("\n"));
+  });
+  const localCacheFile = path.join(root, ".agentify", "cache", "local.txt");
+  const sharedCacheFile = path.join(link.project_store, "cache", "shared.txt");
+  await fs.mkdir(path.dirname(localCacheFile), { recursive: true });
+  await fs.mkdir(path.dirname(sharedCacheFile), { recursive: true });
+  await fs.writeFile(localCacheFile, "local\n", "utf8");
+  await fs.writeFile(sharedCacheFile, "shared\n", "utf8");
+
+  const statusOutput = await captureConsoleLog(() => runCli(["cache", "status", "--root", root, "--json"]));
+  const status = JSON.parse(statusOutput.join("\n"));
+  assert.equal(status.store, "shared");
+  assert.equal(status.cache_root, path.join(link.project_store, "cache"));
+
+  await captureConsoleLog(() => runCli(["cache", "clean", "--root", root, "--local", "--json"]));
+  await assert.rejects(() => fs.access(localCacheFile), { code: "ENOENT" });
+  await assert.doesNotReject(() => fs.access(sharedCacheFile));
+
+  await fs.writeFile(localCacheFile, "local\n", "utf8");
+  const dryRun = await captureConsoleLog(() => runCli(["cache", "clean", "--root", root, "--shared", "--dry-run", "--json"]));
+  const dryRunResult = JSON.parse(dryRun.join("\n"));
+  assert.equal(dryRunResult.cleaned[0].store, "shared");
+  assert.equal(dryRunResult.cleaned[0].removed, 1);
+  await assert.doesNotReject(() => fs.access(localCacheFile));
+  await assert.doesNotReject(() => fs.access(sharedCacheFile));
+
+  await captureConsoleLog(() => runCli(["cache", "clean", "--root", root, "--shared", "--json"]));
+  await assert.doesNotReject(() => fs.access(localCacheFile));
+  await assert.rejects(() => fs.access(sharedCacheFile), { code: "ENOENT" });
+
+  await fs.writeFile(sharedCacheFile, "shared\n", "utf8");
+  await assert.rejects(
+    () => runCli(["cache", "clean", "--root", root, "--all"]),
+    /cache clean --all requires --yes/,
+  );
+  await captureConsoleLog(() => runCli(["cache", "clean", "--root", root, "--all", "--yes", "--json"]));
+  await assert.rejects(() => fs.access(localCacheFile), { code: "ENOENT" });
+  await assert.rejects(() => fs.access(sharedCacheFile), { code: "ENOENT" });
+});
+
+test("runCli cache clean refuses shared deletion when shared store locks exist", async () => {
+  const parent = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-cache-clean-locks-"));
+  const root = path.join(parent, "primary");
+  const sharedBase = path.join(parent, "shared-store");
+  await fs.mkdir(root, { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await initGitRepo(root);
+
+  const link = await withEnv("AGENTIFY_SHARED_STORE_PATH", sharedBase, async () => {
+    const output = await captureConsoleLog(() => runCli(["link", "--root", root, "--auto", "--migrate=none", "--json"]));
+    return JSON.parse(output.join("\n"));
+  });
+  const sharedCacheFile = path.join(link.project_store, "cache", "shared.txt");
+  await fs.mkdir(path.dirname(sharedCacheFile), { recursive: true });
+  await fs.writeFile(sharedCacheFile, "shared\n", "utf8");
+  await fs.writeFile(path.join(link.project_store, "locks", "active-session.lock"), "{}\n", "utf8");
+
+  await assert.rejects(
+    () => runCli(["cache", "clean", "--root", root, "--shared"]),
+    /Refusing to clean shared cache while shared store locks are present/,
+  );
+  await assert.doesNotReject(() => fs.access(sharedCacheFile));
 });
 
 test("runCli link rejects unrelated git repositories without writing a pointer", async () => {


### PR DESCRIPTION
## Summary
- migrate reusable local .agentify artifacts into the shared project store during link --auto
- add --migrate=none and --migrate=local-to-shared controls for shared-store migration
- make cache status shared-store aware and add cache clean --local/--shared/--all with dry-run and lock guards

Closes #261

## Validation
- rtk node --test test/project-store.test.js test/main.test.js
- rtk git diff --check
- rtk npm test (392/393 passing; existing publish-metadata failure on origin/main rejects package.json self-dependency agentify: link:)