### PR TITLE
feat: add shared index freshness locks

### DIFF
--- a/src/core/commands.js
+++ b/src/core/commands.js
@@ -6,13 +6,14 @@ import { ensureDir, ensurePrivateDir, exists, writeJson, writePrivateJson, write
 import { getHeadCommit } from "./git.js";
 import { stripLeadingAgentifyHeader, updateFileHeader } from "./headers.js";
 import { ensureAgentifyGitignore } from "./gitignore.js";
+import { getIndexFreshness, writeIndexMeta } from "./index-freshness.js";
 import { createProvider, renderModuleMarkdown, summarizeModule } from "./provider.js";
 import { runProjectTests } from "./project-tests.js";
 import { ensureProjectStore, resolveAgentifyPaths, resolveLocalAgentifyPaths } from "./project-store.js";
 import { createRunReporter } from "./run-report.js";
 import { validateRepo } from "./validate.js";
 import { checkSchema, migrateIndex, SCHEMA_VERSIONS } from "./schema.js";
-import { acquireLock } from "./lock.js";
+import { acquireLock, acquireProjectStoreLock } from "./lock.js";
 import { closeIndexDatabase, inTransaction, openIndexDatabase } from "./db/connection.js";
 import { getRepoMeta } from "./db/metadata-store.js";
 import { getArtifact, removeArtifact, upsertArtifact } from "./db/artifact-store.js";
@@ -441,15 +442,27 @@ export async function runScan(root, config, options = {}) {
   const progress = options.reporter || createRunReporter(root);
   progress.log("scan: starting deterministic repository scan");
 
-  const lock = await acquireLock(root, "scan");
+  const ghostRunId = (config.ghost || config.ghostMode)
+    ? (options.ghostRunId || `ghost_${Date.now()}`)
+    : null;
+  const artifactRoot = resolveArtifactRoot(root, config, ghostRunId);
+  const artifactPaths = await resolveArtifactPaths(root, config, { artifactRoot });
+  const legacyLock = await acquireLock(root, "scan");
+  if (!legacyLock.acquired) {
+    return emitLockContention("scan", legacyLock, progress, config, options);
+  }
+
+  const lock = await acquireProjectStoreLock(artifactPaths, "index-refresh");
   if (!lock.acquired) {
+    await legacyLock.release();
     return emitLockContention("scan", lock, progress, config, options);
   }
 
   try {
-    return await _runScanInner(root, config, options, progress);
+    return await _runScanInner(root, config, options, progress, { artifactRoot, artifactPaths });
   } finally {
     await lock.release();
+    await legacyLock.release();
   }
 }
 
@@ -483,45 +496,45 @@ async function emitLockContention(phase, lock, progress, config, options) {
   return result;
 }
 
-async function _runScanInner(root, config, options, progress) {
-  const ghostRunId = (config.ghost || config.ghostMode)
-    ? (options.ghostRunId || `ghost_${Date.now()}`)
-    : null;
-  const artifactRoot = resolveArtifactRoot(root, config, ghostRunId);
-  const artifactPaths = await resolveArtifactPaths(root, config, { artifactRoot });
-
+async function _runScanInner(root, config, options, progress, resolvedArtifacts = {}) {
+  const artifactRoot = resolvedArtifacts.artifactRoot || resolveArtifactRoot(root, config, options.ghostRunId || null);
+  const artifactPaths = resolvedArtifacts.artifactPaths || await resolveArtifactPaths(root, config, { artifactRoot });
   await ensureBaselineArtifacts(artifactRoot, config, { paths: artifactPaths });
   const headCommit = await getHeadCommit(root);
-  if (!config.dryRun && artifactPaths.mode === "shared" && await exists(artifactPaths.indexDb)) {
+  const freshness = !config.dryRun ? await getIndexFreshness(root, artifactPaths) : null;
+  if (!config.dryRun && freshness?.index_status === "warm") {
     try {
       const db = openIndexDatabase(artifactPaths, { readOnly: true });
       try {
-        const meta = getRepoMeta(db);
-        if (meta.head_commit === headCommit) {
-          const result = {
-            command: options.commandName || "scan",
-            status: "reused",
-            reused_index: true,
-            index_path: artifactPaths.indexDb,
-            wrote: [],
-          };
-          progress.log("scan: reused warm shared index");
-          progress.setCommand(options.commandName || "scan");
-          progress.setScan(result);
-          if (!options.skipOutput && (config.json || !config._suppressProgress)) {
-            progress.json(result);
-          }
-          if (!options.skipFinalize) {
-            await progress.finalize();
-          }
-          return result;
+        getRepoMeta(db);
+        const result = {
+          command: options.commandName || "scan",
+          status: "reused",
+          index_status: "warm",
+          refresh_mode: "reuse",
+          reused_index: true,
+          index_path: artifactPaths.indexDb,
+          wrote: [],
+        };
+        progress.log("scan: reused warm index");
+        progress.setCommand(options.commandName || "scan");
+        progress.setScan(result);
+        if (!options.skipOutput && (config.json || !config._suppressProgress)) {
+          progress.json(result);
         }
+        if (!options.skipFinalize) {
+          await progress.finalize();
+        }
+        return result;
       } finally {
         closeIndexDatabase(db);
       }
     } catch {
       // Fall through and rebuild an unreadable or stale shared index.
     }
+  }
+  if (!config.dryRun && freshness?.refresh_mode === "incremental") {
+    progress.log(`scan: refreshing changed index inputs (${freshness.changed_files.length} file(s))`);
   }
   const snapshot = options.scanSnapshot || await buildRepositoryIndex(root, config);
   progress.log(`scan: analyzed ${snapshot.files.length} files and detected ${snapshot.modules.length} modules`);
@@ -540,15 +553,19 @@ async function _runScanInner(root, config, options, progress) {
     } finally {
       closeIndexDatabase(db);
     }
+    await writeIndexMeta(root, artifactPaths, snapshot, freshness || await getIndexFreshness(root, artifactPaths));
   }
   progress.log("scan: wrote SQLite index and repo guidance");
 
   const result = {
     command: options.commandName || "scan",
+    index_status: freshness?.refresh_mode === "incremental" ? "incremental" : "rebuilt",
+    refresh_mode: freshness?.refresh_mode || "full",
+    changed_files: freshness?.changed_files || [],
     detected_stacks: snapshot.repo.detected_stacks,
     default_stack: snapshot.repo.default_stack,
     modules: snapshot.modules.map((moduleInfo) => ({ id: moduleInfo.id, root_path: moduleInfo.root_path })),
-    wrote: config.dryRun ? [] : [".agentify/index.db", "docs/repo-map.md"],
+    wrote: config.dryRun ? [] : [".agentify/index.db", ".agentify/index.meta.json", "docs/repo-map.md"],
   };
   progress.setCommand(options.commandName || "scan");
   progress.setScan(result);
@@ -1318,6 +1335,8 @@ export async function runUpdate(root, config, options = {}) {
   }
   const finalOutput = {
     command: commandName,
+    index_status: scanResult?.index_status || (scanResult?.reused_index ? "warm" : "rebuilt"),
+    scan: scanResult || null,
     validation: result,
     tests,
     ...(options.preflight ? { repo_sync: options.preflight } : {}),

--- a/src/core/git.js
+++ b/src/core/git.js
@@ -167,6 +167,28 @@ export async function getHeadCommit(root) {
   }
 }
 
+export async function getHeadTree(root) {
+  try {
+    const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD^{tree}"], {
+      cwd: root,
+    });
+    return stdout.trim();
+  } catch {
+    return "nogit";
+  }
+}
+
+export async function getCurrentBranch(root) {
+  try {
+    const { stdout } = await execFileAsync("git", ["branch", "--show-current"], {
+      cwd: root,
+    });
+    return stdout.trim() || "HEAD";
+  } catch {
+    return "nogit";
+  }
+}
+
 export async function getChangedFiles(root) {
   try {
     const { stdout } = await execFileAsync(

--- a/src/core/index-freshness.js
+++ b/src/core/index-freshness.js
@@ -1,0 +1,202 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { exists, readJson, writeJson } from "./fs.js";
+import { getChangedFiles, getChangedFilesSince, getCurrentBranch, getHeadCommit, getHeadTree } from "./git.js";
+import { SCHEMA_VERSIONS } from "./schema.js";
+
+const LARGE_DIFF_FILE_LIMIT = 50;
+const INDEX_META_SCHEMA_VERSION = 1;
+
+function sha1(buffer) {
+  return crypto.createHash("sha1").update(buffer).digest("hex");
+}
+
+function shouldTrackDirtyPath(filePath) {
+  const normalized = String(filePath || "").split(path.sep).join("/");
+  return Boolean(normalized)
+    && !normalized.startsWith(".agentify/")
+    && !normalized.startsWith(".current_session/")
+    && !normalized.startsWith("docs/")
+    && normalized !== "agentify-report.html"
+    && normalized !== "output.txt"
+    && !/(^|\/)AGENTIFY\.md$/.test(normalized);
+}
+
+function normalizeDirtyFiles(entries) {
+  return [...new Set((entries || [])
+    .map((entry) => entry?.path)
+    .filter(shouldTrackDirtyPath))]
+    .sort();
+}
+
+async function fingerprintFile(root, filePath) {
+  const fullPath = path.join(root, filePath);
+  try {
+    const [stat, content] = await Promise.all([
+      fs.stat(fullPath),
+      fs.readFile(fullPath),
+    ]);
+    return {
+      sha1: sha1(content),
+      mtime_ms: Math.round(Number(stat.mtimeMs)),
+      size: Number(stat.size),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function fingerprintPaths(root, filePaths) {
+  const fingerprints = {};
+  for (const filePath of filePaths) {
+    const fingerprint = await fingerprintFile(root, filePath);
+    if (fingerprint) {
+      fingerprints[filePath] = fingerprint;
+    }
+  }
+  return fingerprints;
+}
+
+function sameArray(left, right) {
+  if (left.length !== right.length) {
+    return false;
+  }
+  return left.every((value, index) => value === right[index]);
+}
+
+function sameFingerprint(left, right) {
+  return Boolean(left && right)
+    && left.sha1 === right.sha1
+    && Number(left.size) === Number(right.size);
+}
+
+async function dirtySnapshotMatches(root, meta, dirtyFiles) {
+  const previousDirtyFiles = Array.isArray(meta?.dirty_files_snapshot)
+    ? [...meta.dirty_files_snapshot].sort()
+    : [];
+  if (!sameArray(previousDirtyFiles, dirtyFiles)) {
+    return false;
+  }
+  if (dirtyFiles.length === 0) {
+    return true;
+  }
+
+  const currentFingerprints = await fingerprintPaths(root, dirtyFiles);
+  for (const filePath of dirtyFiles) {
+    if (!sameFingerprint(meta?.file_fingerprints?.[filePath], currentFingerprints[filePath])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export async function readIndexMeta(indexMetaPath) {
+  try {
+    return await readJson(indexMetaPath);
+  } catch {
+    return null;
+  }
+}
+
+export async function getIndexFreshness(root, artifactPaths) {
+  const [meta, indexedHead, indexedTree, indexedBranch, dirtyEntries] = await Promise.all([
+    readIndexMeta(artifactPaths.indexMetaPath),
+    getHeadCommit(root),
+    getHeadTree(root),
+    getCurrentBranch(root),
+    getChangedFiles(root),
+  ]);
+  const dirtyFiles = normalizeDirtyFiles(dirtyEntries);
+
+  if (!(await exists(artifactPaths.indexDb))) {
+    return {
+      index_status: "missing",
+      refresh_mode: "full",
+      stale_reason: "missing_index",
+      indexed_head: indexedHead,
+      indexed_tree: indexedTree,
+      indexed_branch: indexedBranch,
+      dirty_files: dirtyFiles,
+      changed_files: dirtyFiles,
+    };
+  }
+
+  if (!meta) {
+    return {
+      index_status: "stale",
+      refresh_mode: "full",
+      stale_reason: "missing_meta",
+      indexed_head: indexedHead,
+      indexed_tree: indexedTree,
+      indexed_branch: indexedBranch,
+      dirty_files: dirtyFiles,
+      changed_files: dirtyFiles,
+    };
+  }
+
+  if (meta.agentify_index_schema !== SCHEMA_VERSIONS.INDEX) {
+    return {
+      index_status: "stale",
+      refresh_mode: "full",
+      stale_reason: "schema_mismatch",
+      indexed_head: indexedHead,
+      indexed_tree: indexedTree,
+      indexed_branch: indexedBranch,
+      dirty_files: dirtyFiles,
+      changed_files: dirtyFiles,
+    };
+  }
+
+  const dirtyMatchesMeta = await dirtySnapshotMatches(root, meta, dirtyFiles);
+  if (meta.indexed_tree === indexedTree && dirtyMatchesMeta) {
+    return {
+      index_status: "warm",
+      refresh_mode: "reuse",
+      stale_reason: null,
+      indexed_head: indexedHead,
+      indexed_tree: indexedTree,
+      indexed_branch: indexedBranch,
+      dirty_files: dirtyFiles,
+      changed_files: [],
+    };
+  }
+
+  const diffEntries = meta.indexed_head
+    ? await getChangedFilesSince(root, meta.indexed_head)
+    : [];
+  const changedFiles = [...new Set([
+    ...diffEntries.map((entry) => entry?.path).filter(Boolean),
+    ...(dirtyMatchesMeta ? [] : dirtyFiles),
+  ])].filter(shouldTrackDirtyPath).sort();
+  const smallDiff = changedFiles.length > 0 && changedFiles.length < LARGE_DIFF_FILE_LIMIT;
+
+  return {
+    index_status: "stale",
+    refresh_mode: smallDiff ? "incremental" : "full",
+    stale_reason: smallDiff ? "small_diff" : "large_or_unknown_diff",
+    indexed_head: indexedHead,
+    indexed_tree: indexedTree,
+    indexed_branch: indexedBranch,
+    dirty_files: dirtyFiles,
+    changed_files: changedFiles,
+  };
+}
+
+export async function writeIndexMeta(root, artifactPaths, snapshot, freshness) {
+  const fileFingerprints = await fingerprintPaths(root, snapshot.files.map((fileInfo) => fileInfo.path));
+  const payload = {
+    schema_version: INDEX_META_SCHEMA_VERSION,
+    agentify_index_schema: SCHEMA_VERSIONS.INDEX,
+    repo_key: artifactPaths.repoKey || null,
+    indexed_head: freshness.indexed_head,
+    indexed_tree: freshness.indexed_tree,
+    indexed_branch: freshness.indexed_branch,
+    indexed_at: new Date().toISOString(),
+    dirty_files_snapshot: freshness.dirty_files || [],
+    file_fingerprints: fileFingerprints,
+  };
+  await writeJson(artifactPaths.indexMetaPath, payload);
+  return payload;
+}

--- a/src/core/lock.js
+++ b/src/core/lock.js
@@ -6,6 +6,10 @@ import process from "node:process";
 import { resolveLocalAgentifyPaths } from "./project-store.js";
 
 const LOCK_STALE_MS = 300000;
+const LOCK_NAMES = {
+  "index-refresh": "index.lock",
+  "cache-gc": "cache-gc.lock",
+};
 
 function isProcessAlive(pid) {
   if (!Number.isInteger(pid) || pid <= 0) {
@@ -21,20 +25,20 @@ function isProcessAlive(pid) {
 }
 
 function canReclaimLock(existing) {
-  if (!existing || typeof existing.acquired_at !== "number") {
+  const acquiredAt = existing?.acquired_at || Date.parse(existing?.created_at || "");
+  if (!existing || !Number.isFinite(acquiredAt)) {
     return false;
   }
 
-  if (Date.now() - existing.acquired_at <= LOCK_STALE_MS) {
+  if (Date.now() - acquiredAt <= LOCK_STALE_MS) {
     return false;
   }
 
-  return !(existing.host === os.hostname() && isProcessAlive(existing.pid));
+  const host = existing.host || existing.hostname;
+  return !(host === os.hostname() && isProcessAlive(existing.pid));
 }
 
-export async function acquireLock(root, operation) {
-  const lockPath = resolveLocalAgentifyPaths(root).lockPath;
-
+async function acquireLockFile(lockPath, operation) {
   try {
     await fs.mkdir(path.dirname(lockPath), { recursive: true });
   } catch {
@@ -43,7 +47,9 @@ export async function acquireLock(root, operation) {
 
   const lockData = {
     pid: process.pid,
+    hostname: os.hostname(),
     operation,
+    created_at: new Date().toISOString(),
     acquired_at: Date.now(),
     host: os.hostname(),
   };
@@ -52,7 +58,28 @@ export async function acquireLock(root, operation) {
     const handle = await fs.open(lockPath, "wx");
     await handle.writeFile(JSON.stringify(lockData));
     await handle.close();
-    return { acquired: true, release: () => fs.unlink(lockPath).catch(() => {}) };
+    let released = false;
+    const release = async () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+        process.off(signal, signalHandlers.get(signal));
+      }
+      await fs.unlink(lockPath).catch(() => {});
+    };
+    const signalHandlers = new Map();
+    for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+      const handler = () => {
+        release().finally(() => {
+          process.kill(process.pid, signal);
+        });
+      };
+      signalHandlers.set(signal, handler);
+      process.once(signal, handler);
+    }
+    return { acquired: true, lock_path: lockPath, release };
   } catch (error) {
     if (error.code !== "EEXIST") throw error;
 
@@ -60,15 +87,26 @@ export async function acquireLock(root, operation) {
       const existing = JSON.parse(await fs.readFile(lockPath, "utf8"));
       if (canReclaimLock(existing)) {
         await fs.unlink(lockPath);
-        return acquireLock(root, operation);
+        return acquireLockFile(lockPath, operation);
       }
       return {
         acquired: false,
+        lock_path: lockPath,
         holder: existing,
-        message: `Lock held by PID ${existing.pid} for '${existing.operation}' since ${new Date(existing.acquired_at).toISOString()}`,
+        message: `Lock held by PID ${existing.pid} for '${existing.operation}' since ${existing.created_at || new Date(existing.acquired_at).toISOString()}`,
       };
     } catch {
-      return { acquired: false, message: "Lock exists but is unreadable" };
+      return { acquired: false, lock_path: lockPath, message: "Lock exists but is unreadable" };
     }
   }
+}
+
+export async function acquireLock(root, operation) {
+  const lockPath = resolveLocalAgentifyPaths(root).lockPath;
+  return acquireLockFile(lockPath, operation);
+}
+
+export async function acquireProjectStoreLock(agentifyPaths, operation) {
+  const fileName = LOCK_NAMES[operation] || `${operation}.lock`;
+  return acquireLockFile(path.join(agentifyPaths.locksRoot, fileName), operation);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -26,6 +26,7 @@ import { compactSessionContext, loadAutomaticRunMemory, loadAutomaticSessionMemo
 import { runDoctor } from "./core/toolchain.js";
 import { cleanCache, garbageCollect, cacheStatus, hasSharedStoreLocks } from "./core/cache.js";
 import { runClean } from "./core/cleanup.js";
+import { acquireProjectStoreLock } from "./core/lock.js";
 import { runAfk } from "./core/afk.js";
 import { generateCompletionScript, printCompletionValues } from "./core/completion.js";
 import { runSemanticRefresh } from "./core/semantic.js";
@@ -1263,7 +1264,16 @@ export async function runCli(argv, runtime = {}) {
         const cacheRoot = config._agentifyPaths.cacheRoot;
         if (subcommand === "gc") {
           const maxAge = args.maxAge || config.cache?.maxAgeDays || 7;
-          const result = await garbageCollect(cacheRoot, maxAge);
+          const lock = await acquireProjectStoreLock(config._agentifyPaths, "cache-gc");
+          if (!lock.acquired) {
+            throw new Error(lock.message || "Cache garbage collection lock is already held");
+          }
+          let result;
+          try {
+            result = await garbageCollect(cacheRoot, maxAge);
+          } finally {
+            await lock.release();
+          }
           success(`Garbage collected ${result.removed} blob(s).`);
         } else if (subcommand === "status") {
           const status = buildCacheStatus(config._agentifyPaths, await cacheStatus(cacheRoot));

--- a/test/lock.test.js
+++ b/test/lock.test.js
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { acquireLock } from "../src/core/lock.js";
+import { acquireLock, acquireProjectStoreLock } from "../src/core/lock.js";
 
 test("acquireLock refuses to steal a stale lock from a live owner on the same host", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-lock-live-"));
@@ -49,4 +49,26 @@ test("acquireLock reclaims a stale lock when the recorded owner is gone", async 
   assert.equal(lockData.operation, "doc");
   await result.release();
   await assert.rejects(() => fs.access(path.join(root, ".agentify", ".lock")));
+});
+
+test("acquireProjectStoreLock writes named shared-store lock files", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-store-lock-"));
+  const locksRoot = path.join(root, "locks");
+
+  const first = await acquireProjectStoreLock({ locksRoot }, "index-refresh");
+  assert.equal(first.acquired, true);
+  const lockPath = path.join(locksRoot, "index.lock");
+  const lockData = JSON.parse(await fs.readFile(lockPath, "utf8"));
+  assert.equal(lockData.pid, process.pid);
+  assert.equal(lockData.hostname, os.hostname());
+  assert.equal(lockData.operation, "index-refresh");
+  assert.ok(lockData.created_at);
+
+  const second = await acquireProjectStoreLock({ locksRoot }, "index-refresh");
+  assert.equal(second.acquired, false);
+  assert.equal(second.holder.pid, process.pid);
+  assert.match(second.message, /Lock held by PID/);
+
+  await first.release();
+  await assert.rejects(() => fs.access(lockPath));
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1485,6 +1485,80 @@ test("runCli scan reuses a linked shared index across git worktrees", async () =
   }
 });
 
+test("runCli up reports warm index status from index metadata", async () => {
+  const parent = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-warm-up-"));
+  const root = path.join(parent, "repo");
+  const sharedBase = path.join(parent, "shared-store");
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.writeFile(path.join(root, "src", "index.js"), "export const answer = 42;\n", "utf8");
+  await initGitRepo(root);
+
+  const previousSharedStorePath = process.env.AGENTIFY_SHARED_STORE_PATH;
+  process.env.AGENTIFY_SHARED_STORE_PATH = sharedBase;
+  try {
+    await runCli(["link", "--root", root, "--auto"]);
+    await runCli(["up", "--root", root, "--docs=false", "--json"]);
+
+    const link = JSON.parse(await fs.readFile(path.join(root, ".agentify", "link.json"), "utf8"));
+    const metaPath = path.join(link.project_store, "index.meta.json");
+    const meta = JSON.parse(await fs.readFile(metaPath, "utf8"));
+    assert.equal(meta.schema_version, 1);
+    assert.equal(meta.agentify_index_schema, "1.1");
+    assert.equal(meta.repo_key, link.repo_key);
+    assert.match(meta.indexed_head, /^[a-f0-9]{40}$/);
+    assert.match(meta.indexed_tree, /^[a-f0-9]{40}$/);
+    assert.match(meta.indexed_branch, /^(main|master)$/);
+    assert.deepEqual(meta.dirty_files_snapshot, [".agentignore", ".agentify.yaml", ".gitignore", ".guardrails"].sort());
+    assert.equal(meta.file_fingerprints["src/index.js"].sha1.length, 40);
+
+    const output = await captureConsoleLog(() => runCli(["up", "--root", root, "--docs=false", "--json"]));
+    const result = JSON.parse(output.join("\n"));
+    assert.equal(result.index_status, "warm");
+    assert.equal(result.scan.reused_index, true);
+    assert.equal(result.scan.refresh_mode, "reuse");
+  } finally {
+    if (previousSharedStorePath === undefined) {
+      delete process.env.AGENTIFY_SHARED_STORE_PATH;
+    } else {
+      process.env.AGENTIFY_SHARED_STORE_PATH = previousSharedStorePath;
+    }
+  }
+});
+
+test("runCli scan marks small committed diffs as incremental refreshes", async () => {
+  const parent = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-incremental-scan-"));
+  const root = path.join(parent, "repo");
+  const sharedBase = path.join(parent, "shared-store");
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), "{}\n", "utf8");
+  await fs.writeFile(path.join(root, "src", "index.js"), "export const answer = 42;\n", "utf8");
+  await initGitRepo(root);
+
+  const previousSharedStorePath = process.env.AGENTIFY_SHARED_STORE_PATH;
+  process.env.AGENTIFY_SHARED_STORE_PATH = sharedBase;
+  try {
+    await runCli(["link", "--root", root, "--auto"]);
+    await runCli(["scan", "--root", root]);
+
+    await fs.writeFile(path.join(root, "src", "index.js"), "export const answer = 43;\n", "utf8");
+    await execFileAsync("git", ["-C", root, "add", "src/index.js"]);
+    await execFileAsync("git", ["-C", root, "commit", "-m", "change answer"]);
+
+    const output = await captureConsoleLog(() => runCli(["scan", "--root", root, "--json"]));
+    const result = JSON.parse(output.join("\n"));
+    assert.equal(result.index_status, "incremental");
+    assert.equal(result.refresh_mode, "incremental");
+    assert.deepEqual(result.changed_files, ["src/index.js"]);
+  } finally {
+    if (previousSharedStorePath === undefined) {
+      delete process.env.AGENTIFY_SHARED_STORE_PATH;
+    } else {
+      process.env.AGENTIFY_SHARED_STORE_PATH = previousSharedStorePath;
+    }
+  }
+});
+
 test("runCli link --auto migrates reusable local artifacts and preserves local-only state", async () => {
   const parent = await fs.mkdtemp(path.join(os.tmpdir(), "agentify-main-shared-migrate-"));
   const root = path.join(parent, "primary");


### PR DESCRIPTION
## Summary
- add index.meta.json freshness metadata with indexed tree/head/branch, dirty-file snapshots, and file fingerprints
- short-circuit warm scans and surface index_status through scan/up JSON output
- serialize index writes with project-store index.lock while preserving legacy local lock contention behavior
- add cache-gc.lock around shared cache garbage collection

Fixes #262

## Validation
- node --test test/lock-contention.test.js test/lock.test.js test/main.test.js
- git diff --check
- npm test (395/396 passed; existing failure: test/publish-metadata.test.js rejects package.json dependency agentify: link:)