### PR TITLE
ci: add pull request test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20.x", "22.x"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test

--- a/package.json
+++ b/package.json
@@ -46,12 +46,16 @@
     "url": "https://github.com/ixigo/agentify/issues"
   },
   "dependencies": {
-    "agentify": "link:",
     "better-sqlite3": "^12.8.0",
     "cli-table3": "^0.6.5",
     "picocolors": "^1.1.1",
     "typescript": "^6.0.2",
     "yaml": "^2.8.3",
     "yocto-spinner": "^1.1.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,16 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  agentify: 'link:'
-
 importers:
 
   .:
     dependencies:
-      agentify:
-        specifier: 'link:'
-        version: 'link:'
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,2 @@
-allowBuilds:
-  better-sqlite3: set this to true or false
-overrides:
-  agentify: 'link:'
+packages:
+  - "."

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -71,22 +71,32 @@ test("openIndexDatabase read-only fallback snapshots valid databases without ini
   }
 
   const dbPath = path.join(root, ".agentify", "index.db");
-  const sqlite = require("node:sqlite");
-  const OriginalDatabaseSync = sqlite.DatabaseSync;
+  let sqlite;
+  try {
+    sqlite = require("node:sqlite");
+  } catch {
+    sqlite = null;
+  }
+  const OriginalDatabaseSync = sqlite?.DatabaseSync;
   const betterSqlitePath = require.resolve("better-sqlite3");
   const betterSqliteCache = require.cache[betterSqlitePath];
   const originalBetterSqlite = betterSqliteCache?.exports;
 
   // Simulate the narrow case where the source cannot be opened read-only but its copied snapshot can be read.
-  sqlite.DatabaseSync = function DatabaseSync(filename, options) {
-    if (filename === dbPath && options?.readOnly) {
-      throw new Error("simulated read-only source open failure");
-    }
-    return new OriginalDatabaseSync(filename, options);
-  };
+  if (sqlite) {
+    sqlite.DatabaseSync = function DatabaseSync(filename, options) {
+      if (filename === dbPath && options?.readOnly) {
+        throw new Error("simulated node:sqlite source open failure");
+      }
+      return new OriginalDatabaseSync(filename, options);
+    };
+  }
   if (betterSqliteCache) {
-    betterSqliteCache.exports = function BetterSqlite3() {
-      throw new Error("simulated better-sqlite3 source open failure");
+    betterSqliteCache.exports = function BetterSqlite3(filename, options) {
+      if (filename === dbPath && options?.readonly) {
+        throw new Error("simulated better-sqlite3 source open failure");
+      }
+      return new originalBetterSqlite(filename, options);
     };
   }
 
@@ -112,7 +122,9 @@ test("openIndexDatabase read-only fallback snapshots valid databases without ini
       }
     }
   } finally {
-    sqlite.DatabaseSync = OriginalDatabaseSync;
+    if (sqlite) {
+      sqlite.DatabaseSync = OriginalDatabaseSync;
+    }
     if (betterSqliteCache) {
       betterSqliteCache.exports = originalBetterSqlite;
     }


### PR DESCRIPTION
## Summary
- Add a GitHub Actions test workflow for pull requests and pushes to main across Node 20.x and 22.x.
- Normalize pnpm workspace metadata so frozen installs are portable and better-sqlite3 build scripts are approved.
- Keep the read-only DB snapshot fallback test compatible with Node 20 and Node 22.

## Verification
- fnm exec --using 22.22.0 pnpm@9.15.9 install --frozen-lockfile
- fnm exec --using 22.22.0 pnpm@9.15.9 test: 405/405 passed
- fnm exec --using 20.20.0 pnpm@9.15.9 install --frozen-lockfile
- fnm exec --using 20.20.0 pnpm@9.15.9 test: 405/405 passed
- git diff --check
- Parsed .github/workflows/test.yml with yaml

Closes #270